### PR TITLE
feat(whoami): Add whoami endpoints

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -12158,6 +12158,13 @@ integrations:
                     path: /opportunities
                     group: Opportunities
                 version: 1.0.0
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
         syncs:
             accounts:
                 runs: every hour
@@ -12257,6 +12264,9 @@ integrations:
                 salutation: string | null
                 title: string | null
                 last_modified_date: string
+            UserInformation:
+                id: string
+                email: string
             CommonContactInput:
                 first_name?: string | undefined
                 account_id?: string | undefined
@@ -12644,6 +12654,13 @@ integrations:
                     path: /opportunities
                     group: Opportunities
                 version: 1.0.0
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
         syncs:
             accounts:
                 runs: every hour
@@ -12743,6 +12760,9 @@ integrations:
                 salutation: string | null
                 title: string | null
                 last_modified_date: string
+            UserInformation:
+                id: string
+                email: string
             CommonContactInput:
                 first_name?: string | undefined
                 account_id?: string | undefined

--- a/flows.yaml
+++ b/flows.yaml
@@ -15422,6 +15422,15 @@ integrations:
                 scopes:
                     - user:write
                     - user:write:admin
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
+                scopes:
+                    - user:read:user
             delete-user:
                 description: Deletes a user in Zoom. Requires Pro account or higher
                 endpoint:
@@ -15520,6 +15529,9 @@ integrations:
                 id: string
                 firstName: string
                 lastName: string
+                email: string
+            UserInformation:
+                id: string
                 email: string
             Meeting:
                 id: string

--- a/flows.yaml
+++ b/flows.yaml
@@ -2175,6 +2175,13 @@ integrations:
                 input: IdEntity
                 scopes:
                     - admin
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
         models:
             IdEntity:
                 id: string
@@ -2186,6 +2193,9 @@ integrations:
                 firstName: string
                 lastName: string
             CreateUser:
+                email: string
+            UserInformation:
+                id: string
                 email: string
             Event:
                 id: string

--- a/integrations/calendly/actions/whoami.md
+++ b/integrations/calendly/actions/whoami.md
@@ -1,0 +1,43 @@
+<!-- BEGIN GENERATED CONTENT -->
+# Whoami
+
+## General Information
+
+- **Description:** Fetch current user information
+- **Version:** 0.0.1
+- **Group:** Others
+- **Scopes:** _None_
+- **Endpoint Type:** Action
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/calendly/actions/whoami.ts)
+
+
+## Endpoint Reference
+
+### Request Endpoint
+
+`GET /whoami`
+
+### Request Query Parameters
+
+_No request parameters_
+
+### Request Body
+
+_No request body_
+
+### Request Response
+
+```json
+{
+  "id": "<string>",
+  "email": "<string>"
+}
+```
+
+## Changelog
+
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/calendly/actions/whoami.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/calendly/actions/whoami.md)
+
+<!-- END  GENERATED CONTENT -->
+

--- a/integrations/calendly/actions/whoami.ts
+++ b/integrations/calendly/actions/whoami.ts
@@ -1,0 +1,28 @@
+import type { NangoAction, ProxyConfiguration, UserInformation } from '../../models';
+import type { CalendlyCurrentUser } from '../types';
+
+export default async function runAction(nango: NangoAction): Promise<UserInformation> {
+    const config: ProxyConfiguration = {
+        // https://developer.calendly.com/api-docs/005832c83aeae-get-current-user
+        endpoint: '/users/me',
+        retries: 10
+    };
+
+    const { data } = await nango.get<{ resource: CalendlyCurrentUser }>(config);
+
+    const id: string | undefined = data.resource.uri.split('/').pop();
+
+    if (!id) {
+        throw new nango.ActionError({
+            message: 'Unable to find user id',
+            data
+        });
+    }
+
+    const user: UserInformation = {
+        id,
+        email: data.resource.email
+    };
+
+    return user;
+}

--- a/integrations/calendly/nango.yaml
+++ b/integrations/calendly/nango.yaml
@@ -56,6 +56,13 @@ integrations:
                 input: IdEntity
                 scopes:
                     - admin
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
 
 models:
     # Generic
@@ -71,6 +78,9 @@ models:
         firstName: string
         lastName: string
     CreateUser:
+        email: string
+    UserInformation:
+        id: string
         email: string
 
     Event:

--- a/integrations/salesforce/actions/whoami.md
+++ b/integrations/salesforce/actions/whoami.md
@@ -1,0 +1,43 @@
+<!-- BEGIN GENERATED CONTENT -->
+# Whoami
+
+## General Information
+
+- **Description:** Fetch current user information
+- **Version:** 0.0.1
+- **Group:** Others
+- **Scopes:** _None_
+- **Endpoint Type:** Action
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/whoami.ts)
+
+
+## Endpoint Reference
+
+### Request Endpoint
+
+`GET /whoami`
+
+### Request Query Parameters
+
+_No request parameters_
+
+### Request Body
+
+_No request body_
+
+### Request Response
+
+```json
+{
+  "id": "<string>",
+  "email": "<string>"
+}
+```
+
+## Changelog
+
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/whoami.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/actions/whoami.md)
+
+<!-- END  GENERATED CONTENT -->
+

