### PR TITLE
fix(endpoints): update confluence

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -1177,7 +1177,7 @@ integrations:
                     Fetches a list of spaces from confluence
                 sync_type: full
                 scopes: read:space:confluence
-                endpoint: GET /confluence/spaces
+                endpoint: GET /spaces
             pages:
                 runs: every 4 hours
                 output: ConfluencePage
@@ -1185,7 +1185,7 @@ integrations:
                     Fetches a list of pages from confluence
                 sync_type: full
                 scopes: read:page:confluence
-                endpoint: GET /confluence/pages
+                endpoint: GET /pages
         models:
             ConfluenceSpace:
                 id: string

--- a/integrations/confluence/nango.yaml
+++ b/integrations/confluence/nango.yaml
@@ -8,7 +8,7 @@ integrations:
                     Fetches a list of spaces from confluence
                 sync_type: full
                 scopes: read:space:confluence
-                endpoint: GET /confluence/spaces
+                endpoint: GET /spaces
             pages:
                 runs: every 4 hours
                 output: ConfluencePage
@@ -16,7 +16,7 @@ integrations:
                     Fetches a list of pages from confluence
                 sync_type: full
                 scopes: read:page:confluence
-                endpoint: GET /confluence/pages
+                endpoint: GET /pages
 models:
     ConfluenceSpace:
         id: string


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
