### PR TITLE
feat: Added upsert-account action to salesforce

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -6632,6 +6632,15 @@ integrations:
                 output: SuccessResponse
                 endpoint: PATCH /accounts
                 version: 1.0.0
+            upsert-account:
+                description: Upsert a single account in salesforce
+                scopes:
+                    - offline_access
+                    - api
+                input: UpsertAccountInput
+                output: ActionResponse
+                endpoint: PATCH /accounts/upsert
+                version: 1.0.0
             delete-account:
                 description: Delete a single account in salesforce
                 scopes:
@@ -6875,6 +6884,16 @@ integrations:
                 billing_country?: string | undefined
                 owner_id?: string | undefined
                 name?: string | undefined
+            UpsertAccountInput:
+                description?: string | undefined
+                website?: string | undefined
+                industry?: string | undefined
+                billing_city?: string | undefined
+                billing_country?: string | undefined
+                owner_id?: string | undefined
+                name?: string | undefined
+                field_name?: string | undefined
+                field_value?: string | undefined
             Opportunity:
                 id: string
                 opportunity_name: string

--- a/integrations/salesforce/actions/upsert-account.ts
+++ b/integrations/salesforce/actions/upsert-account.ts
@@ -1,6 +1,6 @@
 import type { UpsertAccountInput, ProxyConfiguration, SuccessResponse, NangoAction } from '../../models';
 import { upsertAccountInputSchema } from '../schema.zod.js';
