### PR TITLE
fix(netsuite-invoice): [nan-1825] add locations sync and locationId property for create invoice

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -3283,6 +3283,16 @@ integrations:
                 auto_start: true
                 endpoint: GET /creditnotes
                 track_deletes: true
+            locations:
+                version: 1.0.0
+                description: |
+                    Fetches all locations in Netsuite
+                runs: every hour
+                output: NetsuiteLocation
+                sync_type: full
+                auto_start: true
+                endpoint: GET /locations
+                track_deletes: true
         actions:
             customer-create:
                 version: 1.0.0
@@ -3298,7 +3308,7 @@ integrations:
                 output: NetsuiteCustomerUpdateOutput
                 endpoint: PUT /customers
             invoice-create:
-                version: 1.0.0
+                version: 2.0.0
                 description: |
                     Creates an invoice in Netsuite
                 input: NetsuiteInvoiceCreateInput
@@ -3436,6 +3446,7 @@ integrations:
                 amount: number
                 vatCode?: string
                 description?: string
+                locationId: string
             NetsuiteInvoiceCreateInput:
                 customerId: string
                 currency: string
@@ -3452,6 +3463,7 @@ integrations:
                 lines: NetsuiteInvoiceLine[]
                 id: string
                 customerId?: string
+                locationId?: string
                 currency?: string
             NetsuiteInvoiceUpdateOutput:
                 success: boolean
@@ -3491,6 +3503,24 @@ integrations:
                 applyTo?: string[]
             NetsuitePaymentUpdateOutput:
                 success: boolean
+            NetsuiteLocation:
+                id: string
+                isInactive: boolean
+                name: string
+                lastModifiedDate: string
+                address:
+                    address1: string
+                    addressee: string
+                    addressText: string
+                    city: string
+                    country: string
+                    state: string
+                    zip: string
+                returnAddress:
+                    addressText: string
+                    country: string
+                timeZone: string
+                useBins: boolean
     next-cloud-ocs:
         syncs:
             users:

--- a/flows.yaml
+++ b/flows.yaml
@@ -3315,7 +3315,7 @@ integrations:
                 output: NetsuiteInvoiceCreateOutput
                 endpoint: POST /invoices
             invoice-update:
-                version: 1.0.0
+                version: 1.0.1
                 description: |
                     Updates an invoice in Netsuite
                 input: NetsuiteInvoiceUpdateInput

--- a/flows.yaml
+++ b/flows.yaml
@@ -3446,7 +3446,7 @@ integrations:
                 amount: number
                 vatCode?: string
                 description?: string
-                locationId: string
+                locationId?: string
             NetsuiteInvoiceCreateInput:
                 customerId: string
                 currency: string

--- a/integrations/calendly/tests/calendly-event-invitees.test.ts
+++ b/integrations/calendly/tests/calendly-event-invitees.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/event-invitees.js";
+import fetchData from '../syncs/event-invitees.js';
 
-describe("calendly event-invitees tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "event-invitees",
-      Model: "EventInvitee"
-  });
+describe('calendly event-invitees tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'event-invitees',
+        Model: 'EventInvitee'
+    });
 
-  const models = "EventInvitee".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'EventInvitee'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/calendly/tests/calendly-event-types.test.ts
+++ b/integrations/calendly/tests/calendly-event-types.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/event-types.js";
+import fetchData from '../syncs/event-types.js';
 
-describe("calendly event-types tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "event-types",
-      Model: "EventType"
-  });
+describe('calendly event-types tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'event-types',
+        Model: 'EventType'
+    });
 
-  const models = "EventType".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'EventType'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/calendly/tests/calendly-events.test.ts
+++ b/integrations/calendly/tests/calendly-events.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/events.js";
+import fetchData from '../syncs/events.js';
 
-describe("calendly events tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "events",
-      Model: "Event"
-  });
+describe('calendly events tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'events',
+        Model: 'Event'
+    });
 
-  const models = "Event".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Event'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/freshdesk/tests/freshdesk-articles.test.ts
+++ b/integrations/freshdesk/tests/freshdesk-articles.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/articles.js";
+import fetchData from '../syncs/articles.js';
 
-describe("freshdesk articles tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "articles",
-      Model: "Article"
-  });
+describe('freshdesk articles tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'articles',
+        Model: 'Article'
+    });
 
