### PR TITLE
fix(integration-tests): fix overrides

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -71,7 +71,7 @@ export class NangoSyncMock {
     private async *getProxyPaginateData(args: any) {
         const { endpoint: rawEndpoint, method = 'get', paginate } = args;
         const endpoint = rawEndpoint.startsWith('/') ? rawEndpoint.slice(1) : rawEndpoint;
-        const data = await this.getMockFile(`nango/${method.toLowerCase()}/proxy/${endpoint}`);
+        const data = await this.getMockFile(`nango/${method.toLowerCase()}/proxy/${endpoint}/${this.name}`);
 
         if (Array.isArray(data)) {
             yield data;
@@ -90,7 +90,7 @@ export class NangoSyncMock {
     private async proxyGetData(args: any) {
         const { endpoint: rawEndpoint } = args;
         const endpoint = rawEndpoint.startsWith('/') ? rawEndpoint.slice(1) : rawEndpoint;
-        const data = await this.getMockFile(`nango/get/proxy/${endpoint}`);
+        const data = await this.getMockFile(`nango/get/proxy/${endpoint}/${this.name}`);
 
         return { data };
     }
@@ -98,7 +98,7 @@ export class NangoSyncMock {
     private async proxyPostData(args: any) {
         const { endpoint: rawEndpoint } = args;
         const endpoint = rawEndpoint.startsWith('/') ? rawEndpoint.slice(1) : rawEndpoint;
-        const data = await this.getMockFile(`nango/post/proxy/${endpoint}`);
+        const data = await this.getMockFile(`nango/post/proxy/${endpoint}/${this.name}`);
 
         return { data };
     }
@@ -106,7 +106,7 @@ export class NangoSyncMock {
     private async proxyPatchData(args: any) {
         const { endpoint: rawEndpoint } = args;
         const endpoint = rawEndpoint.startsWith('/') ? rawEndpoint.slice(1) : rawEndpoint;
-        const data = await this.getMockFile(`nango/patch/proxy/${endpoint}`);
+        const data = await this.getMockFile(`nango/patch/proxy/${endpoint}/${this.name}`);
 
         return { data };
     }
@@ -114,7 +114,7 @@ export class NangoSyncMock {
     private async proxyPutData(args: any) {
         const { endpoint: rawEndpoint } = args;
         const endpoint = rawEndpoint.startsWith('/') ? rawEndpoint.slice(1) : rawEndpoint;
-        const data = await this.getMockFile(`nango/put/proxy/${endpoint}`);
+        const data = await this.getMockFile(`nango/put/proxy/${endpoint}/${this.name}`);
 
         return { data };
     }
@@ -122,7 +122,7 @@ export class NangoSyncMock {
     private async proxyDeleteData(args: any) {
         const { endpoint: rawEndpoint } = args;
         const endpoint = rawEndpoint.startsWith('/') ? rawEndpoint.slice(1) : rawEndpoint;
-        const data = await this.getMockFile(`nango/delete/proxy/${endpoint}`);
+        const data = await this.getMockFile(`nango/delete/proxy/${endpoint}/${this.name}`);
 
         return { data };
     }


### PR DESCRIPTION
## Describe your changes
continuation from [2786](https://github.com/NangoHQ/nango/pull/2786)
## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
