### PR TITLE
chore: Fix up google drive sync description

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -4168,9 +4168,9 @@ integrations:
                     Metadata required to filter on a particular folder, or file(s).
                     Metadata
 
-                    fields should be {"files": ["<some-id>"]} OR
+                    fields should be `{"files": ["<some-id>"]}` OR
 
-                    {"folders": ["<some-id>"]}. The ID should be able to be provided
+                    `{"folders": ["<some-id>"]}`. The ID should be able to be provided
 
                     by using the Google Picker API
 

--- a/integrations/google-drive/nango.yaml
+++ b/integrations/google-drive/nango.yaml
@@ -8,8 +8,8 @@ integrations:
                     Sync the metadata of a specified file or folders from Google Drive,
                     handling both individual files and nested folders.
                     Metadata required to filter on a particular folder, or file(s). Metadata
-                    fields should be {"files": ["<some-id>"]} OR
-                    {"folders": ["<some-id>"]}. The ID should be able to be provided
+                    fields should be `{"files": ["<some-id>"]}` OR
+                    `{"folders": ["<some-id>"]}`. The ID should be able to be provided
                     by using the Google Picker API
                     (https://developers.google.com/drive/picker/guides/overview)
                     and using the ID field provided by the response


### PR DESCRIPTION
to make mintlify happy

## Describe your changes

For the docs updates in the other repo, Mintlify really doesn't like this drive description having curly braces in it, so I'm making it code to fix the issue up.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