-  const models = "Article".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Article'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/hubspot/actions/fetch-properties.ts
+++ b/integrations/hubspot/actions/fetch-properties.ts
@@ -8,7 +8,7 @@ export default async function runAction(nango: NangoAction, input: InputProperty
     }
 
     const config: ProxyConfiguration = {
-        // https://developers.hubspot.com/docs/api/crm/deals
+        // https://developers.hubspot.com/docs/api/crm/properties
         endpoint: `crm/v3/properties/${input.name}`,
         retries: 10
     };

--- a/integrations/hubspot/tests/hubspot-create-deal.test.ts
+++ b/integrations/hubspot/tests/hubspot-create-deal.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-deal.js";
+import runAction from '../actions/create-deal.js';
 
-describe("hubspot create-deal tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-deal",
-      Model: "CreatedDeal"
-  });
+describe('hubspot create-deal tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-deal',
+        Model: 'CreatedDeal'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/hubspot/tests/hubspot-fetch-properties.test.ts
+++ b/integrations/hubspot/tests/hubspot-fetch-properties.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/fetch-properties.js";
+import runAction from '../actions/fetch-properties.js';
 
-describe("hubspot fetch-properties tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "fetch-properties",
-      Model: "PropertyResponse"
-  });
+describe('hubspot fetch-properties tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'fetch-properties',
+        Model: 'PropertyResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/intercom/tests/intercom-articles.test.ts
+++ b/integrations/intercom/tests/intercom-articles.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/articles.js";
+import fetchData from '../syncs/articles.js';
 
-describe("intercom articles tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "articles",
-      Model: "Article"
-  });
+describe('intercom articles tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'articles',
+        Model: 'Article'
+    });
 
-  const models = "Article".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Article'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/intercom/tests/intercom-contacts.test.ts
+++ b/integrations/intercom/tests/intercom-contacts.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/contacts.js";
+import fetchData from '../syncs/contacts.js';
 
-describe("intercom contacts tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "contacts",
-      Model: "Contact"
-  });
+describe('intercom contacts tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'contacts',
+        Model: 'Contact'
+    });
 
-  const models = "Contact".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Contact'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/intercom/tests/intercom-conversations.test.ts
+++ b/integrations/intercom/tests/intercom-conversations.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/conversations.js";
+import fetchData from '../syncs/conversations.js';
 
-describe("intercom conversations tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "conversations",
-      Model: "Conversation,ConversationMessage"
-  });
+describe('intercom conversations tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'conversations',
+        Model: 'Conversation,ConversationMessage'
+    });
 
-  const models = "Conversation,ConversationMessage".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Conversation,ConversationMessage'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/jira/tests/jira-create-issue.test.ts
+++ b/integrations/jira/tests/jira-create-issue.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-issue.js";
+import runAction from '../actions/create-issue.js';
 
-describe("jira create-issue tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-issue",
-      Model: "CreateIssueOutput"
-  });
+describe('jira create-issue tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-issue',
+        Model: 'CreateIssueOutput'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/jira/tests/jira-issue-types.test.ts
+++ b/integrations/jira/tests/jira-issue-types.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/issue-types.js";
+import fetchData from '../syncs/issue-types.js';
 
-describe("jira issue-types tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "issue-types",
-      Model: "IssueType"
-  });
+describe('jira issue-types tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'issue-types',
+        Model: 'IssueType'
+    });
 
-  const models = "IssueType".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'IssueType'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/jira/tests/jira-issues.test.ts
+++ b/integrations/jira/tests/jira-issues.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/issues.js";
+import fetchData from '../syncs/issues.js';
 
-describe("jira issues tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "issues",
-      Model: "Issue"
-  });
+describe('jira issues tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'issues',
+        Model: 'Issue'
+    });
 
-  const models = "Issue".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Issue'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/jira/tests/jira-projects.test.ts
+++ b/integrations/jira/tests/jira-projects.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/projects.js";
+import fetchData from '../syncs/projects.js';
 
-describe("jira projects tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "projects",
-      Model: "Project"
-  });
+describe('jira projects tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'projects',
+        Model: 'Project'
+    });
 
-  const models = "Project".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Project'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/netsuite-tba/actions/invoice-create.ts
+++ b/integrations/netsuite-tba/actions/invoice-create.ts
@@ -20,7 +20,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteInvoi
                 quantity: line.quantity,
                 amount: line.amount,
                 ...(line.vatCode && { taxDetailsReference: line.vatCode }),
-                location: { id: line.locationId, refName: '' }
+                location: { id: line.locationId!, refName: '' }
             }))
         }
     };