--- a/integrations/salesforce/actions/whoami.ts
+++ b/integrations/salesforce/actions/whoami.ts
@@ -1,0 +1,20 @@
+import type { NangoAction, ProxyConfiguration, UserInformation } from '../../models';
+import type { SalesForceUserInfo } from '../types';
+
+export default async function runAction(nango: NangoAction): Promise<UserInformation> {
+    const config: ProxyConfiguration = {
+        baseUrlOverride: 'https://login.salesforce.com',
+        // https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm&type=5
+        endpoint: '/services/oauth2/userinfo',
+        retries: 10
+    };
+
+    const { data } = await nango.get<SalesForceUserInfo>(config);
+
+    const user: UserInformation = {
+        id: data.user_id,
+        email: data.email
+    };
+
+    return user;
+}

--- a/integrations/salesforce/nango.yaml
+++ b/integrations/salesforce/nango.yaml
@@ -161,6 +161,13 @@ integrations:
                     path: /opportunities
                     group: Opportunities
                 version: 1.0.0
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
         syncs:
             accounts:
                 runs: every hour
@@ -260,6 +267,9 @@ models:
         salutation: string | null
         title: string | null
         last_modified_date: string
+    UserInformation:
+        id: string
+        email: string
     CommonContactInput:
         first_name?: string | undefined
         account_id?: string | undefined

--- a/integrations/salesforce/types.ts
+++ b/integrations/salesforce/types.ts
@@ -321,3 +321,58 @@ export interface SalesforceOpportunity {
     Type: string | null;
     LastModifiedDate: string;
 }
+
+export interface SalesForceUserInfo {
+    sub: string;
+    user_id: string;
+    organization_id: string;
+    preferred_username: string;
+    nickname: string;
+    name: string;
+    email: string;
+    email_verified: boolean;
+    given_name: string;
+    family_name: string;
+    zoneinfo: string;
+    photos: UserInfoPhotos;
+    profile: string;
+    picture: string;
+    address: UserInfoAddress;
+    is_salesforce_integration_user: boolean;
+    urls: UserInfoUrls;
+    active: boolean;
+    user_type: string;
+    language: string;
+    locale: string;
+    utcOffset: number;
+    updated_at: string;
+}
+
+interface UserInfoPhotos {
+    picture: string;
+    thumbnail: string;
+}
+
+interface UserInfoAddress {
+    country: string;
+}
+
+interface UserInfoUrls {
+    enterprise: string;
+    metadata: string;
+    partner: string;
+    rest: string;
+    sobjects: string;
+    search: string;
+    query: string;
+    recent: string;
+    tooling_soap: string;
+    tooling_rest: string;
+    profile: string;
+    feeds: string;
+    groups: string;
+    users: string;
+    feed_items: string;
+    feed_elements: string;
+    custom_domain: string;
+}

--- a/integrations/zoom/actions/whoami.md
+++ b/integrations/zoom/actions/whoami.md
@@ -1,0 +1,43 @@
+<!-- BEGIN GENERATED CONTENT -->
+# Whoami
+
+## General Information
+
+- **Description:** Fetch current user information
+- **Version:** 0.0.1
+- **Group:** Others
+- **Scopes:** `user:read:user`
+- **Endpoint Type:** Action
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/actions/whoami.ts)
+
+
+## Endpoint Reference
+
+### Request Endpoint
+
+`GET /whoami`
+
+### Request Query Parameters
+
+_No request parameters_
+
+### Request Body
+
+_No request body_
+
+### Request Response
+
+```json
+{
+  "id": "<string>",
+  "email": "<string>"
+}
+```
+
+## Changelog
+
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/zoom/actions/whoami.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/zoom/actions/whoami.md)
+
+<!-- END  GENERATED CONTENT -->
+

--- a/integrations/zoom/actions/whoami.ts
+++ b/integrations/zoom/actions/whoami.ts
@@ -1,0 +1,19 @@
+import type { NangoAction, ProxyConfiguration, UserInformation } from '../../models';
+import type { ZoomUser } from '../types';
+
+export default async function runAction(nango: NangoAction): Promise<UserInformation> {
+    const config: ProxyConfiguration = {
+        // https://developers.zoom.us/docs/api/users/#tag/users/GET/users/{userId}
+        endpoint: '/users/me',
+        retries: 10
+    };
+
+    const { data } = await nango.get<ZoomUser>(config);
+
+    const user: UserInformation = {
+        id: data.id,
+        email: data.email
+    };
+
+    return user;
+}

--- a/integrations/zoom/nango.yaml
+++ b/integrations/zoom/nango.yaml
@@ -12,6 +12,15 @@ integrations:
                 scopes:
                     - user:write
                     - user:write:admin
+            whoami:
+                description: Fetch current user information
+                output: UserInformation
+                endpoint:
+                    method: GET
+                    path: /whoami
+                    group: Users
+                scopes:
+                    - user:read:user
             delete-user:
                 description: Deletes a user in Zoom. Requires Pro account or higher
                 endpoint:
@@ -113,6 +122,9 @@ models:
         id: string
         firstName: string
         lastName: string
+        email: string
+    UserInformation:
+        id: string
         email: string
 
     # Meetings


### PR DESCRIPTION
## Describe your changes
Adds whoami endpoints for a few APIs for consistency

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
