### PR TITLE
fix(g-drive): add includeAllDrives query param

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -2754,7 +2754,7 @@ integrations:
                 version: 1.0.3
                 output: Document
                 sync_type: full
-                endpoint: GET /google-drive/documents
+                endpoint: GET /documents
                 scopes: https://www.googleapis.com/auth/drive.readonly
         actions:
             fetch-document:
@@ -2768,8 +2768,8 @@ integrations:
                     string can be used to recreate the file in its original format using
                     an external tool.
                 output: string
-                version: 1.0.1
-                endpoint: GET /google-drive/fetch-document
+                version: 1.0.2
+                endpoint: GET /fetch-document
                 scopes: https://www.googleapis.com/auth/drive.readonly
         models:
             DocumentMetadata:

--- a/integrations/google-drive/actions/fetch-document.ts
+++ b/integrations/google-drive/actions/fetch-document.ts
@@ -21,9 +21,11 @@ export default async function runAction(nango: NangoAction, input: string): Prom
 
     // Fetch the file metadata first to get the MIME type
     const Config: ProxyConfiguration = {
+        // https://developers.google.com/drive/api/reference/rest/v3/files/get
         endpoint: `drive/v3/files/${input}`,
         params: {
-            fields: 'id, name, mimeType'
+            fields: 'id, name, mimeType',
+            supportsAllDrives: 'true'
         },
         retries: 10
     };

--- a/integrations/google-drive/nango.yaml
+++ b/integrations/google-drive/nango.yaml
@@ -19,7 +19,7 @@ integrations:
                 version: 1.0.3
                 output: Document
                 sync_type: full
-                endpoint: GET /google-drive/documents
+                endpoint: GET /documents
                 scopes: https://www.googleapis.com/auth/drive.readonly
         actions:
             fetch-document:
@@ -29,8 +29,8 @@ integrations:
                     a response stream, and encodes it into a base64 string. This base64-encoded
                     string can be used to recreate the file in its original format using an external tool.
                 output: string
-                version: 1.0.1
-                endpoint: GET /google-drive/fetch-document
+                version: 1.0.2
+                endpoint: GET /fetch-document
                 scopes: https://www.googleapis.com/auth/drive.readonly
 models:
     DocumentMetadata:


### PR DESCRIPTION
## Describe your changes
Same fix as #85 

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