--- a/integrations/netsuite-tba/actions/invoice-create.ts
+++ b/integrations/netsuite-tba/actions/invoice-create.ts
@@ -19,7 +19,8 @@ export default async function runAction(nango: NangoAction, input: NetsuiteInvoi
                 item: { id: line.itemId, refName: line.description || '' },
                 quantity: line.quantity,
                 amount: line.amount,
-                ...(line.vatCode && { taxDetailsReference: line.vatCode })
+                ...(line.vatCode && { taxDetailsReference: line.vatCode }),
+                location: { id: line.locationId, refName: '' }
             }))
         }
     };

--- a/integrations/netsuite-tba/actions/invoice-update.ts
+++ b/integrations/netsuite-tba/actions/invoice-update.ts
@@ -20,6 +20,10 @@ export default async function runAction(nango: NangoAction, input: NetsuiteInvoi
         if (line.vatCode) {
             item.taxDetailsReference = line.vatCode;
         }
+
+        if (line.locationId) {
+            item.location = { id: line.locationId, refName: '' };
+        }
         return item;
     });
 
@@ -38,6 +42,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteInvoi
     if (input.description) {
         body.memo = input.description;
     }
+
     if (lines) {
         body.item = { items: lines };
     }

--- a/integrations/netsuite-tba/nango.yaml
+++ b/integrations/netsuite-tba/nango.yaml
@@ -86,7 +86,7 @@ integrations:
                 output: NetsuiteInvoiceCreateOutput
                 endpoint: POST /invoices
             invoice-update:
-                version: 1.0.0
+                version: 1.0.1
                 description: |
                     Updates an invoice in Netsuite
                 input: NetsuiteInvoiceUpdateInput

--- a/integrations/netsuite-tba/nango.yaml
+++ b/integrations/netsuite-tba/nango.yaml
@@ -49,6 +49,18 @@ integrations:
                 endpoint: GET /creditnotes
                 track_deletes: true
 
+            # Locations
+            locations:
+                version: 1.0.0
+                description: |
+                    Fetches all locations in Netsuite
+                runs: every hour
+                output: NetsuiteLocation
+                sync_type: full
+                auto_start: true
+                endpoint: GET /locations
+                track_deletes: true
+
         actions:
             # Customers
             customer-create:
@@ -67,7 +79,7 @@ integrations:
 
             # Invoices
             invoice-create:
-                version: 1.0.0
+                version: 2.0.0
                 description: |
                     Creates an invoice in Netsuite
                 input: NetsuiteInvoiceCreateInput
@@ -208,6 +220,7 @@ models:
         amount: number
         vatCode?: string
         description?: string
+        locationId: string
 
     NetsuiteInvoiceCreateInput:
         customerId: string
@@ -222,6 +235,7 @@ models:
         __extends: NetsuiteInvoiceCreateInput
         id: string
         customerId?: string
+        locationId?: string
         currency?: string
         description?: string
     NetsuiteInvoiceUpdateOutput:
@@ -260,3 +274,23 @@ models:
         applyTo?: string[]
     NetsuitePaymentUpdateOutput:
         success: boolean
+
+    # Locations
+    NetsuiteLocation:
+        id: string
+        isInactive: boolean
+        name: string
+        lastModifiedDate: string
+        address:
+            address1: string
+            addressee: string
+            addressText: string
+            city: string
+            country: string
+            state: string
+            zip: string
+        returnAddress:
+            addressText: string
+            country: string
+        timeZone: string
+        useBins: boolean

--- a/integrations/netsuite-tba/nango.yaml
+++ b/integrations/netsuite-tba/nango.yaml
@@ -220,7 +220,7 @@ models:
         amount: number
         vatCode?: string
         description?: string
-        locationId: string
+        locationId?: string
 
     NetsuiteInvoiceCreateInput:
         customerId: string

