### PR TITLE
fix(notion): tweak yaml

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -9570,7 +9570,9 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /metadata
+                    path: /contents
+                    group: Contents
+                version: 1.0.0
             users:
                 runs: every day
                 description: |
@@ -9581,6 +9583,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /users
+                    group: Users
             databases:
                 runs: every 1h
                 track_deletes: true
@@ -9593,7 +9596,9 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /notion/database
+                    path: /databases
+                    group: Databases
+                version: 1.0.0
         actions:
             fetch-rich-page:
                 description: >
@@ -9609,7 +9614,9 @@ integrations:
                 output: RichPage
                 endpoint:
                     method: GET
-                    path: /fetch-rich-page
+                    path: /pages/single
+                    group: Pages
+                version: 1.0.0
             fetch-database:
                 description: >-
                     Fetch a specific Notion database by passing in the database id. This
@@ -9619,8 +9626,9 @@ integrations:
                 output: Database
                 endpoint:
                     method: GET
-                    path: /fetch-database
-                version: 1.0.0
+                    path: /databases/single
+                    group: Databases
+                version: 1.0.1
             fetch-content-metadata:
                 description: >
                     Retrieve the entity type as well as an id for a Notion entity to later
@@ -9631,7 +9639,9 @@ integrations:
                 output: ContentMetadata
                 endpoint:
                     method: GET
-                    path: /fetch-content-metadata
+                    path: /contents/single
+                    group: Contents
+                version: 1.0.0
         models:
             RichPageInput:
                 pageId: string

--- a/integrations/notion/actions/fetch-content-metadata.md
+++ b/integrations/notion/actions/fetch-content-metadata.md
@@ -6,7 +6,7 @@
 - **Description:** Retrieve the entity type as well as an id for a Notion entity to later call
 fetch-database or fetch-rich-page based on the type.
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
@@ -17,7 +17,7 @@ fetch-database or fetch-rich-page based on the type.
 
 ### Request Endpoint
 
-`GET /fetch-content-metadata`
+`GET /contents/single`
 
 ### Request Query Parameters
 

--- a/integrations/notion/actions/fetch-database.md
+++ b/integrations/notion/actions/fetch-database.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetch a specific Notion database by passing in the database id. This action fetches the database and outputs an object. Note that this should be used for small databases.
-- **Version:** 1.0.0
+- **Version:** 1.0.1
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
@@ -15,7 +15,7 @@
 
 ### Request Endpoint
 
-`GET /fetch-database`
+`GET /databases/single`
 
 ### Request Query Parameters
 

--- a/integrations/notion/actions/fetch-rich-page.md
+++ b/integrations/notion/actions/fetch-rich-page.md
@@ -7,7 +7,7 @@
 and its content and converts it into a full markdown. It transforms images,
 tables, uploaded files, etc., into their markdown counterparts, providing a complete markdown.
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
@@ -18,7 +18,7 @@ tables, uploaded files, etc., into their markdown counterparts, providing a comp
 
 ### Request Endpoint
 
-`GET /fetch-rich-page`
+`GET /pages/single`
 
 ### Request Query Parameters
 

--- a/integrations/notion/nango.yaml
+++ b/integrations/notion/nango.yaml
@@ -11,7 +11,9 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /metadata
+                    path: /contents
+                    group: Contents
+                version: 1.0.0
             users:
                 runs: every day
                 description: |
@@ -22,6 +24,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /users
+                    group: Users
             databases:
                 runs: every 1h
                 track_deletes: true
@@ -32,7 +35,9 @@ integrations:
                 sync_type: full
                 endpoint:
                     method: GET
-                    path: /notion/database
+                    path: /databases
+                    group: Databases
+                version: 1.0.0
         actions:
             fetch-rich-page:
                 description: |
@@ -43,15 +48,18 @@ integrations:
                 output: RichPage
                 endpoint:
                     method: GET
-                    path: /fetch-rich-page
+                    path: /pages/single
+                    group: Pages
+                version: 1.0.0
             fetch-database:
                 description: Fetch a specific Notion database by passing in the database id. This action fetches the database and outputs an object. Note that this should be used for small databases.
                 input: DatabaseInput
                 output: Database
                 endpoint:
                     method: GET
-                    path: /fetch-database
-                version: 1.0.0
+                    path: /databases/single
+                    group: Databases
+                version: 1.0.1
             fetch-content-metadata:
                 description: |
                     Retrieve the entity type as well as an id for a Notion entity to later call
@@ -60,7 +68,9 @@ integrations:
                 output: ContentMetadata
                 endpoint:
                     method: GET
-                    path: /fetch-content-metadata
+                    path: /contents/single
+                    group: Contents
+                version: 1.0.0
 models:
     RichPageInput:
         pageId: string

--- a/integrations/notion/syncs/content-metadata.md
+++ b/integrations/notion/syncs/content-metadata.md
@@ -6,7 +6,7 @@
 - **Description:** Sync pages and databases metadata to further fetch the content
 using a dedicated action
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
@@ -17,7 +17,7 @@ using a dedicated action
 
 ### Request Endpoint
 
-`GET /metadata`
+`GET /contents`
 
 ### Request Query Parameters
 

--- a/integrations/notion/syncs/databases.md
+++ b/integrations/notion/syncs/databases.md
@@ -6,7 +6,7 @@
 - **Description:** Sync a database content with each row as an entry. Store the top level
 database information in the metadata to be able to reconcile the database
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
@@ -17,7 +17,7 @@ database information in the metadata to be able to reconcile the database
 
 ### Request Endpoint
 
-`GET /notion/database`
+`GET /databases`
 
 ### Request Query Parameters
 


### PR DESCRIPTION
## Describe your changes
Cleanup endpoints and groups

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
