### PR TITLE
fix(endpoint): clari endpoint update

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -1118,7 +1118,7 @@ integrations:
                     Fetches a list of calls from your account. For the first sync, it will
                     go back to the past one year
                 sync_type: incremental
-                endpoint: GET /clari-copilot/call
+                endpoint: GET /calls
         models:
             ClariCopilotCall:
                 id: string

--- a/integrations/clari-copilot/nango.yaml
+++ b/integrations/clari-copilot/nango.yaml
@@ -7,7 +7,7 @@ integrations:
                 description: |
                     Fetches a list of calls from your account. For the first sync, it will go back to the past one year
                 sync_type: incremental
-                endpoint: GET /clari-copilot/call
+                endpoint: GET /calls
 models:
     ClariCopilotCall:
         id: string


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
