### PR TITLE
fix(xero): clean up scopes

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -13480,12 +13480,13 @@ integrations:
                     path: /contacts
                     group: Contacts
                 version: 1.0.2
+                scopes:
+                    - accounting.contacts
             accounts:
                 description: >
                     Fetches all accounts in Xero (chart of accounts). Incremental sync,
                     detects deletes, metadata is not required.
                 runs: every hour
-                scopes: accounting.settings
                 output: Account
                 sync_type: incremental
                 endpoint:
@@ -13493,6 +13494,8 @@ integrations:
                     path: /accounts
                     group: Accounts
                 version: 1.0.2
+                scopes:
+                    - accounting.settings
             items:
                 description: >
                     Fetches all items in Xero. Incremental sync, does not detect deletes,
@@ -13500,7 +13503,6 @@ integrations:
 
                     required.
                 runs: every hour
-                scopes: accounting.settings
                 output: Item
                 sync_type: incremental
                 endpoint:
@@ -13508,11 +13510,12 @@ integrations:
                     path: /items
                     group: Items
                 version: 1.0.2
+                scopes:
+                    - accounting.settings
             invoices:
                 description: |
                     Fetches all invoices in Xero. Incremental sync.
                 runs: every hour
-                scopes: accounting.transactions
                 output: Invoice
                 sync_type: incremental
                 endpoint:
@@ -13520,11 +13523,12 @@ integrations:
                     path: /invoices
                     group: Invoices
                 version: 1.0.2
+                scopes:
+                    - accounting.transactions
             payments:
                 description: |
                     Fetches all payments in Xero. Incremental sync.
                 runs: every hour
-                scopes: accounting.transactions
                 output: Payment
                 sync_type: incremental
                 endpoint:
@@ -13532,44 +13536,49 @@ integrations:
                     path: /payments
                     group: Payments
                 version: 1.0.2
+                scopes:
+                    - accounting.transactions
         actions:
             create-contact:
                 description: |
                     Creates one or multiple contacts in Xero.
                     Note: Does NOT check if these contacts already exist.
                 input: CreateContact[]
-                scopes: accounting.contacts
                 output: ContactActionResponse
                 endpoint:
                     method: POST
                     path: /contacts
                     group: Contacts
                 version: 1.0.2
+                scopes:
+                    - accounting.contacts
             update-contact:
                 description: >
                     Updates one or multiple contacts in Xero. Only fields that are passed
                     in are modified. If a field should not be changed, omit it in the
                     input. The id field is mandatory.
                 input: Contact[]
-                scopes: accounting.contacts
                 output: ContactActionResponse
                 endpoint:
                     method: PUT
                     path: /contacts
                     group: Contacts
                 version: 1.0.2
+                scopes:
+                    - accounting.contacts
             create-invoice:
                 description: |
                     Creates one or more invoices in Xero.
                     Note: Does NOT check if the invoice already exists.
                 input: CreateInvoice[]
-                scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint:
                     method: POST
                     path: /invoices
                     group: Invoices
                 version: 1.0.3
+                scopes:
+                    - accounting.transactions
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -13577,59 +13586,64 @@ integrations:
                     invoice has been AUTHORISED it can't be deleted but you can set
                     the status to VOIDED.
                 input: UpdateInvoice[]
-                scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint:
                     method: PUT
                     path: /invoices
                     group: Invoices
                 version: 1.0.3
+                scopes:
+                    - accounting.transactions
             create-credit-note:
                 description: |
                     Creates one or more credit notes in Xero.
                     Note: Does NOT check if the credit note already exists.
                 input: CreditNote[]
-                scopes: accounting.transactions
                 output: CreditNoteActionResponse
                 endpoint:
                     method: POST
                     path: /credit-notes
                     group: Credit Notes
+                scopes:
+                    - accounting.transactions
                 version: 1.0.3
             update-credit-note:
                 description: |
                     Updates one or more credit notes in Xero.
                 input: CreditNote[]
-                scopes: accounting.transactions
                 output: CreditNoteActionResponse
                 endpoint:
                     method: PUT
                     path: /credit-notes
                     group: Credit Notes
+                scopes:
+                    - accounting.transactions
                 version: 1.0.3
             create-payment:
                 description: |
                     Creates one or more payments in Xero.
                     Note: Does NOT check if the payment already exists.
