### PR TITLE
fix(docs): Fix issue relating to symlinked configs

### DIFF
--- a/integrations/aircall/actions/create-user.md
+++ b/integrations/aircall/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall-basic/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -44,8 +44,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall-basic/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall-basic/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/aircall/actions/delete-user.md
+++ b/integrations/aircall/actions/delete-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall-basic/actions/delete-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall/actions/delete-user.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall-basic/actions/delete-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall-basic/actions/delete-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall/actions/delete-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall/actions/delete-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/aircall/syncs/users.md
+++ b/integrations/aircall/syncs/users.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall-basic/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -42,8 +42,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall-basic/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall-basic/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/aircall/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/avalara/actions/commit-transaction.md
+++ b/integrations/avalara/actions/commit-transaction.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara-sandbox/actions/commit-transaction.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/actions/commit-transaction.ts)
 
 
 ## Endpoint Reference
@@ -40,8 +40,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/actions/commit-transaction.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/actions/commit-transaction.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/actions/commit-transaction.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/actions/commit-transaction.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/avalara/actions/create-transaction.md
+++ b/integrations/avalara/actions/create-transaction.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara-sandbox/actions/create-transaction.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/actions/create-transaction.ts)
 
 
 ## Endpoint Reference
@@ -139,8 +139,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/actions/create-transaction.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/actions/create-transaction.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/actions/create-transaction.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/actions/create-transaction.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/avalara/actions/void-transaction.md
+++ b/integrations/avalara/actions/void-transaction.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara-sandbox/actions/void-transaction.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/actions/void-transaction.ts)
 
 
 ## Endpoint Reference
@@ -40,8 +40,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/actions/void-transaction.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/actions/void-transaction.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/actions/void-transaction.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/actions/void-transaction.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/avalara/syncs/transactions.md
+++ b/integrations/avalara/syncs/transactions.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara-sandbox/syncs/transactions.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/syncs/transactions.ts)
 
 
 ## Endpoint Reference
@@ -205,8 +205,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/syncs/transactions.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara-sandbox/syncs/transactions.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/syncs/transactions.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/syncs/transactions.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/bill/actions/create-user.md
+++ b/integrations/bill/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill-sandbox/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -46,8 +46,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill-sandbox/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill-sandbox/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/bill/actions/disable-user.md
+++ b/integrations/bill/actions/disable-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill-sandbox/actions/disable-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill/actions/disable-user.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill-sandbox/actions/disable-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill-sandbox/actions/disable-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill/actions/disable-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill/actions/disable-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/bill/syncs/users.md
+++ b/integrations/bill/syncs/users.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill-sandbox/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -42,8 +42,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill-sandbox/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill-sandbox/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/bill/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/docusign/actions/create-user.md
+++ b/integrations/docusign/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `openid, signature`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign-sandbox/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -55,8 +55,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign-sandbox/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign-sandbox/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/docusign/actions/delete-user.md
+++ b/integrations/docusign/actions/delete-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `openid, signature`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign-sandbox/actions/delete-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign/actions/delete-user.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign-sandbox/actions/delete-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign-sandbox/actions/delete-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign/actions/delete-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign/actions/delete-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/docusign/syncs/users.md
+++ b/integrations/docusign/syncs/users.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `openid, signature`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign-sandbox/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -42,8 +42,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign-sandbox/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign-sandbox/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/docusign/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/gusto/actions/create-user.md
+++ b/integrations/gusto/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `employees:manage`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto-demo/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -49,8 +49,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto-demo/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto-demo/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/gusto/actions/delete-user.md
+++ b/integrations/gusto/actions/delete-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `employments:write`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto-demo/actions/delete-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto/actions/delete-user.ts)
 
 
 ## Endpoint Reference
