### PR TITLE
fix(front): add cursor in request param for pagination

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -3456,6 +3456,7 @@ integrations:
                     path: /conversations
                 track_deletes: true
                 sync_type: full
+                version: 1.0.1
         actions:
             conversation:
                 description: >-

--- a/integrations/front/nango.yaml
+++ b/integrations/front/nango.yaml
@@ -10,6 +10,7 @@ integrations:
                     path: /conversations
                 track_deletes: true
                 sync_type: full
+                version: 1.0.1
         actions:
             conversation:
                 description: List the messages in a conversation in reverse chronological order (newest first).

--- a/integrations/front/syncs/list-conversations.ts
+++ b/integrations/front/syncs/list-conversations.ts
@@ -11,6 +11,7 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
             cursor_path_in_response: '_pagination.next',
             limit_name_in_request: 'limit',
             response_path: '_results',
+            cursor_name_in_request: 'page_token',
             limit: 100
         },
         retries: 10


### PR DESCRIPTION
## Describe your changes

- Small fix to Front's `list-conversations` pagination

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