--- a/integrations/netsuite-tba/schema.zod.ts
+++ b/integrations/netsuite-tba/schema.zod.ts
@@ -74,6 +74,7 @@ export const netsuiteInvoiceCreateInputSchema = z.object({
         z.object({
             itemId: z.string().min(1),
             quantity: z.number().min(0),
+            locationId: z.string().min(1),
             amount: z.number().min(0),
             vatCode: z.string().optional(),
             description: z.string().optional()
@@ -92,6 +93,7 @@ export const netsuiteInvoiceUpdateInputSchema = z.object({
                 itemId: z.string().min(1),
                 quantity: z.number().min(0),
                 amount: z.number().min(0),
+                locationId: z.string().optional(),
                 vatCode: z.string().optional(),
                 description: z.string().optional()
             })

--- a/integrations/netsuite-tba/syncs/locations.ts
+++ b/integrations/netsuite-tba/syncs/locations.ts
@@ -1,0 +1,56 @@
+import type { NangoSync, NetsuiteLocation, ProxyConfiguration } from '../../models';
+import type { NS_Location, NSAPI_GetResponse } from '../types';
+import { paginate } from '../helpers/pagination.js';
+
+const retries = 3;
+
+export default async function fetchData(nango: NangoSync): Promise<void> {
+    const proxyConfig: ProxyConfiguration = {
+        // https://system.netsuite.com/help/helpcenter/en_US/APIs/REST_API_Browser/record/v1/2022.1/index.html#tag-location
+        endpoint: '/location',
+        retries
+    };
+    for await (const locations of paginate<{ id: string }>({ nango, proxyConfig })) {
+        await nango.log('Listed locations', { total: locations.length });
+
+        const mappedLocations: NetsuiteLocation[] = [];
+        for (const locationLink of locations) {
+            const location: NSAPI_GetResponse<NS_Location> = await nango.get({
+                endpoint: `/location/${locationLink.id}`,
+                params: {
+                    expandSubResources: 'true'
+                },
+                retries
+            });
+            if (!location.data) {
+                await nango.log('Location not found', { id: locationLink.id });
+                continue;
+            }
+
+            const mappedLocation: NetsuiteLocation = {
+                id: location.data.id,
+                isInactive: location.data.isInactive,
+                name: location.data.name,
+                lastModifiedDate: location.data.lastModifiedDate,
+                address: {
+                    address1: location.data.mainAddress.addr1,
+                    addressee: location.data.mainAddress.addressee,
+                    addressText: location.data.mainAddress.addrText,
+                    city: location.data.mainAddress.city,
+                    country: location.data.mainAddress.country.refName,
+                    state: location.data.mainAddress.state,
+                    zip: location.data.mainAddress.zip
+                },
+                returnAddress: {
+                    addressText: location.data.returnAddress.addrText,
+                    country: location.data.returnAddress.country.refName
+                },
+                timeZone: location.data.timeZone.refName,
+                useBins: location.data.useBins
+            };
+
+            mappedLocations.push(mappedLocation);
+        }
+        await nango.batchSave<NetsuiteLocation>(mappedLocations, 'NetsuiteLocation');
+    }
+}

--- a/integrations/netsuite-tba/types.ts
+++ b/integrations/netsuite-tba/types.ts
@@ -105,83 +105,81 @@ export interface NS_Payment {
 }
 
 export interface NS_Location {
-  links: NS_Link[];
-  classTranslation: NS_ClassTranslation;
-  id: string;
-  includeInControlTower: boolean;
-  includeInSupplyPlanning: boolean;
-  inventoryBalance: NS_InventoryBalance;
-  isInactive: boolean;
-  lastModifiedDate: string;
-  mainAddress: NS_Location_Address;
-  makeInventoryAvailable: boolean;
-  makeInventoryAvailableStore: boolean;
-  name: string;
-  returnAddress: NS_ReturnAddress;
-  subsidiary: NS_Subsidiary;
-  timeZone: NS_TimeZone;
-  useBins: boolean;
+    links: NS_Link[];
+    classTranslation: NS_ClassTranslation;
+    id: string;
+    includeInControlTower: boolean;
+    includeInSupplyPlanning: boolean;
+    inventoryBalance: NS_InventoryBalance;
+    isInactive: boolean;
+    lastModifiedDate: string;
+    mainAddress: NS_Location_Address;
+    makeInventoryAvailable: boolean;
+    makeInventoryAvailableStore: boolean;
+    name: string;
+    returnAddress: NS_ReturnAddress;
+    subsidiary: NS_Subsidiary;
+    timeZone: NS_TimeZone;
+    useBins: boolean;
 }
 
 interface NS_Link {
-  rel: string;
-  href: string;
+    rel: string;
+    href: string;
 }
 
 interface NS_ClassTranslation {
-  links: NS_Link[];
-  items: any[];
-  totalResults: number;
+    links: NS_Link[];
+    items: any[];
+    totalResults: number;
 }
 
 interface NS_InventoryBalance {
-  links: NS_Link[];
-  items: any[];
-  totalResults: number;
+    links: NS_Link[];
+    items: any[];
+    totalResults: number;
 }
 
 interface NS_Location_Address {
-  links: NS_Link[];
-  addr1: string;
-  addressee: string;
-  addrText: string;
-  city: string;
-  country: NS_Country;
-  override: boolean;
-  state: string;
-  zip: string;
+    links: NS_Link[];
+    addr1: string;
+    addressee: string;
+    addrText: string;
+    city: string;
+    country: NS_Country;
+    override: boolean;
+    state: string;
+    zip: string;
 }
 
 interface NS_Country {
-  id: string;
-  refName: string;
+    id: string;
+    refName: string;
 }
 
 interface NS_ReturnAddress {
-  links: NS_Link[];
-  addrText: string;
-  country: NS_Country;
-  override: boolean;
+    links: NS_Link[];
+    addrText: string;
+    country: NS_Country;
+    override: boolean;
 }
 
 interface NS_Subsidiary {
-  links: NS_Link[];
-  count: number;
-  hasMore: boolean;
-  items: NS_SubsidiaryItem[];
-  offset: number;
-  totalResults: number;
+    links: NS_Link[];
+    count: number;
+    hasMore: boolean;
+    items: NS_SubsidiaryItem[];
+    offset: number;
+    totalResults: number;
 }
 
 interface NS_SubsidiaryItem {
-  links: NS_Link[];
-  id: string;
-  refName: string;
+    links: NS_Link[];
+    id: string;
+    refName: string;
 }
 
 interface NS_TimeZone {
-  id: string;
-  refName: string;
+    id: string;
+    refName: string;
 }
-
-

--- a/integrations/netsuite-tba/types.ts
+++ b/integrations/netsuite-tba/types.ts
@@ -30,6 +30,10 @@ export interface NS_Item {
         id: string;
         refName: string;
     };
+    location?: {
+        id: string;
+        refName: string;
+    };
     quantity?: number;
     amount?: number;
     taxDetailsReference?: string;
@@ -99,3 +103,85 @@ export interface NS_Payment {
         items: { doc: { id: string } }[];
     };
 }
+
+export interface NS_Location {
+  links: NS_Link[];
+  classTranslation: NS_ClassTranslation;
+  id: string;
+  includeInControlTower: boolean;
+  includeInSupplyPlanning: boolean;
+  inventoryBalance: NS_InventoryBalance;
+  isInactive: boolean;
+  lastModifiedDate: string;
+  mainAddress: NS_Location_Address;
+  makeInventoryAvailable: boolean;
+  makeInventoryAvailableStore: boolean;
+  name: string;
+  returnAddress: NS_ReturnAddress;
+  subsidiary: NS_Subsidiary;
+  timeZone: NS_TimeZone;
+  useBins: boolean;
+}
+
+interface NS_Link {
+  rel: string;
+  href: string;
+}
+
+interface NS_ClassTranslation {
+  links: NS_Link[];
+  items: any[];
+  totalResults: number;
+}
+
+interface NS_InventoryBalance {
+  links: NS_Link[];
+  items: any[];
+  totalResults: number;
+}
+
+interface NS_Location_Address {
+  links: NS_Link[];
+  addr1: string;
+  addressee: string;
+  addrText: string;
+  city: string;
+  country: NS_Country;
+  override: boolean;
+  state: string;
+  zip: string;
+}
+
+interface NS_Country {
+  id: string;
+  refName: string;
+}
+
+interface NS_ReturnAddress {
+  links: NS_Link[];
+  addrText: string;
+  country: NS_Country;
+  override: boolean;
+}
+
+interface NS_Subsidiary {
+  links: NS_Link[];
+  count: number;
+  hasMore: boolean;
+  items: NS_SubsidiaryItem[];
+  offset: number;
+  totalResults: number;
+}
+
+interface NS_SubsidiaryItem {
+  links: NS_Link[];
+  id: string;
+  refName: string;
+}
+
+interface NS_TimeZone {
+  id: string;
+  refName: string;
+}
+
+

--- a/integrations/notion/tests/notion-content-metadata.test.ts
+++ b/integrations/notion/tests/notion-content-metadata.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/content-metadata.js";
+import fetchData from '../syncs/content-metadata.js';
 
-describe("notion content-metadata tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "content-metadata",
-      Model: "ContentMetadata"
-  });
+describe('notion content-metadata tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'content-metadata',
+        Model: 'ContentMetadata'
+    });
 
-  const models = "ContentMetadata".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'ContentMetadata'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/notion/tests/notion-fetch-content-metadata.test.ts
+++ b/integrations/notion/tests/notion-fetch-content-metadata.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/fetch-content-metadata.js";
+import runAction from '../actions/fetch-content-metadata.js';
 
-describe("notion fetch-content-metadata tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "fetch-content-metadata",
-      Model: "ContentMetadata"
-  });
+describe('notion fetch-content-metadata tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'fetch-content-metadata',
+        Model: 'ContentMetadata'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/notion/tests/notion-fetch-database.test.ts
+++ b/integrations/notion/tests/notion-fetch-database.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/fetch-database.js";
+import runAction from '../actions/fetch-database.js';
 
-describe("notion fetch-database tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "fetch-database",
-      Model: "Database"
-  });
+describe('notion fetch-database tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'fetch-database',
+        Model: 'Database'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/notion/tests/notion-fetch-rich-page.test.ts
+++ b/integrations/notion/tests/notion-fetch-rich-page.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/fetch-rich-page.js";
+import runAction from '../actions/fetch-rich-page.js';
 
-describe("notion fetch-rich-page tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "fetch-rich-page",
-      Model: "RichPage"
-  });
+describe('notion fetch-rich-page tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'fetch-rich-page',
+        Model: 'RichPage'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/salesforce/tests/salesforce-accounts.test.ts
+++ b/integrations/salesforce/tests/salesforce-accounts.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/accounts.js";
+import fetchData from '../syncs/accounts.js';
 
-describe("salesforce accounts tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "accounts",
-      Model: "Account"
-  });
+describe('salesforce accounts tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'accounts',
+        Model: 'Account'
+    });
 