-                scopes: accounting.transactions
                 input: CreatePayment[]
                 output: PaymentActionResponse
                 endpoint:
                     method: POST
                     path: /payments
                     group: Payments
+                scopes:
+                    - accounting.transactions
                 version: 1.0.2
             create-item:
                 description: |
                     Creates one or more items in Xero.
                     Note: Does NOT check if the item already exists.
-                scopes: accounting.settings
                 input: Item[]
                 output: ItemActionResponse
                 endpoint:
                     method: POST
                     path: /items
                     group: Items
+                scopes:
+                    - accounting.settings
                 version: 1.0.2
             get-tenants:
                 description: |
@@ -13643,13 +13657,14 @@ integrations:
             update-item:
                 description: |
                     Updates one or more items in Xero.
-                scopes: accounting.settings
                 input: Item[]
                 output: ItemActionResponse
                 endpoint:
                     method: PUT
                     path: /items
                     group: Items
+                scopes:
+                    - accounting.settings
                 version: 1.0.2
         models:
             ActionErrorResponse:

--- a/flows.yaml
+++ b/flows.yaml
@@ -13479,9 +13479,9 @@ integrations:
                     method: GET
                     path: /contacts
                     group: Contacts
-                version: 1.0.2
                 scopes:
                     - accounting.contacts
+                version: 1.0.2
             accounts:
                 description: >
                     Fetches all accounts in Xero (chart of accounts). Incremental sync,
@@ -13493,9 +13493,9 @@ integrations:
                     method: GET
                     path: /accounts
                     group: Accounts
-                version: 1.0.2
                 scopes:
                     - accounting.settings
+                version: 1.0.2
             items:
                 description: >
                     Fetches all items in Xero. Incremental sync, does not detect deletes,
@@ -13509,9 +13509,9 @@ integrations:
                     method: GET
                     path: /items
                     group: Items
-                version: 1.0.2
                 scopes:
                     - accounting.settings
+                version: 1.0.2
             invoices:
                 description: |
                     Fetches all invoices in Xero. Incremental sync.
@@ -13522,9 +13522,9 @@ integrations:
                     method: GET
                     path: /invoices
                     group: Invoices
-                version: 1.0.2
                 scopes:
                     - accounting.transactions
+                version: 1.0.2
             payments:
                 description: |
                     Fetches all payments in Xero. Incremental sync.
@@ -13535,9 +13535,9 @@ integrations:
                     method: GET
                     path: /payments
                     group: Payments
-                version: 1.0.2
                 scopes:
                     - accounting.transactions
+                version: 1.0.2
         actions:
             create-contact:
                 description: |
@@ -13549,9 +13549,9 @@ integrations:
                     method: POST
                     path: /contacts
                     group: Contacts
-                version: 1.0.2
                 scopes:
                     - accounting.contacts
+                version: 1.0.2
             update-contact:
                 description: >
                     Updates one or multiple contacts in Xero. Only fields that are passed
@@ -13563,9 +13563,9 @@ integrations:
                     method: PUT
                     path: /contacts
                     group: Contacts
-                version: 1.0.2
                 scopes:
                     - accounting.contacts
+                version: 1.0.2
             create-invoice:
                 description: |
                     Creates one or more invoices in Xero.
@@ -13576,9 +13576,9 @@ integrations:
                     method: POST
                     path: /invoices
                     group: Invoices
-                version: 1.0.3
                 scopes:
                     - accounting.transactions
+                version: 1.0.3
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -13591,9 +13591,9 @@ integrations:
                     method: PUT
                     path: /invoices
                     group: Invoices
-                version: 1.0.3
                 scopes:
                     - accounting.transactions
+                version: 1.0.3
             create-credit-note:
                 description: |
                     Creates one or more credit notes in Xero.
@@ -13604,9 +13604,9 @@ integrations:
                     method: POST
                     path: /credit-notes
                     group: Credit Notes
+                version: 1.0.3
                 scopes:
                     - accounting.transactions
-                version: 1.0.3
             update-credit-note:
                 description: |
                     Updates one or more credit notes in Xero.

