### PR TITLE
chore(templates): add command and export upgrade ignore

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 node ./scripts/flows.js
+npm run generate:tests
 git add ./integrations/*/tests/*.test.ts
 git add ./flows.yaml
 npx lint-staged --allow-empty

--- a/scripts/generate-integration-template-tests.bash
+++ b/scripts/generate-integration-template-tests.bash
@@ -17,6 +17,8 @@ else
     cd ..
 fi
 
+export NANGO_CLI_UPGRADE_MODE=ignore
+
 # Process each integration
 for integration in "${integrations[@]}" ; do
     if [ ! -d "./integrations/$integration/mocks" ]; then


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
