### PR TITLE
fix(xero): bump versions

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -13479,7 +13479,7 @@ integrations:
                     method: GET
                     path: /contacts
                     group: Contacts
-                version: 1.0.1
+                version: 1.0.2
             accounts:
                 description: >
                     Fetches all accounts in Xero (chart of accounts). Incremental sync,
@@ -13492,7 +13492,7 @@ integrations:
                     method: GET
                     path: /accounts
                     group: Accounts
-                version: 1.0.1
+                version: 1.0.2
             items:
                 description: >
                     Fetches all items in Xero. Incremental sync, does not detect deletes,
@@ -13507,7 +13507,7 @@ integrations:
                     method: GET
                     path: /items
                     group: Items
-                version: 1.0.1
+                version: 1.0.2
             invoices:
                 description: |
                     Fetches all invoices in Xero. Incremental sync.
@@ -13519,7 +13519,7 @@ integrations:
                     method: GET
                     path: /invoices
                     group: Invoices
-                version: 1.0.1
+                version: 1.0.2
             payments:
                 description: |
                     Fetches all payments in Xero. Incremental sync.
@@ -13531,7 +13531,7 @@ integrations:
                     method: GET
                     path: /payments
                     group: Payments
-                version: 1.0.1
+                version: 1.0.2
         actions:
             create-contact:
                 description: |
@@ -13544,7 +13544,7 @@ integrations:
                     method: POST
                     path: /contacts
                     group: Contacts
-                version: 1.0.1
+                version: 1.0.2
             update-contact:
                 description: >
                     Updates one or multiple contacts in Xero. Only fields that are passed
@@ -13557,7 +13557,7 @@ integrations:
                     method: PUT
                     path: /contacts
                     group: Contacts
-                version: 1.0.1
+                version: 1.0.2
             create-invoice:
                 description: |
                     Creates one or more invoices in Xero.
@@ -13569,7 +13569,7 @@ integrations:
                     method: POST
                     path: /invoices
                     group: Invoices
-                version: 1.0.2
+                version: 1.0.3
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -13583,7 +13583,7 @@ integrations:
                     method: PUT
                     path: /invoices
                     group: Invoices
-                version: 1.0.2
+                version: 1.0.3
             create-credit-note:
                 description: |
                     Creates one or more credit notes in Xero.
@@ -13595,7 +13595,7 @@ integrations:
                     method: POST
                     path: /credit-notes
                     group: Credit Notes
-                version: 1.0.2
+                version: 1.0.3
             update-credit-note:
                 description: |
                     Updates one or more credit notes in Xero.
@@ -13606,7 +13606,7 @@ integrations:
                     method: PUT
                     path: /credit-notes
                     group: Credit Notes
-                version: 1.0.2
+                version: 1.0.3
             create-payment:
                 description: |
                     Creates one or more payments in Xero.
@@ -13618,7 +13618,7 @@ integrations:
                     method: POST
                     path: /payments
                     group: Payments
-                version: 1.0.1
+                version: 1.0.2
             create-item:
                 description: |
                     Creates one or more items in Xero.
@@ -13630,7 +13630,7 @@ integrations:
                     method: POST
                     path: /items
                     group: Items
-                version: 1.0.1
+                version: 1.0.2
             get-tenants:
                 description: |
                     Fetches all the tenants the connection has access to.
@@ -13650,7 +13650,7 @@ integrations:
                     method: PUT
                     path: /items
                     group: Items
-                version: 1.0.1
+                version: 1.0.2
         models:
             ActionErrorResponse:
                 message: string

--- a/integrations/xero/nango.yaml
+++ b/integrations/xero/nango.yaml
@@ -12,7 +12,7 @@ integrations:
                     method: GET
                     path: /contacts
                     group: Contacts
-                version: 1.0.1
+                version: 1.0.2
             accounts:
                 description: |
                     Fetches all accounts in Xero (chart of accounts). Incremental sync, detects deletes, metadata is not required.
@@ -24,7 +24,7 @@ integrations:
                     method: GET
                     path: /accounts
                     group: Accounts
-                version: 1.0.1
+                version: 1.0.2
             items:
                 description: |
                     Fetches all items in Xero. Incremental sync, does not detect deletes, metadata is not
@@ -37,7 +37,7 @@ integrations:
                     method: GET
                     path: /items
                     group: Items
-                version: 1.0.1
+                version: 1.0.2
             invoices:
                 description: |
                     Fetches all invoices in Xero. Incremental sync.
@@ -49,7 +49,7 @@ integrations:
                     method: GET
                     path: /invoices
                     group: Invoices
-                version: 1.0.1
+                version: 1.0.2
             payments:
                 description: |
                     Fetches all payments in Xero. Incremental sync.
@@ -61,7 +61,7 @@ integrations:
                     method: GET
                     path: /payments
                     group: Payments
-                version: 1.0.1
+                version: 1.0.2
         actions:
             create-contact:
                 description: |
@@ -74,7 +74,7 @@ integrations:
                     method: POST
                     path: /contacts
                     group: Contacts
-                version: 1.0.1
+                version: 1.0.2
             update-contact:
                 description: >
                     Updates one or multiple contacts in Xero.
@@ -88,7 +88,7 @@ integrations:
                     method: PUT
                     path: /contacts
                     group: Contacts
-                version: 1.0.1
+                version: 1.0.2
             create-invoice:
                 description: |
                     Creates one or more invoices in Xero.
@@ -100,7 +100,7 @@ integrations:
                     method: POST
                     path: /invoices
                     group: Invoices
-                version: 1.0.2
+                version: 1.0.3
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -114,7 +114,7 @@ integrations:
                     method: PUT
                     path: /invoices
                     group: Invoices
-                version: 1.0.2
+                version: 1.0.3
             create-credit-note:
                 description: |
                     Creates one or more credit notes in Xero.
@@ -126,7 +126,7 @@ integrations:
                     method: POST
                     path: /credit-notes
                     group: Credit Notes
-                version: 1.0.2
+                version: 1.0.3
             update-credit-note:
                 description: |
                     Updates one or more credit notes in Xero.
@@ -137,7 +137,7 @@ integrations:
                     method: PUT
                     path: /credit-notes
                     group: Credit Notes
-                version: 1.0.2
+                version: 1.0.3
             create-payment:
                 description: |
                     Creates one or more payments in Xero.
@@ -149,7 +149,7 @@ integrations:
                     method: POST
                     path: /payments
                     group: Payments
-                version: 1.0.1
+                version: 1.0.2
             create-item:
                 description: |
                     Creates one or more items in Xero.
@@ -161,7 +161,7 @@ integrations:
                     method: POST
                     path: /items
                     group: Items
-                version: 1.0.1
+                version: 1.0.2
             get-tenants:
                 description: |
                     Fetches all the tenants the connection has access to.
@@ -181,7 +181,7 @@ integrations:
                     method: PUT
                     path: /items
                     group: Items
-                version: 1.0.1
+                version: 1.0.2
 
 models:
     ActionErrorResponse:


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
