### PR TITLE
fix(lever): more cleanup of endpoints

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -5751,7 +5751,7 @@ integrations:
         actions:
             create-note:
                 description: |
-                    Action to create a note and add it to a candidate profile in Lever
+                    Action to create a note and add it to an opportunity.
                 output: LeverOpportunityNote
                 input: LeverCreateNoteInput
                 endpoint:
@@ -5762,8 +5762,9 @@ integrations:
                     - notes:write:admin
                 version: 1.0.0
             create-opportunity:
-                description: |
-                    Action to create candidates and opportunities in Lever
+                description: >
+                    Create an opportunity and optionally candidates associated with the
+                    opportunity
                 output: LeverOpportunity
                 input: LeverCreateOpportunityInput
                 endpoint:
@@ -5864,7 +5865,7 @@ integrations:
                 version: 1.0.0
             update-opportunity-archived:
                 description: |
-                    Update the tags in an opportunity
+                    Update the archived state of an opportunity
                 output: SuccessResponse
                 input: ArchiveOpportunity
                 endpoint:
@@ -5888,14 +5889,14 @@ integrations:
                 output: ReturnObjUpdateOpportunity
                 input: UpdateOpportunity
                 endpoint:
-                    method: POST
-                    path: /opportunity/update
+                    method: PATCH
+                    path: /opportunities
                     group: Opportunities
         syncs:
             opportunities:
                 runs: every 6 hours
                 description: |
-                    Fetches a list of all pipeline opportunities for contacts in Lever
+                    Fetches al opportunities
                 output: LeverOpportunity
                 sync_type: incremental
                 endpoint:
@@ -5938,7 +5939,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/interviewers
+                    path: /opportunities/interviews
                     group: Opportunities
                 scopes:
                     - interviews:read:admin
@@ -5951,7 +5952,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities-notes
+                    path: /notes
                     group: Notes
                 scopes:
                     - notes:read:admin
@@ -5964,7 +5965,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/offers
+                    path: /offers
                     group: Offers
                 scopes:
                     - offers:write:admin
@@ -6387,7 +6388,7 @@ integrations:
         actions:
             create-note:
                 description: |
-                    Action to create a note and add it to a candidate profile in Lever
+                    Action to create a note and add it to an opportunity.
                 output: LeverOpportunityNote
                 input: LeverCreateNoteInput
                 endpoint:
@@ -6398,8 +6399,9 @@ integrations:
                     - notes:write:admin
                 version: 1.0.0
             create-opportunity:
-                description: |
-                    Action to create candidates and opportunities in Lever
+                description: >
+                    Create an opportunity and optionally candidates associated with the
+                    opportunity
                 output: LeverOpportunity
                 input: LeverCreateOpportunityInput
                 endpoint:
@@ -6500,7 +6502,7 @@ integrations:
                 version: 1.0.0
             update-opportunity-archived:
                 description: |
-                    Update the tags in an opportunity
+                    Update the archived state of an opportunity
                 output: SuccessResponse
                 input: ArchiveOpportunity
                 endpoint:
@@ -6524,14 +6526,14 @@ integrations:
                 output: ReturnObjUpdateOpportunity
                 input: UpdateOpportunity
                 endpoint:
-                    method: POST
-                    path: /opportunity/update
+                    method: PATCH
+                    path: /opportunities
                     group: Opportunities
         syncs:
             opportunities:
                 runs: every 6 hours
                 description: |
-                    Fetches a list of all pipeline opportunities for contacts in Lever
+                    Fetches al opportunities
                 output: LeverOpportunity
                 sync_type: incremental
                 endpoint:
@@ -6574,7 +6576,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/interviewers
+                    path: /opportunities/interviews
                     group: Opportunities
                 scopes:
                     - interviews:read:admin
@@ -6587,7 +6589,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities-notes
+                    path: /notes
                     group: Notes
                 scopes:
                     - notes:read:admin
@@ -6600,7 +6602,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/offers
+                    path: /offers
                     group: Offers
                 scopes:
                     - offers:write:admin
@@ -7023,7 +7025,7 @@ integrations:
         actions:
             create-note:
                 description: |
-                    Action to create a note and add it to a candidate profile in Lever
+                    Action to create a note and add it to an opportunity.
                 output: LeverOpportunityNote
                 input: LeverCreateNoteInput
                 endpoint:
@@ -7034,8 +7036,9 @@ integrations:
                     - notes:write:admin
                 version: 1.0.0
             create-opportunity:
-                description: |
-                    Action to create candidates and opportunities in Lever
+                description: >
+                    Create an opportunity and optionally candidates associated with the
+                    opportunity
                 output: LeverOpportunity
                 input: LeverCreateOpportunityInput
                 endpoint:
@@ -7136,7 +7139,7 @@ integrations:
                 version: 1.0.0
             update-opportunity-archived:
                 description: |
-                    Update the tags in an opportunity
+                    Update the archived state of an opportunity
                 output: SuccessResponse
                 input: ArchiveOpportunity
                 endpoint:
@@ -7160,14 +7163,14 @@ integrations:
                 output: ReturnObjUpdateOpportunity
                 input: UpdateOpportunity
                 endpoint:
-                    method: POST
-                    path: /opportunity/update
+                    method: PATCH
+                    path: /opportunities
                     group: Opportunities
         syncs:
             opportunities:
                 runs: every 6 hours
                 description: |
