### PR TITLE
fix(test): Set limit on first page

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -129,10 +129,7 @@ class NangoActionMock {
         const updatedBodyOrParams = paginateInBody ? (args.data as Record<string, any>) || {} : args.params || {};
 
         if (args.paginate['limit']) {
-            const limitParameterName = args.paginate.limit_name_in_request;
-            if (!limitParameterName) {
-                throw new Error('limit_name_in_request is required when using pagination');
-            }
+            const limitParameterName = args.paginate.limit_name_in_request!;
 
             updatedBodyOrParams[limitParameterName] = args.paginate['limit'];
         }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -128,6 +128,15 @@ class NangoActionMock {
         const paginateInBody = ['post', 'put', 'patch'].includes(args.method.toLowerCase());
         const updatedBodyOrParams = paginateInBody ? (args.data as Record<string, any>) || {} : args.params || {};
 
+        if (args.paginate['limit']) {
+            const limitParameterName = args.paginate.limit_name_in_request;
+            if (!limitParameterName) {
+                throw new Error('limit_name_in_request is required when using pagination');
+            }
+
+            updatedBodyOrParams[limitParameterName] = args.paginate['limit'];
+        }
+
         if (args.paginate?.type === 'cursor') {
             yield* this.cursorPaginate(args, updatedBodyOrParams, paginateInBody);
         } else if (args.paginate?.type === 'link') {


### PR DESCRIPTION
## Describe your changes

The first page wasn't including a limit param, and that caused issues for tests.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