-  const models = "Account".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Account'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/salesforce/tests/salesforce-articles.test.ts
+++ b/integrations/salesforce/tests/salesforce-articles.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/articles.js";
+import fetchData from '../syncs/articles.js';
 
-describe("salesforce articles tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "articles",
-      Model: "Article"
-  });
+describe('salesforce articles tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'articles',
+        Model: 'Article'
+    });
 
-  const models = "Article".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Article'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/salesforce/tests/salesforce-contacts.test.ts
+++ b/integrations/salesforce/tests/salesforce-contacts.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/contacts.js";
+import fetchData from '../syncs/contacts.js';
 
-describe("salesforce contacts tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "contacts",
-      Model: "Contact"
-  });
+describe('salesforce contacts tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'contacts',
+        Model: 'Contact'
+    });
 
-  const models = "Contact".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Contact'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/salesforce/tests/salesforce-deals.test.ts
+++ b/integrations/salesforce/tests/salesforce-deals.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/deals.js";
+import fetchData from '../syncs/deals.js';
 
-describe("salesforce deals tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "deals",
-      Model: "Deal"
-  });
+describe('salesforce deals tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'deals',
+        Model: 'Deal'
+    });
 
-  const models = "Deal".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Deal'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/salesforce/tests/salesforce-fetch-fields.test.ts
+++ b/integrations/salesforce/tests/salesforce-fetch-fields.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/fetch-fields.js";
+import runAction from '../actions/fetch-fields.js';
 
