### PR TITLE
feat: Hosea/ext 207 upsert a contact in hubspot

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -3596,9 +3596,17 @@ integrations:
                     - oauth
             update-contact:
                 description: Updates a single contact in Hubspot
-                output: CreateUpdateContactOutput
+                output: SuccessResponse
                 endpoint: PATCH /contact
                 input: UpdateContactInput
+                scopes:
+                    - crm.objects.contacts.write
+                    - oauth
+            upsert-contact:
+                description: Upserts contacts in Hubspot
+                output: SuccessResponse
+                endpoint: POST /contact/batch-upsert
+                input: BatchUpsertContactInput
                 scopes:
                     - crm.objects.contacts.write
                     - oauth
@@ -3887,6 +3895,18 @@ integrations:
                 website_url?: string | undefined
                 owner?: string | undefined
                 id: string
+            UpsertContactInput:
+                properties: CreateContactInput
+                field_name: string
+                field_value: string
+            BatchUpsertContactInput:
+                inputs: UpsertContactInput[]
+            UpsertContactHubspot:
+                properties: CreateContactInput
+                id: string
+                idProperty: string
+            BatchUpsertContactHubspot:
+                inputs: UpsertContactHubspot[]
             Contact:
                 id: string
                 created_date: string

--- a/flows.yaml
+++ b/flows.yaml
@@ -3596,7 +3596,7 @@ integrations:
                     - oauth
             update-contact:
                 description: Updates a single contact in Hubspot
-                output: SuccessResponse
+                output: CreateUpdateContactOutput
                 endpoint: PATCH /contact
                 input: UpdateContactInput
                 scopes:

--- a/integrations/hubspot/actions/upsert-contact.ts
+++ b/integrations/hubspot/actions/upsert-contact.ts
@@ -1,11 +1,9 @@
 import type { NangoAction, SuccessResponse, BatchUpsertContactInput, ProxyConfiguration } from '../../models';
-import { toBatchUpsertContact } from '../mappers/toContact';
+import { toBatchUpsertContact } from '../mappers/toContact.js';
 import { batchUpsertContactInputSchema } from '../schema.zod.js';
-
 
 export default async function runAction(nango: NangoAction, input: BatchUpsertContactInput): Promise<SuccessResponse> {
     const parsedInput = batchUpsertContactInputSchema.safeParse(input);
-
 
     if (!parsedInput.success) {
         for (const error of parsedInput.error.errors) {
@@ -16,20 +14,20 @@ export default async function runAction(nango: NangoAction, input: BatchUpsertCo
         });
     }
 
-    const hubSpotContactUpsert = toBatchUpsertContact(parsedInput.data as BatchUpsertContactInput);    
-    
+    const hubSpotContactUpsert = toBatchUpsertContact(parsedInput.data as BatchUpsertContactInput);
+
     // https://developers.hubspot.com/beta-docs/guides/api/crm/objects/contacts?uuid=0e730bc9-9531-4ef3-b417-e8b86d262203#upsert-contacts
-    const endpoint = 'crm/v3/objects/contacts/batch/upsert'
+    const endpoint = 'crm/v3/objects/contacts/batch/upsert';
 
     const config: ProxyConfiguration = {
         endpoint,
         data: hubSpotContactUpsert,
         retries: 10
     };
-    
+
     await nango.post(config);
 
     return {
         success: true
-    }
-}   
+    };
+}

