### PR TITLE
fix(docs): fix zoom endpoint

### DIFF
--- a/integrations/zoom/syncs/meetings.ts
+++ b/integrations/zoom/syncs/meetings.ts
@@ -3,7 +3,7 @@ import type { ZoomMeeting } from '../types';
 
 export default async function fetchData(nango: NangoSync) {
     const config: ProxyConfiguration = {
-        // https://developers.zoom.us/docs/api/meetings/#tag/meetings/GET/users/{userId}/meeting_templates
+        // https://developers.zoom.us/docs/api/meetings/#tag/meetings/GET/users/{userId}/meetings
         endpoint: '/users/me/meetings',
         retries: 10,
         paginate: {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [ ] I added tests, otherwise the reason is:
- [ ] External API requests have `retries`
- [ ] Pagination is used where appropriate
- [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
- [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
- [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
- [ ] If the sync is a `full` sync then `track_deletes: true` is set
- [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
