### PR TITLE
feat(flows.yaml): [nan-1761] add github app push

### DIFF
--- a/.github/workflows/push-flows-to-nango-repo.yaml
+++ b/.github/workflows/push-flows-to-nango-repo.yaml
@@ -1,0 +1,84 @@
+name: Push flows to Nango repo
+
+on:
+    push:
+        branches:
+            - main
+
+concurrency:
+    group: push-flows-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    push_to_nango_repo:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout the current repository
+              uses: actions/checkout@v3
+
+            - name: Log current branch and repository
+              run: |
+                  echo "Current branch: ${{ github.ref }}"
+                  echo "Repository: ${{ github.repository }}"
+
+            - name: Check for changes in flows.yaml
+              id: changes
+              uses: tj-actions/changed-files@v41
+              with:
+                  files: 'flows.yaml'
+
+            - name: Debug - Log if flows.yaml has changed
+              run: |
+                  if [ "${{ steps.changes.outputs.any_changed }}" == "true" ]; then
+                    echo "flows.yaml has changed."
+                  else
+                    echo "No changes detected in flows.yaml."
+                  fi
+
+            - name: Generate GitHub App Token
+              if: steps.changes.outputs.any_changed == 'true'
+              id: generate_token
+              uses: tibdex/github-app-token@v1
+              with:
+                  app_id: ${{ secrets.GH_APP_PUSHER_ID }}
+                  private_key: ${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}
+
+            - name: Debug - Log token generation status
+              if: steps.changes.outputs.any_changed == 'true'
+              run: |
+                  echo "GitHub App token generated."
+
+            - name: Clone the target repository and copy the flows.yaml file
+              if: steps.changes.outputs.any_changed == 'true'
+              run: |
+                  echo "Cloning the target repository..."
+                  git clone https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/NangoHQ/nango.git
+                  echo "Repository cloned."
+                  echo "Copying flows.yaml into the nango repository."
+                  cp flows.yaml nango/packages/shared/flows.yaml
+                  echo "flows.yaml file copied."
+
+            - name: Debug - Log nango directory contents
+              if: steps.changes.outputs.any_changed == 'true'
+              run: |
+                  echo "Contents of nango directory after copying flows.yaml:"
+                  ls nango/
+
+            - name: Make changes and commit
+              if: steps.changes.outputs.any_changed == 'true'
+              working-directory: nango
+              run: |
+                  echo "Configuring Git and committing changes..."
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                  git config --global user.name "GitHub Actions Bot"
+                  git add packages/shared/flows.yaml
+                  git commit -m "Automated commit updating flows.yaml from the integration-templates repo"
+                  echo "Changes committed."
+
+            - name: Push changes to target repo
+              if: steps.changes.outputs.any_changed == 'true'
+              working-directory: nango
+              run: |
+                  echo "Pushing changes to target repository..."
+                  git push origin master
+                  echo "Changes pushed successfully."


### PR DESCRIPTION
## Describe your changes
When the `flows.yaml` file changes push it to the `nango` repo so that the file is always up to date. I opted for a Github Action because that seem more fitting to the purposes of a Github App rather than a separate bot user. Additionally a Github App can have special bypass permissions

![image](https://github.com/user-attachments/assets/fa7c9a7b-c970-4528-8640-d5a37c841304)


## Issue ticket number and link
NAN-1761

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:

- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
