### PR TITLE
fix(outlook): fix sender property

### DIFF
--- a/integrations/outlook/syncs/emails.ts
+++ b/integrations/outlook/syncs/emails.ts
@@ -45,7 +45,7 @@ export default async function fetchData(nango: NangoSync) {
 
 function extractHeaders(message: OutlookMessage): Record<string, any> {
     return {
-        From: message.from?.address,
+        From: message.from?.emailAddress.address,
         To: message.toRecipients?.map((recipient) => recipient.emailAddress.address).join(', '),
         Subject: message.subject
     };

--- a/integrations/outlook/types.ts
+++ b/integrations/outlook/types.ts
@@ -1,6 +1,6 @@
 export interface OutlookMessage {
     id: string;
-    from: EmailAddress;
+    from: Recipient;
     toRecipients: Recipient[];
     receivedDateTime: string;
     subject: string;

--- a/scripts/run-integration-template.bash
+++ b/scripts/run-integration-template.bash
@@ -14,7 +14,7 @@ fi
 
 TEMP_DIRECTORY=tmp-run-integration-template
 
-NANGO_HOSTPORT_DEFAULT=http://localhost:3003
+NANGO_HOSTPORT_DEFAULT=https://api.nango.dev
 
 ITERATIONS=1
 INPUT_JSON=""


### PR DESCRIPTION
## Describe your changes
Sender was trying to be accessed at the incorrect key

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
- [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