@@ -41,8 +41,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto-demo/actions/delete-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto-demo/actions/delete-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto/actions/delete-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto/actions/delete-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/gusto/syncs/users.md
+++ b/integrations/gusto/syncs/users.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `employees:read`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto-demo/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -42,8 +42,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto-demo/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto-demo/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/gusto/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/apply-posting.md
+++ b/integrations/lever/actions/apply-posting.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/apply-posting.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/apply-posting.ts)
 
 
 ## Endpoint Reference
@@ -145,8 +145,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/apply-posting.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/apply-posting.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/apply-posting.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/apply-posting.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/create-note.md
+++ b/integrations/lever/actions/create-note.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `notes:write:admin`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/create-note.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/create-note.ts)
 
 
 ## Endpoint Reference
@@ -56,8 +56,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/create-note.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/create-note.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/create-note.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/create-note.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/create-opportunity.md
+++ b/integrations/lever/actions/create-opportunity.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `opportunities:write:admin`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/create-opportunity.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/create-opportunity.ts)
 
 
 ## Endpoint Reference
@@ -110,8 +110,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/create-opportunity.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/create-opportunity.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/create-opportunity.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/create-opportunity.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/get-archive-reasons.md
+++ b/integrations/lever/actions/get-archive-reasons.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/get-archive-reasons.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-archive-reasons.ts)
 
 
 ## Endpoint Reference
@@ -92,8 +92,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-archive-reasons.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-archive-reasons.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-archive-reasons.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-archive-reasons.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/get-posting.md
+++ b/integrations/lever/actions/get-posting.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/get-posting.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-posting.ts)
 
 
 ## Endpoint Reference
@@ -96,8 +96,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-posting.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-posting.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-posting.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-posting.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/get-postings.md
+++ b/integrations/lever/actions/get-postings.md
@@ -11,7 +11,7 @@ are returned.
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/get-postings.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-postings.ts)
 
 
 ## Endpoint Reference
@@ -94,8 +94,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-postings.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-postings.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-postings.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-postings.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/get-stages.md
+++ b/integrations/lever/actions/get-stages.md
@@ -11,7 +11,7 @@ are returned.
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/get-stages.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-stages.ts)
 
 
 ## Endpoint Reference
@@ -43,8 +43,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-stages.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/get-stages.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-stages.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/get-stages.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/update-opportunity-archived.md
+++ b/integrations/lever/actions/update-opportunity-archived.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/update-opportunity-archived.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-archived.ts)
 
 
 ## Endpoint Reference
@@ -100,8 +100,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-archived.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-archived.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-archived.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-archived.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/update-opportunity-links.md
+++ b/integrations/lever/actions/update-opportunity-links.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/update-opportunity-links.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-links.ts)
 
 
 ## Endpoint Reference
@@ -101,8 +101,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-links.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-links.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-links.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-links.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/update-opportunity-sources.md
+++ b/integrations/lever/actions/update-opportunity-sources.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/update-opportunity-sources.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-sources.ts)
 
 
 ## Endpoint Reference
@@ -101,8 +101,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-sources.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-sources.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-sources.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-sources.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/update-opportunity-stage.md
+++ b/integrations/lever/actions/update-opportunity-stage.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/update-opportunity-stage.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-stage.ts)
 
 
 ## Endpoint Reference
@@ -98,8 +98,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-stage.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-stage.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-stage.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-stage.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/update-opportunity-tags.md
+++ b/integrations/lever/actions/update-opportunity-tags.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/update-opportunity-tags.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-tags.ts)
 
 
 ## Endpoint Reference
@@ -101,8 +101,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-tags.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity-tags.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-tags.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity-tags.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/update-opportunity.md
+++ b/integrations/lever/actions/update-opportunity.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/update-opportunity.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity.ts)
 
 
 ## Endpoint Reference
@@ -114,8 +114,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/update-opportunity.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/update-opportunity.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/actions/users.md
+++ b/integrations/lever/actions/users.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/actions/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/users.ts)
 
 
 ## Endpoint Reference