-import { toSalesForceAccount } from '../mappers/toAccount';
+import { toSalesForceAccount } from '../mappers/toAccount.js';
 
 export default async function runAction(nango: NangoAction, input: UpsertAccountInput): Promise<SuccessResponse> {
     const parsedInput = upsertAccountInputSchema.safeParse(input);

--- a/integrations/salesforce/actions/upsert-account.ts
+++ b/integrations/salesforce/actions/upsert-account.ts
@@ -1,0 +1,32 @@
+import type { UpsertAccountInput, ProxyConfiguration, SuccessResponse, NangoAction } from '../../models';
+import { upsertAccountInputSchema } from '../schema.zod.js';
+import { toSalesForceAccount } from '../mappers/toAccount';
+
+export default async function runAction(nango: NangoAction, input: UpsertAccountInput): Promise<SuccessResponse> {
+    const parsedInput = upsertAccountInputSchema.safeParse(input);
+
+    if (!parsedInput.success) {
+        for (const error of parsedInput.error.errors) {
+            await nango.log(`Invalid input provided to upsert an account: ${error.message} at path ${error.path.join('.')}`, { level: 'error' });
+        }
+        throw new nango.ActionError({
+            message: 'Invalid input provided to upsert an account'
+        });
+    }
+
+    await nango.log(parsedInput.data);
+    const salesforceAccount = toSalesForceAccount(parsedInput.data);
+
+    const config: ProxyConfiguration = {
+        // https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_account.htm
+        endpoint: `/services/data/v60.0/sobjects/Account/${parsedInput.data.field_name}/${parsedInput.data.field_value}`,
+        data: salesforceAccount,
+        retries: 10
+    };
+
+    await nango.patch(config);
+
+    return {
+        success: true
+    };
+}

--- a/integrations/salesforce/fixtures/upsert-account.json
+++ b/integrations/salesforce/fixtures/upsert-account.json
@@ -1,0 +1,13 @@
+{
+    "id": "001J6000005uLCHIA2",
+    "name": "Nango_test",
+    "description": "test description",
+    "website": "https://nango.dev",
+    "industry": "Software",
+    "billing_city": "San Francisco",
+    "billing_country": "USA",
+    "owner_id": "005J6000001B3C8IAK",
+    "owner_name": "Hassan Wari",
+    "field_name": "id",
+    "field_value": "001J6000005uLCHIA2"
+}

--- a/integrations/salesforce/mappers/toAccount.ts
+++ b/integrations/salesforce/mappers/toAccount.ts
@@ -1,4 +1,4 @@
-import type { Account, CreateAccountInput, UpdateAccountInput } from '../../models';
+import type { Account, CreateAccountInput, UpdateAccountInput, UpsertAccountInput } from '../../models';
 import type { SalesforceAccount } from '../types';
 
 export function toAccount(account: SalesforceAccount): Account {
@@ -16,7 +16,7 @@ export function toAccount(account: SalesforceAccount): Account {
     };
 }
 
-export function toSalesForceAccount(account: CreateAccountInput | UpdateAccountInput): Partial<SalesforceAccount> {
+export function toSalesForceAccount(account: CreateAccountInput | UpdateAccountInput | UpsertAccountInput): Partial<SalesforceAccount> {
     const salesforceAccount: Partial<SalesforceAccount> = {};
 
     if (account.name) {

--- a/integrations/salesforce/mocks/nango/patch/proxy/services/data/v60.0/sobjects/Account/id/001J6000005uLCHIA2/upsert-account.json
+++ b/integrations/salesforce/mocks/nango/patch/proxy/services/data/v60.0/sobjects/Account/id/001J6000005uLCHIA2/upsert-account.json
@@ -1,0 +1,6 @@
+{
+    "id": "001J6000005uLCHIA2",
+    "success": true,
+    "errors": [],
+    "created": false
+}

--- a/integrations/salesforce/mocks/upsert-account/input.json
+++ b/integrations/salesforce/mocks/upsert-account/input.json
@@ -1,0 +1,13 @@
+{
+    "id": "001J6000005uLCHIA2",
+    "name": "Nango_test",
+    "description": "test description",
+    "website": "https://nango.dev",
+    "industry": "Software",
+    "billing_city": "San Francisco",
+    "billing_country": "USA",
+    "owner_id": "005J6000001B3C8IAK",
+    "owner_name": "Hassan Wari",
+    "field_name": "id",
+    "field_value": "001J6000005uLCHIA2"
+}

--- a/integrations/salesforce/mocks/upsert-account/output.json
+++ b/integrations/salesforce/mocks/upsert-account/output.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/integrations/salesforce/nango.yaml
+++ b/integrations/salesforce/nango.yaml
@@ -84,6 +84,15 @@ integrations:
                 output: SuccessResponse
                 endpoint: PATCH /accounts
                 version: 1.0.0
+            upsert-account:
+                description: Upsert a single account in salesforce
+                scopes:
+                    - offline_access
+                    - api
+                input: UpsertAccountInput
+                output: ActionResponse
+                endpoint: PATCH /accounts/upsert
+                version: 1.0.0
             delete-account:
                 description: Delete a single account in salesforce
                 scopes:
@@ -285,6 +294,11 @@ models:
     UpdateAccountInput:
         __extends: CommonAccountInput, IdEntity
         name?: string | undefined
+    UpsertAccountInput:
+        __extends: CommonAccountInput
+        name?: string | undefined
+        field_name?: string | undefined
+        field_value?: string | undefined
     Opportunity:
         id: string
         opportunity_name: string

--- a/integrations/salesforce/schema.zod.ts
+++ b/integrations/salesforce/schema.zod.ts
@@ -172,6 +172,18 @@ export const updateAccountInputSchema = z.object({
     name: z.union([z.string(), z.undefined()]).optional()
 });
 
+export const upsertAccountInputSchema = z.object({
+    description: z.union([z.string(), z.undefined()]).optional(),
+    website: z.union([z.string(), z.undefined()]).optional(),
+    industry: z.union([z.string(), z.undefined()]).optional(),
+    billing_city: z.union([z.string(), z.undefined()]).optional(),
+    billing_country: z.union([z.string(), z.undefined()]).optional(),
+    owner_id: z.union([z.string(), z.undefined()]).optional(),
+    name: z.union([z.string(), z.undefined()]).optional(),
+    field_name: z.union([z.string(), z.undefined()]).optional(),
+    field_value: z.union([z.string(), z.undefined()]).optional()
+});
+
 export const opportunitySchema = z.object({
     id: z.string(),
     opportunity_name: z.string(),


### PR DESCRIPTION
## Describe your changes
Added upsert-account action to salesforce

## Issue ticket number and link
EXT-205
https://linear.app/nango/issue/EXT-205/upsert-an-account-in-salesforce


## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