--- a/integrations/hubspot/actions/upsert-contact.ts
+++ b/integrations/hubspot/actions/upsert-contact.ts
@@ -1,0 +1,35 @@
+import type { NangoAction, SuccessResponse, BatchUpsertContactInput, ProxyConfiguration } from '../../models';
+import { toBatchUpsertContact } from '../mappers/toContact';
+import { batchUpsertContactInputSchema } from '../schema.zod.js';
+
+
+export default async function runAction(nango: NangoAction, input: BatchUpsertContactInput): Promise<SuccessResponse> {
+    const parsedInput = batchUpsertContactInputSchema.safeParse(input);
+
+
+    if (!parsedInput.success) {
+        for (const error of parsedInput.error.errors) {
+            await nango.log(`Invalid input provided to upsert a contact: ${error.message} at path ${error.path.join('.')}`, { level: 'error' });
+        }
+        throw new nango.ActionError({
+            message: 'Invalid input provided to upsert a contact'
+        });
+    }
+
+    const hubSpotContactUpsert = toBatchUpsertContact(parsedInput.data as BatchUpsertContactInput);    
+    
+    // https://developers.hubspot.com/beta-docs/guides/api/crm/objects/contacts?uuid=0e730bc9-9531-4ef3-b417-e8b86d262203#upsert-contacts
+    const endpoint = 'crm/v3/objects/contacts/batch/upsert'
+
+    const config: ProxyConfiguration = {
+        endpoint,
+        data: hubSpotContactUpsert,
+        retries: 10
+    };
+    
+    await nango.post(config);
+
+    return {
+        success: true
+    }
+}   

--- a/integrations/hubspot/fixtures/upsert-contact.json
+++ b/integrations/hubspot/fixtures/upsert-contact.json
@@ -1,0 +1,18 @@
+{
+    "inputs": [
+        {
+            "properties": {
+                "phone": "5555555555"
+            },
+            "field_name": "email",
+            "field_value": "test@test.com"
+        },
+        {
+            "properties": {
+                "phone": "7777777777"
+            },
+            "field_name": "email",
+            "field_value": "example@hubspot.com"
+        }
+    ]
+}

--- a/integrations/hubspot/mappers/toContact.ts
+++ b/integrations/hubspot/mappers/toContact.ts
@@ -1,4 +1,11 @@
-import type { Contact, CreateContactInput, UpdateContactInput, CreateUpdateContactOutput, BatchUpsertContactHubspot, BatchUpsertContactInput } from '../../models';
+import type {
+    Contact,
+    CreateContactInput,
+    UpdateContactInput,
+    CreateUpdateContactOutput,
+    BatchUpsertContactHubspot,
+    BatchUpsertContactInput
+} from '../../models';
 import type { HubSpotContact, HubSpotContactNonUndefined, HubSpotContactNonNull } from '../types';
 
 export function toContact(contact: HubSpotContactNonUndefined): Contact {
@@ -97,6 +104,6 @@ export function toBatchUpsertContact(contacts: BatchUpsertContactInput): Partial
             };
         })
     };
-    
+
     return hubSpotContactUpsert;
 }

--- a/integrations/hubspot/mappers/toContact.ts
+++ b/integrations/hubspot/mappers/toContact.ts
@@ -1,4 +1,4 @@
-import type { Contact, CreateContactInput, UpdateContactInput, CreateUpdateContactOutput } from '../../models';
+import type { Contact, CreateContactInput, UpdateContactInput, CreateUpdateContactOutput, BatchUpsertContactHubspot, BatchUpsertContactInput } from '../../models';
 import type { HubSpotContact, HubSpotContactNonUndefined, HubSpotContactNonNull } from '../types';
 
 export function toContact(contact: HubSpotContactNonUndefined): Contact {
@@ -85,4 +85,18 @@ export function toHubspotContact(contact: CreateContactInput | UpdateContactInpu
     }
 
     return hubSpotContact;
+}
+
+export function toBatchUpsertContact(contacts: BatchUpsertContactInput): Partial<BatchUpsertContactHubspot> {
+    const hubSpotContactUpsert: Partial<BatchUpsertContactHubspot> = {
+        inputs: contacts.inputs.map((contact) => {
+            return {
+                properties: contact.properties,
+                id: contact.field_value,
+                idProperty: contact.field_name
+            };
+        })
+    };
+    
+    return hubSpotContactUpsert;
 }

--- a/integrations/hubspot/mocks/nango/post/proxy/crm/v3/objects/contacts/batch/upsert/upsert-contact.json
+++ b/integrations/hubspot/mocks/nango/post/proxy/crm/v3/objects/contacts/batch/upsert/upsert-contact.json
@@ -1,0 +1,6 @@
+{
+    "status": "COMPLETE",
+    "results": [],
+    "startedAt": "2024-11-01T10:36:31.602Z",
+    "completedAt": "2024-11-01T10:36:31.641Z"
+}

