### PR TITLE
fix(drive): supportsAllDrives option

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -2751,7 +2751,7 @@ integrations:
                     (https://developers.google.com/drive/picker/reference/results)
                 input: DocumentMetadata
                 auto_start: false
-                version: 1.0.2
+                version: 1.0.3
                 output: Document
                 sync_type: full
                 endpoint: GET /google-drive/documents

--- a/integrations/google-drive/nango.yaml
+++ b/integrations/google-drive/nango.yaml
@@ -16,7 +16,7 @@ integrations:
                     (https://developers.google.com/drive/picker/reference/results)
                 input: DocumentMetadata
                 auto_start: false
-                version: 1.0.2
+                version: 1.0.3
                 output: Document
                 sync_type: full
                 endpoint: GET /google-drive/documents

--- a/integrations/google-drive/syncs/documents.ts
+++ b/integrations/google-drive/syncs/documents.ts
@@ -78,9 +78,11 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         for (const file of metadata.files) {
             try {
                 const config: ProxyConfiguration = {
+                    // https://developers.google.com/drive/api/reference/rest/v3/files/get
                     endpoint: `drive/v3/files/${file}`,
                     params: {
-                        fields: 'id, name, mimeType, webViewLink, parents'
+                        fields: 'id, name, mimeType, webViewLink, parents',
+                        supportsAllDrives: 'true'
                     },
                     retries: 10
                 };


### PR DESCRIPTION
## Describe your changes
Ensure all files can be fetched

## Issue ticket number and link
NAN-2004

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