-describe("salesforce fetch-fields tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "fetch-fields",
-      Model: "SalesforceFieldSchema"
-  });
+describe('salesforce fetch-fields tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'fetch-fields',
+        Model: 'SalesforceFieldSchema'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/salesforce/tests/salesforce-tickets.test.ts
+++ b/integrations/salesforce/tests/salesforce-tickets.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/tickets.js";
+import fetchData from '../syncs/tickets.js';
 
-describe("salesforce tickets tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "tickets",
-      Model: "Ticket"
-  });
+describe('salesforce tickets tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'tickets',
+        Model: 'Ticket'
+    });
 
-  const models = "Ticket".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Ticket'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/slack/tests/slack-channels.test.ts
+++ b/integrations/slack/tests/slack-channels.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/channels.js";
+import fetchData from '../syncs/channels.js';
 
-describe("slack channels tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "channels",
-      Model: "SlackChannel"
-  });
+describe('slack channels tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'channels',
+        Model: 'SlackChannel'
+    });
 
-  const models = "SlackChannel".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'SlackChannel'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/slack/tests/slack-send-message.test.ts
+++ b/integrations/slack/tests/slack-send-message.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/send-message.js";
+import runAction from '../actions/send-message.js';
 
-describe("slack send-message tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "send-message",
-      Model: "SendMesssageOutput"
-  });
+describe('slack send-message tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'send-message',
+        Model: 'SendMesssageOutput'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/slack/tests/slack-users.test.ts
+++ b/integrations/slack/tests/slack-users.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/users.js";
+import fetchData from '../syncs/users.js';
 
-describe("slack users tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "users",
-      Model: "SlackUser"
-  });
+describe('slack users tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'users',
+        Model: 'SlackUser'
+    });
 