@@ -92,8 +92,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/actions/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/actions/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/opportunities-applications.md
+++ b/integrations/lever/syncs/opportunities-applications.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `applications:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/opportunities-applications.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-applications.ts)
 
 
 ## Endpoint Reference
@@ -72,8 +72,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-applications.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-applications.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-applications.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-applications.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/opportunities-feedbacks.md
+++ b/integrations/lever/syncs/opportunities-feedbacks.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `feedback:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/opportunities-feedbacks.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-feedbacks.ts)
 
 
 ## Endpoint Reference
@@ -53,8 +53,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-feedbacks.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-feedbacks.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-feedbacks.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-feedbacks.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/opportunities-interviews.md
+++ b/integrations/lever/syncs/opportunities-interviews.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `interviews:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/opportunities-interviews.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-interviews.ts)
 
 
 ## Endpoint Reference
@@ -62,8 +62,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-interviews.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-interviews.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-interviews.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-interviews.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/opportunities-notes.md
+++ b/integrations/lever/syncs/opportunities-notes.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `notes:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/opportunities-notes.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-notes.ts)
 
 
 ## Endpoint Reference
@@ -48,8 +48,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-notes.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-notes.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-notes.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-notes.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/opportunities-offers.md
+++ b/integrations/lever/syncs/opportunities-offers.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `offers:write:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/opportunities-offers.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-offers.ts)
 
 
 ## Endpoint Reference
@@ -55,8 +55,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-offers.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities-offers.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-offers.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities-offers.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/opportunities.md
+++ b/integrations/lever/syncs/opportunities.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `opportunities:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/opportunities.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities.ts)
 
 
 ## Endpoint Reference
@@ -91,8 +91,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/opportunities.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/opportunities.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/postings-questions.md
+++ b/integrations/lever/syncs/postings-questions.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `postings:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/postings-questions.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/postings-questions.ts)
 
 
 ## Endpoint Reference
@@ -52,8 +52,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/postings-questions.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/postings-questions.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/postings-questions.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/postings-questions.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/postings.md
+++ b/integrations/lever/syncs/postings.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `postings:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/postings.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/postings.ts)
 
 
 ## Endpoint Reference
@@ -95,8 +95,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/postings.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/postings.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/postings.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/postings.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/lever/syncs/stages.md
+++ b/integrations/lever/syncs/stages.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `stages:read:admin`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever-sandbox/syncs/stages.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/stages.ts)
 
 
 ## Endpoint Reference
@@ -40,8 +40,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/stages.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever-sandbox/syncs/stages.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/stages.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/lever/syncs/stages.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/okta/actions/add-group.md
+++ b/integrations/okta/actions/add-group.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `okta.groups.manage`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta-preview/actions/add-group.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/add-group.ts)
 
 
 ## Endpoint Reference
@@ -48,8 +48,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/add-group.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/add-group.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/add-group.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/add-group.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/okta/actions/add-user-group.md
+++ b/integrations/okta/actions/add-user-group.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `okta.groups.manage`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta-preview/actions/add-user-group.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/add-user-group.ts)
 
 
 ## Endpoint Reference
@@ -40,8 +40,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/add-user-group.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/add-user-group.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/add-user-group.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/add-user-group.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/okta/actions/create-user.md
+++ b/integrations/okta/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `okta.users.manage`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta-preview/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -61,8 +61,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/okta/actions/remove-user-group.md
+++ b/integrations/okta/actions/remove-user-group.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `okta.groups.manage`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta-preview/actions/remove-user-group.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/remove-user-group.ts)
 
 
 ## Endpoint Reference
@@ -40,8 +40,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/remove-user-group.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/actions/remove-user-group.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/remove-user-group.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/actions/remove-user-group.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/okta/syncs/users.md
+++ b/integrations/okta/syncs/users.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `okta.users.read`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta-preview/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -56,8 +56,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta-preview/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/okta/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/create-account.md
+++ b/integrations/quickbooks/actions/create-account.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/create-account.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-account.ts)
 
 
 ## Endpoint Reference
