### PR TITLE
feat(tooling): simplify dryrun command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "move:integrations": "bash scripts/move-all-to-nango-integration-directories.bash $npm_config_integration",
         "undo:move:integrations": "bash scripts/undo-move-to-nango-directories.bash",
         "lint-moved-integrations": "npm run move:integrations && npm run lint && npm run undo:move:integrations",
+        "dryrun": "bash scripts/run-integration-template.bash --dryrun",
         "generate:zod": "bash scripts/generate-integration-template-zod.bash $npm_config_integration && npm run undo:move:integrations",
         "compile": "bash scripts/compile-all-templates.bash $npm_config_integration && npm run undo:move:integrations",
         "prettier-format": "prettier --config .prettierrc \"./**/*.{ts,tsx}\" --write",


### PR DESCRIPTION
## Describe your changes
If an .env file is added with these contents:
```
NANGO_SECRET_KEY_DEV=aaa-aaa-aaa
NANGO_HOSTPORT=https://api.nango.dev
```
You can now just run 
```
npm run dryrun -- datadog users d
```

The pattern above being `dryrun $INTEGRATION $SCRIPT_NAME $CONNECTION_NAME`

Instead of 
```
bash scripts/run-integration-template.bash KEY=aaa-aaa-aaa HOST=https://api.nango.dev datadog dryrun users d
```

Note that this is backwards compatible

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