-  const models = "SlackUser".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'SlackUser'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/xero/tests/xero-accounts.test.ts
+++ b/integrations/xero/tests/xero-accounts.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/accounts.js";
+import fetchData from '../syncs/accounts.js';
 
-describe("xero accounts tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "accounts",
-      Model: "Account"
-  });
+describe('xero accounts tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'accounts',
+        Model: 'Account'
+    });
 
-  const models = "Account".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Account'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/xero/tests/xero-contacts.test.ts
+++ b/integrations/xero/tests/xero-contacts.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/contacts.js";
+import fetchData from '../syncs/contacts.js';
 
-describe("xero contacts tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "contacts",
-      Model: "Contact"
-  });
+describe('xero contacts tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'contacts',
+        Model: 'Contact'
+    });
 
-  const models = "Contact".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Contact'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/xero/tests/xero-create-contact.test.ts
+++ b/integrations/xero/tests/xero-create-contact.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-contact.js";
+import runAction from '../actions/create-contact.js';
 
-describe("xero create-contact tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-contact",
-      Model: "ContactActionResponse"
-  });
+describe('xero create-contact tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-contact',
+        Model: 'ContactActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-create-credit-note.test.ts
+++ b/integrations/xero/tests/xero-create-credit-note.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-credit-note.js";
+import runAction from '../actions/create-credit-note.js';
 
-describe("xero create-credit-note tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-credit-note",
-      Model: "CreditNoteActionResponse"
-  });
+describe('xero create-credit-note tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-credit-note',
+        Model: 'CreditNoteActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-create-invoice.test.ts
+++ b/integrations/xero/tests/xero-create-invoice.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-invoice.js";
+import runAction from '../actions/create-invoice.js';
 
-describe("xero create-invoice tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-invoice",
-      Model: "InvoiceActionResponse"
-  });
+describe('xero create-invoice tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-invoice',
+        Model: 'InvoiceActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-create-item.test.ts
+++ b/integrations/xero/tests/xero-create-item.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-item.js";
+import runAction from '../actions/create-item.js';
 
-describe("xero create-item tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-item",
-      Model: "ItemActionResponse"
-  });
+describe('xero create-item tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-item',
+        Model: 'ItemActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-create-payment.test.ts
+++ b/integrations/xero/tests/xero-create-payment.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/create-payment.js";
+import runAction from '../actions/create-payment.js';
 
-describe("xero create-payment tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "create-payment",
-      Model: "PaymentActionResponse"
-  });
+describe('xero create-payment tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-payment',
+        Model: 'PaymentActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-invoices.test.ts
+++ b/integrations/xero/tests/xero-invoices.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/invoices.js";
+import fetchData from '../syncs/invoices.js';
 
-describe("xero invoices tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "invoices",
-      Model: "Invoice"
-  });
+describe('xero invoices tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'invoices',
+        Model: 'Invoice'
+    });
 
-  const models = "Invoice".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Invoice'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/xero/tests/xero-items.test.ts
+++ b/integrations/xero/tests/xero-items.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/items.js";
+import fetchData from '../syncs/items.js';
 
-describe("xero items tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "items",
-      Model: "Item"
-  });
+describe('xero items tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'items',
+        Model: 'Item'
+    });
 
-  const models = "Item".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Item'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/xero/tests/xero-payments.test.ts
+++ b/integrations/xero/tests/xero-payments.test.ts
@@ -1,53 +1,52 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import fetchData from "../syncs/payments.js";
+import fetchData from '../syncs/payments.js';
 
-describe("xero payments tests", () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
-      dirname: __dirname,
-      name: "payments",
-      Model: "Payment"
-  });
+describe('xero payments tests', () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
+        dirname: __dirname,
+        name: 'payments',
+        Model: 'Payment'
+    });
 
