### PR TITLE
fix: Readme descriptions that say undefined because they're empty

### DIFF
--- a/integrations/asana/actions/delete-task.md
+++ b/integrations/asana/actions/delete-task.md
@@ -3,7 +3,7 @@
 
 ## General Information
 
-- **Description:** undefined
+- **Description:** 
 - **Version:** 0.0.1
 - **Group:** Others
 - **Scopes:** _None_

--- a/integrations/checkr-partner/actions/create-candidate.md
+++ b/integrations/checkr-partner/actions/create-candidate.md
@@ -3,7 +3,7 @@
 
 ## General Information
 
-- **Description:** undefined
+- **Description:** 
 - **Version:** 0.0.1
 - **Group:** Others
 - **Scopes:** _None_

--- a/integrations/google-drive/syncs/documents.md
+++ b/integrations/google-drive/syncs/documents.md
@@ -6,8 +6,8 @@
 - **Description:** Sync the metadata of a specified file or folders from Google Drive,
 handling both individual files and nested folders.
 Metadata required to filter on a particular folder, or file(s). Metadata
-fields should be {"files": ["<some-id>"]} OR
-{"folders": ["<some-id>"]}. The ID should be able to be provided
+fields should be `{"files": ["<some-id>"]}` OR
+`{"folders": ["<some-id>"]}`. The ID should be able to be provided
 by using the Google Picker API
 (https://developers.google.com/drive/picker/guides/overview)
 and using the ID field provided by the response

--- a/integrations/google/syncs/workspace-org-units.md
+++ b/integrations/google/syncs/workspace-org-units.md
@@ -3,7 +3,7 @@
 
 ## General Information
 
-- **Description:** undefined
+- **Description:** 
 - **Version:** 0.0.1
 - **Group:** Others
 - **Scopes:** `https://www.googleapis.com/auth/admin.directory.orgunit.readonly, https://www.googleapis.com/auth/admin.directory.user.readonly`

--- a/integrations/google/syncs/workspace-user-access-tokens.md
+++ b/integrations/google/syncs/workspace-user-access-tokens.md
@@ -3,7 +3,7 @@
 
 ## General Information
 
-- **Description:** undefined
+- **Description:** 
 - **Version:** 0.0.1
 - **Group:** Others
 - **Scopes:** `https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.user.security`

--- a/integrations/google/syncs/workspace-users.md
+++ b/integrations/google/syncs/workspace-users.md
@@ -3,7 +3,7 @@
 
 ## General Information
 
-- **Description:** undefined
+- **Description:** 
 - **Version:** 0.0.1
 - **Group:** Others
 - **Scopes:** _None_

--- a/scripts/generate-readmes.ts
+++ b/scripts/generate-readmes.ts
@@ -69,6 +69,10 @@ function updateReadme(markdown: string, scriptName: string, scriptPath: string, 
 function generalInfo(scriptPath: string, endpointType: string, scriptConfig: any) {
     const scopes = Array.isArray(scriptConfig.scopes) ? scriptConfig.scopes.join(', ') : scriptConfig.scopes;
 
+    if (!scriptConfig.description) {
+        console.warn(`Warning: no description for ${scriptPath}`);
+    }
+
     return [
         `## General Information`,
         ``,

--- a/scripts/generate-readmes.ts
+++ b/scripts/generate-readmes.ts
@@ -72,7 +72,7 @@ function generalInfo(scriptPath: string, endpointType: string, scriptConfig: any
     return [
         `## General Information`,
         ``,
-        `- **Description:** ${scriptConfig.description}`,
+        `- **Description:** ${scriptConfig.description ?? ''}`,
         `- **Version:** ${scriptConfig.version ? scriptConfig.version : '0.0.1'}`,
         `- **Group:** ${scriptConfig.group || 'Others'}`,
         `- **Scopes:** ${scopes ? `\`${scopes}\`` : '_None_'}`,


### PR DESCRIPTION
## Describe your changes

Fixes up our readme generator to not show anything after description if it's unset in the nango.yaml. Also adds a warning so they're easier to spot.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
