### PR TITLE
fix(gh-action): add gh token

### DIFF
--- a/.github/workflows/push-flows-to-nango-repo.yaml
+++ b/.github/workflows/push-flows-to-nango-repo.yaml
@@ -84,6 +84,8 @@ jobs:
                       gh run watch --repo NangoHQ/nango --check $check --exit-status
                   done
                   echo "All required status checks have passed."
+              env:
+                  GH_TOKEN: ${{ github.token }}
 
             - name: Push changes to target repo
               if: steps.changes.outputs.any_changed == 'true'


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