@@ -56,8 +56,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-account.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-account.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-account.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-account.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/create-credit-memo.md
+++ b/integrations/quickbooks/actions/create-credit-memo.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/create-credit-memo.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-credit-memo.ts)
 
 
 ## Endpoint Reference
@@ -83,8 +83,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-credit-memo.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-credit-memo.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-credit-memo.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-credit-memo.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/create-customer.md
+++ b/integrations/quickbooks/actions/create-customer.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/create-customer.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-customer.ts)
 
 
 ## Endpoint Reference
@@ -76,8 +76,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-customer.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-customer.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-customer.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-customer.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/create-invoice.md
+++ b/integrations/quickbooks/actions/create-invoice.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/create-invoice.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-invoice.ts)
 
 
 ## Endpoint Reference
@@ -83,8 +83,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-invoice.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-invoice.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-invoice.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-invoice.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/create-item.md
+++ b/integrations/quickbooks/actions/create-item.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/create-item.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-item.ts)
 
 
 ## Endpoint Reference
@@ -69,8 +69,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-item.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-item.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-item.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-item.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/create-payment.md
+++ b/integrations/quickbooks/actions/create-payment.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/create-payment.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-payment.ts)
 
 
 ## Endpoint Reference
@@ -57,8 +57,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-payment.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/create-payment.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-payment.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/create-payment.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/update-account.md
+++ b/integrations/quickbooks/actions/update-account.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/update-account.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-account.ts)
 
 
 ## Endpoint Reference
@@ -50,8 +50,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-account.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-account.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-account.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-account.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/update-credit-memo.md
+++ b/integrations/quickbooks/actions/update-credit-memo.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/update-credit-memo.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-credit-memo.ts)
 
 
 ## Endpoint Reference
@@ -53,8 +53,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-credit-memo.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-credit-memo.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-credit-memo.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-credit-memo.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/update-customer.md
+++ b/integrations/quickbooks/actions/update-customer.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/update-customer.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-customer.ts)
 
 
 ## Endpoint Reference
@@ -49,8 +49,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-customer.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-customer.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-customer.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-customer.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/update-invoice.md
+++ b/integrations/quickbooks/actions/update-invoice.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/update-invoice.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-invoice.ts)
 
 
 ## Endpoint Reference
@@ -53,8 +53,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-invoice.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-invoice.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-invoice.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-invoice.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/actions/update-item.md
+++ b/integrations/quickbooks/actions/update-item.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/actions/update-item.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-item.ts)
 
 
 ## Endpoint Reference
@@ -49,8 +49,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-item.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/actions/update-item.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-item.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/actions/update-item.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/syncs/accounts.md
+++ b/integrations/quickbooks/syncs/accounts.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/syncs/accounts.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/accounts.ts)
 
 
 ## Endpoint Reference
@@ -51,8 +51,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/accounts.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/accounts.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/accounts.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/accounts.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/syncs/customers.md
+++ b/integrations/quickbooks/syncs/customers.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/syncs/customers.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/customers.ts)
 
 
 ## Endpoint Reference
@@ -50,8 +50,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/customers.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/customers.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/customers.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/customers.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/syncs/invoices.md
+++ b/integrations/quickbooks/syncs/invoices.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/syncs/invoices.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/invoices.ts)
 
 
 ## Endpoint Reference
@@ -54,8 +54,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/invoices.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/invoices.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/invoices.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/invoices.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/syncs/items.md
+++ b/integrations/quickbooks/syncs/items.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/syncs/items.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/items.ts)
 
 
 ## Endpoint Reference
@@ -50,8 +50,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/items.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/items.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/items.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/items.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/quickbooks/syncs/payments.md
+++ b/integrations/quickbooks/syncs/payments.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks-sandbox/syncs/payments.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/payments.ts)
 
 
 ## Endpoint Reference