--- a/integrations/xero/nango.yaml
+++ b/integrations/xero/nango.yaml
@@ -12,9 +12,9 @@ integrations:
                     method: GET
                     path: /contacts
                     group: Contacts
-                version: 1.0.2
                 scopes:
                     - accounting.contacts
+                version: 1.0.2
             accounts:
                 description: |
                     Fetches all accounts in Xero (chart of accounts). Incremental sync, detects deletes, metadata is not required.
@@ -25,9 +25,9 @@ integrations:
                     method: GET
                     path: /accounts
                     group: Accounts
-                version: 1.0.2
                 scopes:
                     - accounting.settings
+                version: 1.0.2
             items:
                 description: |
                     Fetches all items in Xero. Incremental sync, does not detect deletes, metadata is not
@@ -39,9 +39,9 @@ integrations:
                     method: GET
                     path: /items
                     group: Items
-                version: 1.0.2
                 scopes:
                     - accounting.settings
+                version: 1.0.2
             invoices:
                 description: |
                     Fetches all invoices in Xero. Incremental sync.
@@ -52,9 +52,9 @@ integrations:
                     method: GET
                     path: /invoices
                     group: Invoices
-                version: 1.0.2
                 scopes:
                     - accounting.transactions
+                version: 1.0.2
             payments:
                 description: |
                     Fetches all payments in Xero. Incremental sync.
@@ -65,9 +65,9 @@ integrations:
                     method: GET
                     path: /payments
                     group: Payments
-                version: 1.0.2
                 scopes:
                     - accounting.transactions
+                version: 1.0.2
         actions:
             create-contact:
                 description: |
@@ -79,9 +79,9 @@ integrations:
                     method: POST
                     path: /contacts
                     group: Contacts
-                version: 1.0.2
                 scopes:
                     - accounting.contacts
+                version: 1.0.2
             update-contact:
                 description: >
                     Updates one or multiple contacts in Xero.
@@ -94,9 +94,9 @@ integrations:
                     method: PUT
                     path: /contacts
                     group: Contacts
-                version: 1.0.2
                 scopes:
                     - accounting.contacts
+                version: 1.0.2
             create-invoice:
                 description: |
                     Creates one or more invoices in Xero.
@@ -107,9 +107,9 @@ integrations:
                     method: POST
                     path: /invoices
                     group: Invoices
-                version: 1.0.3
                 scopes:
                     - accounting.transactions
+                version: 1.0.3
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -122,9 +122,9 @@ integrations:
                     method: PUT
                     path: /invoices
                     group: Invoices
-                version: 1.0.3
                 scopes:
                     - accounting.transactions
+                version: 1.0.3
             create-credit-note:
                 description: |
                     Creates one or more credit notes in Xero.
@@ -135,9 +135,9 @@ integrations:
                     method: POST
                     path: /credit-notes
                     group: Credit Notes
+                version: 1.0.3
                 scopes:
                     - accounting.transactions
-                version: 1.0.3
             update-credit-note:
                 description: |
                     Updates one or more credit notes in Xero.

--- a/integrations/xero/nango.yaml
+++ b/integrations/xero/nango.yaml
@@ -13,11 +13,12 @@ integrations:
                     path: /contacts
                     group: Contacts
                 version: 1.0.2
+                scopes:
+                    - accounting.contacts
             accounts:
                 description: |
                     Fetches all accounts in Xero (chart of accounts). Incremental sync, detects deletes, metadata is not required.
                 runs: every hour
-                scopes: accounting.settings
                 output: Account
                 sync_type: incremental
                 endpoint:
@@ -25,12 +26,13 @@ integrations:
                     path: /accounts
                     group: Accounts
                 version: 1.0.2
+                scopes:
+                    - accounting.settings
             items:
                 description: |
                     Fetches all items in Xero. Incremental sync, does not detect deletes, metadata is not
                     required.
                 runs: every hour
-                scopes: accounting.settings
                 output: Item
                 sync_type: incremental
                 endpoint:
@@ -38,11 +40,12 @@ integrations:
                     path: /items
                     group: Items
                 version: 1.0.2
+                scopes:
+                    - accounting.settings
             invoices:
                 description: |
                     Fetches all invoices in Xero. Incremental sync.
                 runs: every hour
-                scopes: accounting.transactions
                 output: Invoice
                 sync_type: incremental
                 endpoint:
