### PR TITLE
fix(notion-db-action): add id of the row in the output

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -3979,7 +3979,10 @@ integrations:
                     Fetch a specific Notion database by passing in the database id. This
                     action fetches
 
-                    the database and converts it into a CSV string.
+                    the database and outputs an object. Note that this should be used for
+                    small
+
+                    databases.
                 input: DatabaseInput
                 output: Database
                 endpoint: GET /fetch-database

--- a/flows.yaml
+++ b/flows.yaml
@@ -3983,6 +3983,7 @@ integrations:
                 input: DatabaseInput
                 output: Database
                 endpoint: GET /fetch-database
+                version: 1.0.0
             fetch-content-metadata:
                 description: >
                     Retrieve the entity type as well as an id for a Notion entity to later
@@ -4013,15 +4014,17 @@ integrations:
                 parent_id?: string | undefined
             DatabaseInput:
                 databaseId: string
-            DatabaseEntry:
-                __string: string
+            RowEntry:
+                id: string
+                row:
+                    __string: any
             Database:
                 id: string
                 path: string
                 title: string
                 meta: object
                 last_modified: string
-                entries: DatabaseEntry[]
+                entries: RowEntry[]
             UrlOrId:
                 url?: string
                 id?: string

--- a/flows.yaml
+++ b/flows.yaml
@@ -3975,14 +3975,10 @@ integrations:
                 output: RichPage
                 endpoint: GET /fetch-rich-page
             fetch-database:
-                description: >
+                description: >-
                     Fetch a specific Notion database by passing in the database id. This
-                    action fetches
-
-                    the database and outputs an object. Note that this should be used for
-                    small
-
-                    databases.
+                    action fetches the database and outputs an object. Note that this
+                    should be used for small databases.
                 input: DatabaseInput
                 output: Database
                 endpoint: GET /fetch-database

--- a/integrations/notion/actions/fetch-database.ts
+++ b/integrations/notion/actions/fetch-database.ts
@@ -1,4 +1,4 @@
-import type { NangoAction, DatabaseInput, Database, ProxyConfiguration } from '../../models';
+import type { NangoAction, RowEntry, DatabaseInput, Database, ProxyConfiguration } from '../../models';
 import { databaseInputSchema } from '../schema.zod.js';
 import type { Database as NotionDatabase } from '../types.js';
 