@@ -44,8 +44,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/payments.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks-sandbox/syncs/payments.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/payments.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/quickbooks/syncs/payments.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/ramp/actions/create-user.md
+++ b/integrations/ramp/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `users:write`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp-sandbox/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -49,8 +49,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp-sandbox/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp-sandbox/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/ramp/actions/disable-user.md
+++ b/integrations/ramp/actions/disable-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `users:write`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp-sandbox/actions/disable-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp/actions/disable-user.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp-sandbox/actions/disable-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp-sandbox/actions/disable-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp/actions/disable-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp/actions/disable-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/ramp/syncs/users.md
+++ b/integrations/ramp/syncs/users.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `users:read`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp-sandbox/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -41,8 +41,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp-sandbox/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp-sandbox/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ramp/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/ring-central/actions/create-user.md
+++ b/integrations/ring-central/actions/create-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `EditAccounts`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central-sandbox/actions/create-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central/actions/create-user.ts)
 
 
 ## Endpoint Reference
@@ -72,8 +72,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central-sandbox/actions/create-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central-sandbox/actions/create-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central/actions/create-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central/actions/create-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/ring-central/actions/delete-user.md
+++ b/integrations/ring-central/actions/delete-user.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `EditAccounts`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central-sandbox/actions/delete-user.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central/actions/delete-user.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central-sandbox/actions/delete-user.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central-sandbox/actions/delete-user.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central/actions/delete-user.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central/actions/delete-user.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/ring-central/syncs/users.md
+++ b/integrations/ring-central/syncs/users.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `ReadAccounts`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central-sandbox/syncs/users.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central/syncs/users.ts)
 
 
 ## Endpoint Reference
@@ -42,8 +42,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central-sandbox/syncs/users.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central-sandbox/syncs/users.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central/syncs/users.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/ring-central/syncs/users.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/create-account.md
+++ b/integrations/salesforce/actions/create-account.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/create-account.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-account.ts)
 
 
 ## Endpoint Reference
@@ -47,8 +47,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-account.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-account.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-account.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-account.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/create-contact.md
+++ b/integrations/salesforce/actions/create-contact.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/create-contact.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-contact.ts)
 
 
 ## Endpoint Reference
@@ -49,8 +49,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-contact.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-contact.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-contact.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-contact.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/create-lead.md
+++ b/integrations/salesforce/actions/create-lead.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/create-lead.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-lead.ts)
 
 
 ## Endpoint Reference
@@ -50,8 +50,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-lead.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-lead.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-lead.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-lead.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/create-opportunity.md
+++ b/integrations/salesforce/actions/create-opportunity.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/create-opportunity.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-opportunity.ts)
 
 
 ## Endpoint Reference
@@ -50,8 +50,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-opportunity.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/create-opportunity.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-opportunity.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/create-opportunity.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/delete-account.md
+++ b/integrations/salesforce/actions/delete-account.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/delete-account.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-account.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-account.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-account.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-account.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-account.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/delete-contact.md
+++ b/integrations/salesforce/actions/delete-contact.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/delete-contact.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-contact.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-contact.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-contact.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-contact.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-contact.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/delete-lead.md
+++ b/integrations/salesforce/actions/delete-lead.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/delete-lead.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-lead.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-lead.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-lead.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-lead.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-lead.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/delete-opportunity.md
+++ b/integrations/salesforce/actions/delete-opportunity.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/delete-opportunity.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-opportunity.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-opportunity.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/delete-opportunity.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-opportunity.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/delete-opportunity.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/fetch-fields.md
+++ b/integrations/salesforce/actions/fetch-fields.md
@@ -10,7 +10,7 @@ Data Validation: Parses all incoming data with Zod. Does not fail on parsing err
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/fetch-fields.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/fetch-fields.ts)
 
 
 ## Endpoint Reference
