### PR TITLE
fix(groups): backfill quickbooks sandbox

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -7163,6 +7163,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /customers
+                    group: Customers
             accounts:
                 description: >
                     Fetches all accounts in QuickBooks. Handles both active and archived
@@ -7174,6 +7175,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /accounts
+                    group: Accounts
             payments:
                 description: >
                     Fetches all payments in QuickBooks. Handles both active and voided
@@ -7185,6 +7187,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /payments
+                    group: Payments
             items:
                 description: >
                     Fetches all items in QuickBooks. Handles both active and archived
@@ -7196,6 +7199,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /items
+                    group: Items
             invoices:
                 description: >
                     Fetches all invoices in QuickBooks. Handles both active and voided
@@ -7207,6 +7211,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /invoices
+                    group: Invoices
         actions:
             create-customer:
                 description: |
@@ -7217,6 +7222,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /customers
+                    group: Customers
             update-customer:
                 description: |
                     Update a single customer in QuickBooks.
@@ -7226,6 +7232,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /customers
+                    group: Customers
             create-item:
                 description: |
                     Creates a single item in QuickBooks.
@@ -7235,6 +7242,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /items
+                    group: Items
             update-item:
                 description: |
                     Update a single item in QuickBooks.
@@ -7244,6 +7252,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /items
+                    group: Items
             create-account:
                 description: |
                     Creates a single account in QuickBooks.
@@ -7253,6 +7262,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /accounts
+                    group: Accounts
             update-account:
                 description: |
                     Updates a single account in QuickBooks.
@@ -7262,6 +7272,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /accounts
+                    group: Accounts
             create-invoice:
                 description: |
                     Creates a single invoice in QuickBooks.
@@ -7271,6 +7282,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /invoices
+                    group: Invoices
             update-invoice:
                 description: |
                     Updates a single invoice in QuickBooks.
@@ -7280,6 +7292,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /invoices
+                    group: Invoices
             create-credit-memo:
                 description: |
                     Creates a single credit memo in QuickBooks.
@@ -7289,6 +7302,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /credit-memos
+                    group: Credit Memos
             update-credit-memo:
                 description: |
                     Updates a single credit memo in QuickBooks.
@@ -7298,6 +7312,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /credit-memos
+                    group: Credit Memos
             create-payment:
                 description: |
                     Creates a single payment in QuickBooks.
@@ -7307,6 +7322,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /payments
+                    group: Payments
         models:
             Updates:
                 id: string

--- a/integrations/quickbooks-sandbox/nango.yaml
+++ b/integrations/quickbooks-sandbox/nango.yaml
@@ -11,6 +11,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /customers
+                    group: Customers
             accounts:
                 description: |
                     Fetches all accounts in QuickBooks. Handles both active and archived accounts, saving or deleting them based on their status.
@@ -21,6 +22,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /accounts
+                    group: Accounts
             payments:
                 description: |
                     Fetches all payments in QuickBooks. Handles both active and voided payments, saving or deleting them based on their status.
@@ -31,6 +33,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /payments
+                    group: Payments
             items:
                 description: |
                     Fetches all items in QuickBooks. Handles both active and archived items, saving or deleting them based on their status.
@@ -41,6 +44,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /items
+                    group: Items
             invoices:
                 description: |
                     Fetches all invoices in QuickBooks. Handles both active and voided invoices, saving or deleting them based on their status.
@@ -51,6 +55,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /invoices
+                    group: Invoices
         actions:
             create-customer:
                 description: |
@@ -61,6 +66,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /customers
+                    group: Customers
             update-customer:
                 description: |
                     Update a single customer in QuickBooks.
@@ -70,6 +76,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /customers
+                    group: Customers
             create-item:
                 description: |
                     Creates a single item in QuickBooks.
@@ -79,6 +86,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /items
+                    group: Items
             update-item:
                 description: |
                     Update a single item in QuickBooks.
@@ -88,6 +96,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /items
+                    group: Items
             create-account:
                 description: |
                     Creates a single account in QuickBooks.
@@ -97,6 +106,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /accounts
+                    group: Accounts
             update-account:
                 description: |
                     Updates a single account in QuickBooks.
@@ -106,6 +116,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /accounts
+                    group: Accounts
             create-invoice:
                 description: |
                     Creates a single invoice in QuickBooks.
@@ -115,6 +126,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /invoices
+                    group: Invoices
             update-invoice:
                 description: |
                     Updates a single invoice in QuickBooks.
@@ -124,6 +136,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /invoices
+                    group: Invoices
             create-credit-memo:
                 description: |
                     Creates a single credit memo in QuickBooks.
@@ -133,6 +146,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /credit-memos
+                    group: Credit Memos
             update-credit-memo:
                 description: |
                     Updates a single credit memo in QuickBooks.
@@ -142,6 +156,7 @@ integrations:
                 endpoint:
                     method: PUT
                     path: /credit-memos
+                    group: Credit Memos
             create-payment:
                 description: |
                     Creates a single payment in QuickBooks.
@@ -151,6 +166,7 @@ integrations:
                 endpoint:
                     method: POST
                     path: /payments
+                    group: Payments
 
 models:
     Updates:


### PR DESCRIPTION
## Describe your changes
Backfill quickbooks sandbox

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
- [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