@@ -16,18 +16,16 @@ export default async function runAction(nango: NangoAction, input: DatabaseInput
 
     const proxyConfig: ProxyConfiguration = {
         method: 'POST',
-        endpoint: `/v1/databases/${parsedInput.data.databaseId}/query`,
-        paginate: {
-            cursor_path_in_response: 'next_cursor'
-        }
+        endpoint: `/v1/databases/${parsedInput.data.databaseId}/query`
     };
 
-    const entries: Database['entries'] = [];
+    const entries: RowEntry[] = [];
 
     for await (const databases of nango.paginate<NotionDatabase>(proxyConfig)) {
         for (const db of databases) {
-            const entry = db.properties;
-            entries.push(entry);
+            const id = db.id;
+            const row = db.properties;
+            entries.push({ id, row });
         }
     }
 

--- a/integrations/notion/mocks/fetch-database/output.json
+++ b/integrations/notion/mocks/fetch-database/output.json
@@ -9,132 +9,133 @@
     },
     "entries": [
         {
-            "Tags": {
-                "id": "IZ~%60",
-                "type": "multi_select",
-                "multi_select": []
-            },
-            "A": {
-                "id": "KyMi",
-                "type": "select",
-                "select": {
-                    "id": "r}bL",
-                    "name": "C",
-                    "color": "orange"
+            "id": "7ed0e6a1-b899-43aa-a75a-17e31a7b574d",
+            "row": {
+                "Tags": {
+                    "id": "IZ~%60",
+                    "type": "multi_select",
+                    "multi_select": []
+                },
+                "A": {
+                    "id": "KyMi",
+                    "type": "select",
+                    "select": null
+                },
+                "Name": {
+                    "id": "title",
+                    "type": "title",
+                    "title": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Third Row",
+                                "link": null
+                            },
+                            "annotations": {
+                                "bold": false,
+                                "italic": false,
+                                "strikethrough": false,
+                                "underline": false,
+                                "code": false,
+                                "color": "default"
+                            },
+                            "plain_text": "Third Row",
+                            "href": null
+                        }
+                    ]
                 }
-            },
-            "Name": {
-                "id": "title",
-                "type": "title",
-                "title": [
-                    {
-                        "type": "text",
-                        "text": {
-                            "content": "Third Row",
-                            "link": null
-                        },
-                        "annotations": {
-                            "bold": false,
-                            "italic": false,
-                            "strikethrough": false,
-                            "underline": false,
-                            "code": false,
-                            "color": "default"
-                        },
-                        "plain_text": "Third Row",
-                        "href": null
-                    }
-                ]
             }
         },
         {
-            "Tags": {
-                "id": "IZ~%60",
-                "type": "multi_select",
-                "multi_select": [
-                    {
-                        "id": "18a161b4-314c-4a70-a736-d5f50ac16b1d",
-                        "name": "def",
-                        "color": "orange"
+            "id": "9f19af53-91b7-4c4a-8899-3a240b3f6f7a",
+            "row": {
+                "Tags": {
+                    "id": "IZ~%60",
+                    "type": "multi_select",
+                    "multi_select": [
+                        {
+                            "id": "18a161b4-314c-4a70-a736-d5f50ac16b1d",
+                            "name": "def",
+                            "color": "orange"
+                        }
+                    ]
+                },
+                "A": {
+                    "id": "KyMi",
+                    "type": "select",
+                    "select": {
+                        "id": "Lz_l",
+                        "name": "B",
+                        "color": "green"
                     }
-                ]
-            },
-            "A": {
-                "id": "KyMi",
-                "type": "select",
-                "select": {
-                    "id": "Lz_l",
-                    "name": "B",
-                    "color": "green"
+                },
+                "Name": {
+                    "id": "title",
+                    "type": "title",
+                    "title": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Two Row",
+                                "link": null
+                            },
+                            "annotations": {
+                                "bold": false,
+                                "italic": false,
+                                "strikethrough": false,
+                                "underline": false,
+                                "code": false,
+                                "color": "default"
+                            },
+                            "plain_text": "Two Row",
+                            "href": null
+                        }
+                    ]
                 }
-            },
-            "Name": {
-                "id": "title",
-                "type": "title",
-                "title": [
-                    {
-                        "type": "text",
-                        "text": {
-                            "content": "Two Row",
-                            "link": null
-                        },
-                        "annotations": {
-                            "bold": false,
-                            "italic": false,
-                            "strikethrough": false,
-                            "underline": false,
-                            "code": false,
-                            "color": "default"
-                        },
-                        "plain_text": "Two Row",
-                        "href": null
-                    }
-                ]
             }
         },
         {
-            "Tags": {
-                "id": "IZ~%60",
-                "type": "multi_select",
-                "multi_select": [
-                    {
-                        "id": "91287bfb-0a55-4899-a9b0-fd9d3d99a08a",
-                        "name": "abc",
-                        "color": "default"
-                    }
-                ]
-            },
-            "A": {
-                "id": "KyMi",
-                "type": "select",
-                "select": {
-                    "id": "}TDi",
-                    "name": "F",
-                    "color": "default"
-                }
-            },
-            "Name": {
-                "id": "title",
-                "type": "title",
-                "title": [
-                    {
-                        "type": "text",
-                        "text": {
-                            "content": "One Row",
-                            "link": null
-                        },
-                        "annotations": {
-                            "bold": false,
-                            "italic": false,
-                            "strikethrough": false,
-                            "underline": false,
-                            "code": false,
+            "id": "a5d88985-5487-4224-b5fc-efee29fdd549",
+            "row": {
+                "Tags": {
+                    "id": "IZ~%60",
+                    "type": "multi_select",
+                    "multi_select": [
+                        {
+                            "id": "91287bfb-0a55-4899-a9b0-fd9d3d99a08a",
+                            "name": "abc",
                             "color": "default"
-                        },
-                        "plain_text": "One Row",
-                        "href": null
-                    }
-                ]
+                        }
+                    ]
+                },
+                "A": {
+                    "id": "KyMi",
+                    "type": "select",
+                    "select": null
+                },
+                "Name": {
+                    "id": "title",
+                    "type": "title",
+                    "title": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "One Row",
+                                "link": null
+                            },
+                            "annotations": {
+                                "bold": false,
+                                "italic": false,
+                                "strikethrough": false,
+                                "underline": false,
+                                "code": false,
+                                "color": "default"
+                            },
+                            "plain_text": "One Row",
+                            "href": null
+                        }
+                    ]
+                }
             }
         }
     ]

--- a/integrations/notion/mocks/nango/get/proxy/v1/databases/111ce298-3121-802a-8889-e03a52fcc04e/fetch-database.json
+++ b/integrations/notion/mocks/nango/get/proxy/v1/databases/111ce298-3121-802a-8889-e03a52fcc04e/fetch-database.json
@@ -110,5 +110,5 @@
     "public_url": null,
     "archived": false,
     "in_trash": false,