@@ -50,11 +53,12 @@ integrations:
                     path: /invoices
                     group: Invoices
                 version: 1.0.2
+                scopes:
+                    - accounting.transactions
             payments:
                 description: |
                     Fetches all payments in Xero. Incremental sync.
                 runs: every hour
-                scopes: accounting.transactions
                 output: Payment
                 sync_type: incremental
                 endpoint:
@@ -62,19 +66,22 @@ integrations:
                     path: /payments
                     group: Payments
                 version: 1.0.2
+                scopes:
+                    - accounting.transactions
         actions:
             create-contact:
                 description: |
                     Creates one or multiple contacts in Xero.
                     Note: Does NOT check if these contacts already exist.
                 input: CreateContact[]
-                scopes: accounting.contacts
                 output: ContactActionResponse
                 endpoint:
                     method: POST
                     path: /contacts
                     group: Contacts
                 version: 1.0.2
+                scopes:
+                    - accounting.contacts
             update-contact:
                 description: >
                     Updates one or multiple contacts in Xero.
@@ -82,25 +89,27 @@ integrations:
                     changed, omit it in the input.
                     The id field is mandatory.
                 input: Contact[]
-                scopes: accounting.contacts
                 output: ContactActionResponse
                 endpoint:
                     method: PUT
                     path: /contacts
                     group: Contacts
                 version: 1.0.2
+                scopes:
+                    - accounting.contacts
             create-invoice:
                 description: |
                     Creates one or more invoices in Xero.
                     Note: Does NOT check if the invoice already exists.
                 input: CreateInvoice[]
-                scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint:
                     method: POST
                     path: /invoices
                     group: Invoices
                 version: 1.0.3
+                scopes:
+                    - accounting.transactions
             update-invoice:
                 description: |
                     Updates one or more invoices in Xero. To delete an invoice
@@ -108,59 +117,64 @@ integrations:
                     invoice has been AUTHORISED it can't be deleted but you can set
                     the status to VOIDED.
                 input: UpdateInvoice[]
-                scopes: accounting.transactions
                 output: InvoiceActionResponse
                 endpoint:
                     method: PUT
                     path: /invoices
                     group: Invoices
                 version: 1.0.3
+                scopes:
+                    - accounting.transactions
             create-credit-note:
                 description: |
                     Creates one or more credit notes in Xero.
                     Note: Does NOT check if the credit note already exists.
                 input: CreditNote[]
-                scopes: accounting.transactions
                 output: CreditNoteActionResponse
                 endpoint:
                     method: POST
                     path: /credit-notes
                     group: Credit Notes
+                scopes:
+                    - accounting.transactions
                 version: 1.0.3
             update-credit-note:
                 description: |
                     Updates one or more credit notes in Xero.
                 input: CreditNote[]
-                scopes: accounting.transactions
                 output: CreditNoteActionResponse
                 endpoint:
                     method: PUT
                     path: /credit-notes
                     group: Credit Notes
+                scopes:
+                    - accounting.transactions
                 version: 1.0.3
             create-payment:
                 description: |
                     Creates one or more payments in Xero.
                     Note: Does NOT check if the payment already exists.
-                scopes: accounting.transactions
                 input: CreatePayment[]
                 output: PaymentActionResponse
                 endpoint:
                     method: POST
                     path: /payments
                     group: Payments
+                scopes:
+                    - accounting.transactions
                 version: 1.0.2
             create-item:
                 description: |
                     Creates one or more items in Xero.
                     Note: Does NOT check if the item already exists.
-                scopes: accounting.settings
                 input: Item[]
                 output: ItemActionResponse
                 endpoint:
                     method: POST
                     path: /items
                     group: Items
+                scopes:
+                    - accounting.settings
                 version: 1.0.2
             get-tenants:
                 description: |
@@ -174,13 +188,14 @@ integrations:
             update-item:
                 description: |
                     Updates one or more items in Xero.
-                scopes: accounting.settings
                 input: Item[]
                 output: ItemActionResponse
                 endpoint:
                     method: PUT
                     path: /items
                     group: Items
+                scopes:
+                    - accounting.settings
                 version: 1.0.2
 
 models:


### PR DESCRIPTION
## Describe your changes
Move version to the very bottom

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
