### PR TITLE
fix(endpoint): discourse endpoint

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -1222,7 +1222,7 @@ integrations:
             active-users:
                 description: |
                     Fetches a list of active users from Discourse.
-                endpoint: /discourse/active-users
+                endpoint: /users
                 sync_type: full
                 runs: every 1 hour
                 output: User

--- a/integrations/discourse/nango.yaml
+++ b/integrations/discourse/nango.yaml
@@ -4,7 +4,7 @@ integrations:
             active-users:
                 description: |
                     Fetches a list of active users from Discourse.
-                endpoint: /discourse/active-users
+                endpoint: /users
                 sync_type: full
                 runs: every 1 hour
                 output: User


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
