### PR TITLE
fix(netsuite): header access

### DIFF
--- a/integrations/netsuite-tba/actions/credit-note-create.ts
+++ b/integrations/netsuite-tba/actions/credit-note-create.ts
@@ -34,7 +34,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteCredi
         data: body,
         retries: 10
     });
-    const id = res.headers.location?.split('/').pop();
+    const id = res.headers['location']?.split('/').pop();
     if (!id) {
         throw new nango.ActionError({
             message: "Error creating credit note: could not parse 'id' from Netsuite API response"

--- a/integrations/netsuite-tba/actions/customer-create.ts
+++ b/integrations/netsuite-tba/actions/customer-create.ts
@@ -52,7 +52,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteCusto
         data: body,
         retries: 10
     });
-    const id = res.headers.location?.split('/').pop();
+    const id = res.headers['location']?.split('/').pop();
     if (!id) {
         throw new nango.ActionError({
             message: "Error creating customer: could not parse 'id' from Netsuite API response"

--- a/integrations/netsuite-tba/actions/invoice-create.ts
+++ b/integrations/netsuite-tba/actions/invoice-create.ts
@@ -35,7 +35,7 @@ export default async function runAction(nango: NangoAction, input: NetsuiteInvoi
         data: body,
         retries: 10
     });
-    const id = res.headers.location?.split('/').pop();
+    const id = res.headers['location']?.split('/').pop();
     if (!id) {
         throw new nango.ActionError({
             message: "Error creating invoice: could not parse 'id' from Netsuite API response"

--- a/integrations/netsuite-tba/actions/payment-create.ts
+++ b/integrations/netsuite-tba/actions/payment-create.ts
@@ -30,7 +30,7 @@ export default async function runAction(nango: NangoAction, input: NetsuitePayme
     });
 
     // Extract payment ID from response
-    const id = res.headers.location?.split('/').pop();
+    const id = res.headers['location']?.split('/').pop();
     if (!id) {
         throw new nango.ActionError({
             message: "Error creating payment: could not parse 'id' from Netsuite API response"


### PR DESCRIPTION
## Describe your changes
Use different notation to access

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