-    "request_id": "b386ac23-0e75-40ce-99e1-db250861cf41"
+    "request_id": "c069c5de-f7f8-4b00-be37-e04851c061ca"
 }

--- a/integrations/notion/mocks/nango/post/proxy/v1/databases/111ce298-3121-802a-8889-e03a52fcc04e/query/fetch-database.json
+++ b/integrations/notion/mocks/nango/post/proxy/v1/databases/111ce298-3121-802a-8889-e03a52fcc04e/query/fetch-database.json
@@ -5,7 +5,7 @@
             "object": "page",
             "id": "7ed0e6a1-b899-43aa-a75a-17e31a7b574d",
             "created_time": "2024-09-30T16:12:00.000Z",
-            "last_edited_time": "2024-09-30T16:13:00.000Z",
+            "last_edited_time": "2024-10-01T18:55:00.000Z",
             "created_by": {
                 "object": "user",
                 "id": "d42542a8-a81c-4386-aa95-313aa4e818b3"
@@ -31,11 +31,7 @@
                 "A": {
                     "id": "KyMi",
                     "type": "select",
-                    "select": {
-                        "id": "r}bL",
-                        "name": "C",
-                        "color": "orange"
-                    }
+                    "select": null
                 },
                 "Name": {
                     "id": "title",
@@ -137,7 +133,7 @@
             "object": "page",
             "id": "a5d88985-5487-4224-b5fc-efee29fdd549",
             "created_time": "2024-09-30T16:12:00.000Z",
-            "last_edited_time": "2024-09-30T16:13:00.000Z",
+            "last_edited_time": "2024-10-01T18:55:00.000Z",
             "created_by": {
                 "object": "user",
                 "id": "d42542a8-a81c-4386-aa95-313aa4e818b3"
@@ -169,11 +165,7 @@
                 "A": {
                     "id": "KyMi",
                     "type": "select",
-                    "select": {
-                        "id": "}TDi",
-                        "name": "F",
-                        "color": "default"
-                    }
+                    "select": null
                 },
                 "Name": {
                     "id": "title",
@@ -207,5 +199,5 @@
     "has_more": false,
     "type": "page_or_database",
     "page_or_database": {},
-    "request_id": "cd1b82ca-99f9-4a55-a794-85ed39d90749"
+    "request_id": "a5956538-de24-4e9e-bf41-a7762d0b8a94"
 }

--- a/integrations/notion/nango.yaml
+++ b/integrations/notion/nango.yaml
@@ -34,6 +34,7 @@ integrations:
                 input: DatabaseInput
                 output: Database
                 endpoint: GET /fetch-database
+                version: 1.0.0
             fetch-content-metadata:
                 description: |
                     Retrieve the entity type as well as an id for a Notion entity to later call
@@ -62,15 +63,17 @@ models:
         parent_id?: string | undefined
     DatabaseInput:
         databaseId: string
-    DatabaseEntry:
-        __string: string
+    RowEntry:
+        id: string
+        row:
+            __string: any
     Database:
         id: string
         path: string
         title: string
         meta: object
         last_modified: string
-        entries: DatabaseEntry[]
+        entries: RowEntry[]
     UrlOrId:
         url?: string
         id?: string

--- a/integrations/notion/nango.yaml
+++ b/integrations/notion/nango.yaml
@@ -30,7 +30,8 @@ integrations:
             fetch-database:
                 description: |
                     Fetch a specific Notion database by passing in the database id. This action fetches
-                    the database and converts it into a CSV string.
+                    the database and outputs an object. Note that this should be used for small
+                    databases.
                 input: DatabaseInput
                 output: Database
                 endpoint: GET /fetch-database

--- a/integrations/notion/nango.yaml
+++ b/integrations/notion/nango.yaml
@@ -28,10 +28,7 @@ integrations:
                 output: RichPage
                 endpoint: GET /fetch-rich-page
             fetch-database:
-                description: |
-                    Fetch a specific Notion database by passing in the database id. This action fetches
-                    the database and outputs an object. Note that this should be used for small
-                    databases.
+                description: Fetch a specific Notion database by passing in the database id. This action fetches the database and outputs an object. Note that this should be used for small databases.
                 input: DatabaseInput
                 output: Database
                 endpoint: GET /fetch-database


### PR DESCRIPTION
## Describe your changes
Output the row id with the row data for notion. Clarify the description

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
