### PR TITLE
fix(bamboo-yaml): update bamboo endpoints

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -485,22 +485,22 @@ integrations:
                     Fetches a list of current employees from bamboohr
                 output: BamboohrEmployee
                 sync_type: incremental
-                endpoint: GET /bamboohr/employees
+                endpoint: GET /employees
         actions:
             create-employee:
                 description: |
                     Action to create a new employee
                 output: BamboohrCreateEmployeeResponse
                 input: BamboohrCreateEmployee
-                endpoint: POST /bamboohr/create-employee
+                endpoint: POST /employees
                 version: 1.0.0
             update-employee:
-                endpoint: PUT /bamboohr/employee
+                endpoint: PUT /employees
                 input: BamboohrUpdateEmployee
                 output: BamboohrResponseStatus
                 description: Update an existing employee in the system
             fetch-fields:
-                endpoint: GET /bamboohr/fields
+                endpoint: GET /fields
                 output: BamboohrField[]
                 description: Introspection to retrieve available fields
         models:

--- a/integrations/bamboohr-basic/nango.yaml
+++ b/integrations/bamboohr-basic/nango.yaml
@@ -7,22 +7,22 @@ integrations:
                     Fetches a list of current employees from bamboohr
                 output: BamboohrEmployee
                 sync_type: incremental
-                endpoint: GET /bamboohr/employees
+                endpoint: GET /employees
         actions:
             create-employee:
                 description: |
                     Action to create a new employee
                 output: BamboohrCreateEmployeeResponse
                 input: BamboohrCreateEmployee
-                endpoint: POST /bamboohr/create-employee
+                endpoint: POST /employees
                 version: 1.0.0
             update-employee:
-                endpoint: PUT /bamboohr/employee
+                endpoint: PUT /employees
                 input: BamboohrUpdateEmployee
                 output: BamboohrResponseStatus
                 description: Update an existing employee in the system
             fetch-fields:
-                endpoint: GET /bamboohr/fields
+                endpoint: GET /fields
                 output: BamboohrField[]
                 description: Introspection to retrieve available fields
 models:


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