-  const models = "Payment".split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
+    const models = 'Payment'.split(',');
+    const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
 
-  it("should get, map correctly the data and batchSave the result", async () => {
-    await fetchData(nangoMock);
+    it('should get, map correctly the data and batchSave the result', async () => {
+        await fetchData(nangoMock);
 
-    for (const model of models) {
-        const batchSaveData = await nangoMock.getBatchSaveData(model);
+        for (const model of models) {
+            const batchSaveData = await nangoMock.getBatchSaveData(model);
 
-        const totalCalls = batchSaveSpy.mock.calls.length;
+            const totalCalls = batchSaveSpy.mock.calls.length;
 
-        if (totalCalls > models.length) {
-            const splitSize = Math.ceil(batchSaveData.length / totalCalls);
+            if (totalCalls > models.length) {
+                const splitSize = Math.ceil(batchSaveData.length / totalCalls);
 
-            const splitBatchSaveData = [];
-            for (let i = 0; i < totalCalls; i++) {
-              const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
-              splitBatchSaveData.push(chunk);
+                const splitBatchSaveData = [];
+                for (let i = 0; i < totalCalls; i++) {
+                    const chunk = batchSaveData.slice(i * splitSize, (i + 1) * splitSize);
+                    splitBatchSaveData.push(chunk);
+                }
+
+                splitBatchSaveData.forEach((data, index) => {
+                    // @ts-ignore
+                    expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
+                });
+            } else {
+                expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
             }
-
-            splitBatchSaveData.forEach((data, index) => {
-              // @ts-ignore
-              expect(batchSaveSpy?.mock.calls[index][0]).toEqual(data);
-            });
-
-        } else {
-            expect(nangoMock.batchSave).toHaveBeenCalledWith(batchSaveData, model);
         }
-    }
-  });
+    });
 
-  it('should get, map correctly the data and batchDelete the result', async () => {
-      await fetchData(nangoMock);
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        await fetchData(nangoMock);
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
-          }
-      }
-  });
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+            }
+        }
+    });
 });

--- a/integrations/xero/tests/xero-update-contact.test.ts
+++ b/integrations/xero/tests/xero-update-contact.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/update-contact.js";
+import runAction from '../actions/update-contact.js';
 
-describe("xero update-contact tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "update-contact",
-      Model: "ContactActionResponse"
-  });
+describe('xero update-contact tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'update-contact',
+        Model: 'ContactActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-update-credit-note.test.ts
+++ b/integrations/xero/tests/xero-update-credit-note.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/update-credit-note.js";
+import runAction from '../actions/update-credit-note.js';
 
-describe("xero update-credit-note tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "update-credit-note",
-      Model: "CreditNoteActionResponse"
-  });
+describe('xero update-credit-note tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'update-credit-note',
+        Model: 'CreditNoteActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-update-invoice.test.ts
+++ b/integrations/xero/tests/xero-update-invoice.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/update-invoice.js";
+import runAction from '../actions/update-invoice.js';
 
-describe("xero update-invoice tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "update-invoice",
-      Model: "InvoiceActionResponse"
-  });
+describe('xero update-invoice tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'update-invoice',
+        Model: 'InvoiceActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });

--- a/integrations/xero/tests/xero-update-item.test.ts
+++ b/integrations/xero/tests/xero-update-item.test.ts
@@ -1,19 +1,19 @@
-import { vi, expect, it, describe } from "vitest";
+import { vi, expect, it, describe } from 'vitest';
 
-import runAction from "../actions/update-item.js";
+import runAction from '../actions/update-item.js';
 
-describe("xero update-item tests", () => {
-  const nangoMock = new global.vitest.NangoActionMock({ 
-      dirname: __dirname,
-      name: "update-item",
-      Model: "ItemActionResponse"
-  });
+describe('xero update-item tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'update-item',
+        Model: 'ItemActionResponse'
+    });
 
-  it('should output the action output that is expected', async () => {
-      const input = await nangoMock.getInput();
-      const response = await runAction(nangoMock, input);
-      const output = await nangoMock.getOutput();
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await runAction(nangoMock, input);
+        const output = await nangoMock.getOutput();
 
-      expect(response).toEqual(output);
-  });
+        expect(response).toEqual(output);
+    });
 });


### PR DESCRIPTION
## Describe your changes
Add a locations sync so a `locationId` can be provided to the invoice create action which is required as reported by a customer.

## Issue ticket number and link
NAN-1825

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [x] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