-                    Fetches a list of all pipeline opportunities for contacts in Lever
+                    Fetches al opportunities
                 output: LeverOpportunity
                 sync_type: incremental
                 endpoint:
@@ -7210,7 +7213,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/interviewers
+                    path: /opportunities/interviews
                     group: Opportunities
                 scopes:
                     - interviews:read:admin
@@ -7223,7 +7226,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities-notes
+                    path: /notes
                     group: Notes
                 scopes:
                     - notes:read:admin
@@ -7236,7 +7239,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/offers
+                    path: /offers
                     group: Offers
                 scopes:
                     - offers:write:admin
@@ -7659,7 +7662,7 @@ integrations:
         actions:
             create-note:
                 description: |
-                    Action to create a note and add it to a candidate profile in Lever
+                    Action to create a note and add it to an opportunity.
                 output: LeverOpportunityNote
                 input: LeverCreateNoteInput
                 endpoint:
@@ -7670,8 +7673,9 @@ integrations:
                     - notes:write:admin
                 version: 1.0.0
             create-opportunity:
-                description: |
-                    Action to create candidates and opportunities in Lever
+                description: >
+                    Create an opportunity and optionally candidates associated with the
+                    opportunity
                 output: LeverOpportunity
                 input: LeverCreateOpportunityInput
                 endpoint:
@@ -7772,7 +7776,7 @@ integrations:
                 version: 1.0.0
             update-opportunity-archived:
                 description: |
-                    Update the tags in an opportunity
+                    Update the archived state of an opportunity
                 output: SuccessResponse
                 input: ArchiveOpportunity
                 endpoint:
@@ -7796,14 +7800,14 @@ integrations:
                 output: ReturnObjUpdateOpportunity
                 input: UpdateOpportunity
                 endpoint:
-                    method: POST
-                    path: /opportunity/update
+                    method: PATCH
+                    path: /opportunities
                     group: Opportunities
         syncs:
             opportunities:
                 runs: every 6 hours
                 description: |
-                    Fetches a list of all pipeline opportunities for contacts in Lever
+                    Fetches al opportunities
                 output: LeverOpportunity
                 sync_type: incremental
                 endpoint:
@@ -7846,7 +7850,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/interviewers
+                    path: /opportunities/interviews
                     group: Opportunities
                 scopes:
                     - interviews:read:admin
@@ -7859,7 +7863,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities-notes
+                    path: /notes
                     group: Notes
                 scopes:
                     - notes:read:admin
@@ -7872,7 +7876,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/offers
+                    path: /offers
                     group: Offers
                 scopes:
                     - offers:write:admin

--- a/integrations/lever/actions/create-opportunity.ts
+++ b/integrations/lever/actions/create-opportunity.ts
@@ -27,7 +27,7 @@ export default async function runAction(nango: NangoAction, input: LeverCreateOp
     };
 
     const config: ProxyConfiguration = {
-        // https://hire.lever.co/developer/documentation#update-opportunity-stage
+        // https://hire.lever.co/developer/documentation#create-an-opportunity
         endpoint: `/v1/opportunities`,
         data: postData,
         retries: 10

--- a/integrations/lever/nango.yaml
+++ b/integrations/lever/nango.yaml
@@ -6,7 +6,7 @@ integrations:
         actions:
             create-note:
                 description: |
-                    Action to create a note and add it to a candidate profile in Lever
+                    Action to create a note and add it to an opportunity.
                 output: LeverOpportunityNote
                 input: LeverCreateNoteInput
                 endpoint:
@@ -18,7 +18,7 @@ integrations:
                 version: 1.0.0
             create-opportunity:
                 description: |
-                    Action to create candidates and opportunities in Lever
+                    Create an opportunity and optionally candidates associated with the opportunity
                 output: LeverOpportunity
                 input: LeverCreateOpportunityInput
                 endpoint:
@@ -118,7 +118,7 @@ integrations:
                 version: 1.0.0
             update-opportunity-archived:
                 description: |
-                    Update the tags in an opportunity
+                    Update the archived state of an opportunity
                 output: SuccessResponse
                 input: ArchiveOpportunity
                 endpoint:
@@ -141,15 +141,15 @@ integrations:
                 output: ReturnObjUpdateOpportunity
                 input: UpdateOpportunity
                 endpoint:
-                    method: POST
-                    path: /opportunity/update
+                    method: PATCH
+                    path: /opportunities
                     group: Opportunities
 
         syncs:
             opportunities:
                 runs: every 6 hours
                 description: |
-                    Fetches a list of all pipeline opportunities for contacts in Lever
+                    Fetches al opportunities
                 output: LeverOpportunity
                 sync_type: incremental
                 endpoint:
@@ -191,7 +191,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/interviewers
+                    path: /opportunities/interviews
                     group: Opportunities
                 scopes:
                     - interviews:read:admin
@@ -204,7 +204,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities-notes
+                    path: /notes
                     group: Notes
                 scopes:
                     - notes:read:admin
@@ -217,7 +217,7 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /opportunities/offers
+                    path: /offers
                     group: Offers
                 scopes:
                     - offers:write:admin


### PR DESCRIPTION
## Describe your changes
Endpoint cleanup

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
