### PR TITLE
fix(linkedin): Fix endpoint for linkedin

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -9049,7 +9049,9 @@ integrations:
                 description: Create a linkedin post with an optional video
                 input: LinkedinVideoPost
                 output: CreateLinkedInPostWithVideoResponse
-                endpoint: POST /videos
+                endpoint:
+                    method: POST
+                    path: /videos
                 scopes:
                     - openid
                     - profile

--- a/integrations/linkedin/actions/post.md
+++ b/integrations/linkedin/actions/post.md
@@ -15,7 +15,7 @@
 
 ### Request Endpoint
 
-`GET undefined`
+`POST /videos`
 
 ### Request Query Parameters
 

--- a/integrations/linkedin/nango.yaml
+++ b/integrations/linkedin/nango.yaml
@@ -5,7 +5,9 @@ integrations:
                 description: Create a linkedin post with an optional video
                 input: LinkedinVideoPost
                 output: CreateLinkedInPostWithVideoResponse
-                endpoint: POST /videos
+                endpoint:
+                    method: POST
+                    path: /videos
                 scopes:
                     - openid
                     - profile


### PR DESCRIPTION
See https://linear.app/nango/issue/NAN-2434/undefined-undefined-endpoint-in-docs

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