@@ -66,8 +66,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/fetch-fields.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/fetch-fields.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/fetch-fields.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/fetch-fields.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/update-account.md
+++ b/integrations/salesforce/actions/update-account.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/update-account.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-account.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-account.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-account.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-account.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-account.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/update-contact.md
+++ b/integrations/salesforce/actions/update-contact.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/update-contact.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-contact.ts)
 
 
 ## Endpoint Reference
@@ -39,8 +39,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-contact.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-contact.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-contact.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-contact.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/update-lead.md
+++ b/integrations/salesforce/actions/update-lead.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/update-lead.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-lead.ts)
 
 
 ## Endpoint Reference
@@ -40,8 +40,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-lead.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-lead.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-lead.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-lead.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/actions/update-opportunity.md
+++ b/integrations/salesforce/actions/update-opportunity.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/actions/update-opportunity.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-opportunity.ts)
 
 
 ## Endpoint Reference
@@ -41,8 +41,8 @@ _No request parameters_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-opportunity.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/actions/update-opportunity.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-opportunity.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/update-opportunity.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/syncs/accounts.md
+++ b/integrations/salesforce/syncs/accounts.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/syncs/accounts.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/accounts.ts)
 
 
 ## Endpoint Reference
@@ -48,8 +48,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/accounts.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/accounts.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/accounts.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/accounts.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/syncs/articles.md
+++ b/integrations/salesforce/syncs/articles.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/syncs/articles.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/articles.ts)
 
 
 ## Endpoint Reference
@@ -42,8 +42,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/articles.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/articles.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/articles.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/articles.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/syncs/contacts.md
+++ b/integrations/salesforce/syncs/contacts.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/syncs/contacts.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/contacts.ts)
 
 
 ## Endpoint Reference
@@ -51,8 +51,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/contacts.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/contacts.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/contacts.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/contacts.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/syncs/leads.md
+++ b/integrations/salesforce/syncs/leads.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/syncs/leads.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/leads.ts)
 
 
 ## Endpoint Reference
@@ -51,8 +51,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/leads.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/leads.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/leads.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/leads.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/syncs/opportunities.md
+++ b/integrations/salesforce/syncs/opportunities.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/syncs/opportunities.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/opportunities.ts)
 
 
 ## Endpoint Reference
@@ -53,8 +53,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/opportunities.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/opportunities.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/opportunities.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/opportunities.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/salesforce/syncs/tickets.md
+++ b/integrations/salesforce/syncs/tickets.md
@@ -9,7 +9,7 @@
 - **Group:** Others
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce-sandbox/syncs/tickets.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/tickets.ts)
 
 
 ## Endpoint Reference
@@ -65,8 +65,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/tickets.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce-sandbox/syncs/tickets.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/tickets.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/tickets.md)
 
 <!-- END  GENERATED CONTENT -->
 

--- a/integrations/stripe-app/syncs/subscriptions.md
+++ b/integrations/stripe-app/syncs/subscriptions.md
@@ -8,7 +8,7 @@
 - **Group:** Others
 - **Scopes:** `subscription_read`
 - **Endpoint Type:** Sync
-- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/stripe-app-sandbox/syncs/subscriptions.ts)
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/stripe-app/syncs/subscriptions.ts)
 
 
 ## Endpoint Reference
@@ -155,8 +155,8 @@ _No request body_
 
 ## Changelog
 
-- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/stripe-app-sandbox/syncs/subscriptions.ts)
-- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/stripe-app-sandbox/syncs/subscriptions.md)
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/stripe-app/syncs/subscriptions.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/stripe-app/syncs/subscriptions.md)
 
 <!-- END  GENERATED CONTENT -->
 


### PR DESCRIPTION
## Describe your changes

The issue here was that I didn't realize we used symlinks within the repo. We would iterate the non-sandbox version of the docs and generate the readme, and then iterate the sandbox version and generate the readme through a symlink, which replaced the non-sandbox one.

This updates the script to ignore any symlinked integrations.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
