### PR TITLE
fix(harvest): incremental sync for harvest users

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -3365,8 +3365,6 @@ integrations:
                 description: |
                     Fetches the list of users in Harvest
                 endpoint: GET /users
-                sync_type: full
-                track_deletes: true
                 runs: every day
                 output: User
                 scopes:

--- a/integrations/harvest/nango.yaml
+++ b/integrations/harvest/nango.yaml
@@ -5,8 +5,6 @@ integrations:
                 description: |
                     Fetches the list of users in Harvest
                 endpoint: GET /users
-                sync_type: full
-                track_deletes: true
                 runs: every day
                 output: User
                 scopes:

--- a/integrations/harvest/syncs/users.ts
+++ b/integrations/harvest/syncs/users.ts
@@ -19,9 +19,6 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
     const config: ProxyConfiguration = {
         // https://help.getharvest.com/api-v2/users-api/users/users/#list-all-users
         endpoint: '/v2/users',
-        params: {
-            is_active: 'true'
-        },
         paginate: {
             type: 'link',
             response_path: 'users',
@@ -29,6 +26,16 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
         },
         retries: 10
     };
+
+    const params: Record<string, string> = {
+        is_active: 'true'
+    };
+
+    if (nango.lastSyncDate) {
+        params['updated_since'] = nango.lastSyncDate.toISOString();
+    }
+
+    config.params = params;
 
     for await (const harvestUsers of nango.paginate<HarvestUser>(config)) {
         const users = harvestUsers.map(toUser);


### PR DESCRIPTION
## Describe your changes
Harvest has an `updated_since` param

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
- [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