--- a/integrations/hubspot/mocks/upsert-contact/input.json
+++ b/integrations/hubspot/mocks/upsert-contact/input.json
@@ -1,0 +1,18 @@
+{
+    "inputs": [
+        {
+            "properties": {
+                "phone": "5555555555"
+            },
+            "field_name": "email",
+            "field_value": "test@test.com"
+        },
+        {
+            "properties": {
+                "phone": "7777777777"
+            },
+            "field_name": "email",
+            "field_value": "example@hubspot.com"
+        }
+    ]
+}

--- a/integrations/hubspot/mocks/upsert-contact/output.json
+++ b/integrations/hubspot/mocks/upsert-contact/output.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/integrations/hubspot/nango.yaml
+++ b/integrations/hubspot/nango.yaml
@@ -218,9 +218,17 @@ integrations:
                     - oauth
             update-contact:
                 description: Updates a single contact in Hubspot
-                output: CreateUpdateContactOutput
+                output: SuccessResponse
                 endpoint: PATCH /contact
                 input: UpdateContactInput
+                scopes:
+                    - crm.objects.contacts.write
+                    - oauth
+            upsert-contact:
+                description: Upserts contacts in Hubspot
+                output: SuccessResponse
+                endpoint: POST /contact/batch-upsert
+                input: BatchUpsertContactInput
                 scopes:
                     - crm.objects.contacts.write
                     - oauth
@@ -502,6 +510,18 @@ models:
     UpdateContactInput:
         __extends: CreateContactInput
         id: string
+    UpsertContactInput:
+        properties: CreateContactInput
+        field_name: string
+        field_value: string
+    BatchUpsertContactInput:
+        inputs: UpsertContactInput[]
+    UpsertContactHubspot:
+        properties: CreateContactInput
+        id: string
+        idProperty: string
+    BatchUpsertContactHubspot:
+        inputs: UpsertContactHubspot[]
     Contact:
         id: string
         created_date: string

--- a/integrations/hubspot/nango.yaml
+++ b/integrations/hubspot/nango.yaml
@@ -218,7 +218,7 @@ integrations:
                     - oauth
             update-contact:
                 description: Updates a single contact in Hubspot
-                output: SuccessResponse
+                output: CreateUpdateContactOutput
                 endpoint: PATCH /contact
                 input: UpdateContactInput
                 scopes:

--- a/integrations/hubspot/schema.zod.ts
+++ b/integrations/hubspot/schema.zod.ts
@@ -274,6 +274,26 @@ export const updateContactInputSchema = z.object({
     id: z.string()
 });
 
+export const upsertContactInputSchema = z.object({
+    properties: createContactInputSchema,
+    field_name: z.string(),
+    field_value: z.string()
+});
+
+export const batchUpsertContactInputSchema = z.object({
+    inputs: z.array(upsertContactInputSchema)
+});
+
+export const upsertContactHubspotSchema = z.object({
+    properties: createContactInputSchema,
+    id: z.string(),
+    idProperty: z.string()
+});
+
+export const batchUpsertContactHubspotSchema = z.object({
+    inputs: z.array(upsertContactHubspotSchema)
+});
+
 export const contactSchema = z.object({
     id: z.string(),
     created_date: z.string(),

--- a/integrations/hubspot/tests/hubspot-upsert-contact.test.ts
+++ b/integrations/hubspot/tests/hubspot-upsert-contact.test.ts
@@ -1,11 +1,11 @@
 import { vi, expect, it, describe } from "vitest";
 
-import runAction from "../actions/update-contact.js";
+import runAction from "../actions/upsert-contact.js";
 
-describe("hubspot update-contact tests", () => {
+describe("hubspot upsert-contact tests", () => {
   const nangoMock = new global.vitest.NangoActionMock({ 
       dirname: __dirname,
-      name: "update-contact",
+      name: "upsert-contact",
       Model: "SuccessResponse"
   });
 


### PR DESCRIPTION
## Describe your changes
Added an upsert contact feature for hubspot

## Issue ticket number and link
EXT-207
https://linear.app/nango/issue/EXT-207/upsert-a-contact-in-hubspot

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
