### PR TITLE
fix(outlook): version bump

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -5436,7 +5436,7 @@ integrations:
                 output: OutlookEmail
                 sync_type: incremental
                 endpoint: GET /emails
-                version: 1.0.0
+                version: 1.0.1
         actions:
             fetch-attachment:
                 input: DocumentInput

--- a/integrations/outlook/nango.yaml
+++ b/integrations/outlook/nango.yaml
@@ -13,7 +13,7 @@ integrations:
                 output: OutlookEmail
                 sync_type: incremental
                 endpoint: GET /emails
-                version: 1.0.0
+                version: 1.0.1
         actions:
             fetch-attachment:
                 input: DocumentInput


### PR DESCRIPTION
## Describe your changes
BUmp version, remove sender as required.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
