### PR TITLE
fix(docs): Fix groups in generated readmes

### DIFF
--- a/integrations/aircall/actions/create-user.md
+++ b/integrations/aircall/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Aircall.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall/actions/create-user.ts)

--- a/integrations/aircall/actions/delete-user.md
+++ b/integrations/aircall/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Aircall
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall/actions/delete-user.ts)

--- a/integrations/aircall/syncs/users.md
+++ b/integrations/aircall/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Aircall.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aircall/syncs/users.ts)

--- a/integrations/airtable/actions/create-webhook.md
+++ b/integrations/airtable/actions/create-webhook.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a webhook for a particular base
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Webhooks
 - **Scopes:** `webhook:manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/airtable/actions/create-webhook.ts)

--- a/integrations/airtable/actions/delete-webhook.md
+++ b/integrations/airtable/actions/delete-webhook.md
@@ -5,7 +5,7 @@
 
 - **Description:** Delete a webhook
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Webhooks
 - **Scopes:** `webhook:manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/airtable/actions/delete-webhook.ts)

--- a/integrations/airtable/actions/list-webhooks.md
+++ b/integrations/airtable/actions/list-webhooks.md
@@ -5,7 +5,7 @@
 
 - **Description:** List all the webhooks available for a base
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Webhooks
 - **Scopes:** `webhook:manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/airtable/actions/list-webhooks.ts)

--- a/integrations/airtable/actions/whoami.md
+++ b/integrations/airtable/actions/whoami.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch current user information
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user.email:read`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/airtable/actions/whoami.ts)

--- a/integrations/asana/actions/create-task.md
+++ b/integrations/asana/actions/create-task.md
@@ -6,7 +6,7 @@
 - **Description:** Create a task using Asana specific fields and return a unified model task. See https://developers.asana.com/reference/createtask for Asana specific fields
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/actions/create-task.ts)

--- a/integrations/asana/actions/delete-task.md
+++ b/integrations/asana/actions/delete-task.md
@@ -5,7 +5,7 @@
 
 - **Description:** 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/actions/delete-task.ts)

--- a/integrations/asana/actions/update-task.md
+++ b/integrations/asana/actions/update-task.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a task and be able to assign the task to a specific user
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/actions/update-task.ts)

--- a/integrations/asana/syncs/projects.md
+++ b/integrations/asana/syncs/projects.md
@@ -5,7 +5,7 @@
 
 - **Description:** Retrieves all projects for a user
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Projects
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/syncs/projects.ts)

--- a/integrations/asana/syncs/tasks.md
+++ b/integrations/asana/syncs/tasks.md
@@ -5,7 +5,7 @@
 
 - **Description:** Retrieve all tasks that exist in the workspace
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/syncs/tasks.ts)

--- a/integrations/asana/syncs/users.md
+++ b/integrations/asana/syncs/users.md
@@ -5,7 +5,7 @@
 
 - **Description:** Retrieve all users that exist in the workspace
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/syncs/users.ts)

--- a/integrations/asana/syncs/workspaces.md
+++ b/integrations/asana/syncs/workspaces.md
@@ -5,7 +5,7 @@
 
 - **Description:** Retrieve all workspaces for a user
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Workspaces
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/asana/syncs/workspaces.ts)

--- a/integrations/ashby/actions/application-change-source.md
+++ b/integrations/ashby/actions/application-change-source.md
@@ -6,7 +6,7 @@
 - **Description:** Action to change source of application.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Applications
 - **Scopes:** `candidatesWrite`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/application-change-source.ts)

--- a/integrations/ashby/actions/application-change-stage.md
+++ b/integrations/ashby/actions/application-change-stage.md
@@ -6,7 +6,7 @@
 - **Description:** Action to change stage of an application.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Applications
 - **Scopes:** `candidatesWrite`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/application-change-stage.ts)

--- a/integrations/ashby/actions/application-update-history.md
+++ b/integrations/ashby/actions/application-update-history.md
@@ -6,7 +6,7 @@
 - **Description:** Action to update history an application stage.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Applications
 - **Scopes:** `candidatesWrite`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/application-update-history.ts)

--- a/integrations/ashby/actions/application-update.md
+++ b/integrations/ashby/actions/application-update.md
@@ -6,7 +6,7 @@
 - **Description:** Action to update an application.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Applications
 - **Scopes:** `candidatesWrite`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/application-update.ts)

--- a/integrations/ashby/actions/create-application.md
+++ b/integrations/ashby/actions/create-application.md
@@ -6,7 +6,7 @@
 - **Description:** Action to consider a candidate for a job
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Applications
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/create-application.ts)

--- a/integrations/ashby/actions/create-candidate.md
+++ b/integrations/ashby/actions/create-candidate.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a candidate.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Candidates
 - **Scopes:** `candidatesWrite`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/create-candidate.ts)

--- a/integrations/ashby/actions/create-note.md
+++ b/integrations/ashby/actions/create-note.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a note on a candidate.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Notes
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/create-note.ts)

--- a/integrations/ashby/actions/interview-stage.md
+++ b/integrations/ashby/actions/interview-stage.md
@@ -6,7 +6,7 @@
 - **Description:** List all interview stages for an interview plan in order.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Interviews
 - **Scopes:** `interviewsRead`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/actions/interview-stage.ts)

--- a/integrations/ashby/syncs/candidates.md
+++ b/integrations/ashby/syncs/candidates.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all candidates from your ashby account
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Candidates
 - **Scopes:** `candidatelastsyncToken`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/syncs/candidates.ts)

--- a/integrations/ashby/syncs/jobs.md
+++ b/integrations/ashby/syncs/jobs.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all jobs from your ashby account
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Jobs
 - **Scopes:** `jobslastsyncToken`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ashby/syncs/jobs.ts)

--- a/integrations/avalara/actions/commit-transaction.md
+++ b/integrations/avalara/actions/commit-transaction.md
@@ -6,7 +6,7 @@
 - **Description:** Marks a transaction by changing its status to Committed
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Transactions
 - **Scopes:** `AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/actions/commit-transaction.ts)

--- a/integrations/avalara/actions/create-transaction.md
+++ b/integrations/avalara/actions/create-transaction.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a new transaction
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Transactions
 - **Scopes:** `AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/actions/create-transaction.ts)

--- a/integrations/avalara/actions/void-transaction.md
+++ b/integrations/avalara/actions/void-transaction.md
@@ -6,7 +6,7 @@
 - **Description:** Voids the current transaction uniquely identified by the transactionCode
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Transactions
 - **Scopes:** `AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/actions/void-transaction.ts)

--- a/integrations/avalara/syncs/transactions.md
+++ b/integrations/avalara/syncs/transactions.md
@@ -5,7 +5,7 @@
 
 - **Description:** List all transactions with a default backfill date of one year.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Transactions
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/avalara/syncs/transactions.ts)

--- a/integrations/aws-iam/actions/create-user.md
+++ b/integrations/aws-iam/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in AWS IAM.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aws-iam/actions/create-user.ts)

--- a/integrations/aws-iam/actions/delete-user.md
+++ b/integrations/aws-iam/actions/delete-user.md
@@ -6,7 +6,7 @@
 - **Description:** Delete an existing user in AWS IAM. When you delete a user, you must delete the items attached to the user manually, or the deletion fails.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aws-iam/actions/delete-user.ts)

--- a/integrations/aws-iam/syncs/users.md
+++ b/integrations/aws-iam/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from AWS IAM
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/aws-iam/syncs/users.ts)

--- a/integrations/bamboohr-basic/actions/create-employee.md
+++ b/integrations/bamboohr-basic/actions/create-employee.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a new employee
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Employees
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bamboohr-basic/actions/create-employee.ts)

--- a/integrations/bamboohr-basic/actions/update-employee.md
+++ b/integrations/bamboohr-basic/actions/update-employee.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update an existing employee in the system
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Employees
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bamboohr-basic/actions/update-employee.ts)

--- a/integrations/bamboohr-basic/syncs/employees.md
+++ b/integrations/bamboohr-basic/syncs/employees.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of current employees from bamboohr
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Employees
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bamboohr-basic/syncs/employees.ts)

--- a/integrations/bill/actions/create-user.md
+++ b/integrations/bill/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Bill.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill/actions/create-user.ts)

--- a/integrations/bill/actions/disable-user.md
+++ b/integrations/bill/actions/disable-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Archive an existing user in Bill
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill/actions/disable-user.ts)

--- a/integrations/bill/syncs/users.md
+++ b/integrations/bill/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Bill sandbox
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/bill/syncs/users.ts)

--- a/integrations/box/actions/create-user.md
+++ b/integrations/box/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Box. Requires an enterprise account.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/box/actions/create-user.ts)

--- a/integrations/box/actions/delete-user.md
+++ b/integrations/box/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Box. Requires an enterprise account.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/box/actions/delete-user.ts)

--- a/integrations/box/syncs/users.md
+++ b/integrations/box/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Box. Requires an enterprise account.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/box/syncs/users.ts)

--- a/integrations/calendly/actions/create-user.md
+++ b/integrations/calendly/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Calendly
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `admin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/calendly/actions/create-user.ts)

--- a/integrations/calendly/actions/delete-user.md
+++ b/integrations/calendly/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Calendly
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `admin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/calendly/actions/delete-user.ts)

--- a/integrations/calendly/syncs/users.md
+++ b/integrations/calendly/syncs/users.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of users from Calendly
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/calendly/syncs/users.ts)

--- a/integrations/datadog/actions/create-user.md
+++ b/integrations/datadog/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Datadog.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user_access_invite`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/datadog/actions/create-user.ts)

--- a/integrations/datadog/actions/disable-user.md
+++ b/integrations/datadog/actions/disable-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Disables a user in Datadog
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user_access_manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/datadog/actions/disable-user.ts)

--- a/integrations/datadog/syncs/users.md
+++ b/integrations/datadog/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Datadog.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user_access_read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/datadog/syncs/users.ts)

--- a/integrations/dialpad/actions/create-user.md
+++ b/integrations/dialpad/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Dialpad
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/dialpad/actions/create-user.ts)

--- a/integrations/dialpad/actions/delete-user.md
+++ b/integrations/dialpad/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Dialpad by email
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/dialpad/actions/delete-user.ts)

--- a/integrations/dialpad/syncs/users.md
+++ b/integrations/dialpad/syncs/users.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of users from Dialpad
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/dialpad/syncs/users.ts)

--- a/integrations/discourse/actions/create-category.md
+++ b/integrations/discourse/actions/create-category.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a category in discourse
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Categories
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/discourse/actions/create-category.ts)

--- a/integrations/discourse/syncs/categories.md
+++ b/integrations/discourse/syncs/categories.md
@@ -5,7 +5,7 @@
 
 - **Description:** List all categories
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Categories
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/discourse/syncs/categories.ts)

--- a/integrations/docusign/actions/create-user.md
+++ b/integrations/docusign/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in DocuSign
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `openid, signature`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign/actions/create-user.ts)

--- a/integrations/docusign/actions/delete-user.md
+++ b/integrations/docusign/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in DocuSign
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `openid, signature`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign/actions/delete-user.ts)

--- a/integrations/docusign/syncs/users.md
+++ b/integrations/docusign/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from DocuSign
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `openid, signature`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/docusign/syncs/users.ts)

--- a/integrations/dropbox/actions/create-user.md
+++ b/integrations/dropbox/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Dropbox. Requires Dropbox Business.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `members.write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/dropbox/actions/create-user.ts)

--- a/integrations/dropbox/actions/delete-user.md
+++ b/integrations/dropbox/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Dropbox. Requires Dropbox Business.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `members.delete`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/dropbox/actions/delete-user.ts)

--- a/integrations/dropbox/syncs/users.md
+++ b/integrations/dropbox/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Dropbox. Requires Dropbox Business.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `members.read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/dropbox/syncs/users.ts)

--- a/integrations/exact-online/actions/create-customer.md
+++ b/integrations/exact-online/actions/create-customer.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a customer in ExactOnline
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/exact-online/actions/create-customer.ts)

--- a/integrations/exact-online/actions/create-invoice.md
+++ b/integrations/exact-online/actions/create-invoice.md
@@ -6,7 +6,7 @@
 - **Description:** Creates an invoice in ExactOnline
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/exact-online/actions/create-invoice.ts)

--- a/integrations/exact-online/actions/update-customer.md
+++ b/integrations/exact-online/actions/update-customer.md
@@ -6,7 +6,7 @@
 - **Description:** Updates a customer in ExactOnline
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/exact-online/actions/update-customer.ts)

--- a/integrations/exact-online/actions/update-invoice.md
+++ b/integrations/exact-online/actions/update-invoice.md
@@ -6,7 +6,7 @@
 - **Description:** Updates an invoice in ExactOnline
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/exact-online/actions/update-invoice.ts)

--- a/integrations/exact-online/syncs/customers.md
+++ b/integrations/exact-online/syncs/customers.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all customers in Exact Online
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/exact-online/syncs/customers.ts)

--- a/integrations/expensify/actions/create-user.md
+++ b/integrations/expensify/actions/create-user.md
@@ -6,7 +6,7 @@
 - **Description:** Create a user in the account
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/expensify/actions/create-user.ts)

--- a/integrations/expensify/actions/disable-user.md
+++ b/integrations/expensify/actions/disable-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Disables a user in Expensify
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/expensify/actions/disable-user.ts)

--- a/integrations/expensify/syncs/users.md
+++ b/integrations/expensify/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Expensify.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/expensify/syncs/users.ts)

--- a/integrations/freshdesk/actions/create-contact.md
+++ b/integrations/freshdesk/actions/create-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in FreshDesk
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/freshdesk/actions/create-contact.ts)

--- a/integrations/freshdesk/actions/create-user.md
+++ b/integrations/freshdesk/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in FreshDesk
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/freshdesk/actions/create-user.ts)

--- a/integrations/freshdesk/actions/delete-contact.md
+++ b/integrations/freshdesk/actions/delete-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a contact in FreshDesk
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/freshdesk/actions/delete-contact.ts)

--- a/integrations/freshdesk/actions/delete-user.md
+++ b/integrations/freshdesk/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in FreshDesk
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/freshdesk/actions/delete-user.ts)

--- a/integrations/freshdesk/syncs/contacts.md
+++ b/integrations/freshdesk/syncs/contacts.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the list of contacts.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/freshdesk/syncs/contacts.ts)

--- a/integrations/freshdesk/syncs/users.md
+++ b/integrations/freshdesk/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the list of users
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/freshdesk/syncs/users.ts)

--- a/integrations/front/actions/conversation.md
+++ b/integrations/front/actions/conversation.md
@@ -5,7 +5,7 @@
 
 - **Description:** List the messages in a conversation in reverse chronological order (newest first).
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Conversations
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/front/actions/conversation.ts)

--- a/integrations/front/syncs/conversations.md
+++ b/integrations/front/syncs/conversations.md
@@ -5,7 +5,7 @@
 
 - **Description:** List the conversations in the company in reverse chronological order.
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Conversations
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/front/syncs/conversations.ts)

--- a/integrations/github-app/actions/repositories.md
+++ b/integrations/github-app/actions/repositories.md
@@ -5,7 +5,7 @@
 
 - **Description:** List all repositories accessible to this Github App
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Repositories
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/github-app/actions/repositories.ts)

--- a/integrations/github/actions/write-file.md
+++ b/integrations/github/actions/write-file.md
@@ -7,7 +7,7 @@
 the file doesn't exist it creates and then writes to it
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Files
 - **Scopes:** `repo`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/github/actions/write-file.ts)

--- a/integrations/github/syncs/list-files.md
+++ b/integrations/github/syncs/list-files.md
@@ -6,7 +6,7 @@
 - **Description:** Lists all the files of a Github repo given a specific branch
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Files
 - **Scopes:** `repo`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/github/syncs/list-files.ts)

--- a/integrations/google-mail/actions/send-email.md
+++ b/integrations/google-mail/actions/send-email.md
@@ -6,7 +6,7 @@
 - **Description:** Send an Email using Gmail.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Emails
 - **Scopes:** `https://www.googleapis.com/auth/gmail.send`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/google-mail/actions/send-email.ts)

--- a/integrations/google-mail/syncs/emails.md
+++ b/integrations/google-mail/syncs/emails.md
@@ -8,7 +8,7 @@ but metadata can be set using the `backfillPeriodMs` property
 to change the lookback. The property should be set in milliseconds.
 
 - **Version:** 1.0.3
-- **Group:** Others
+- **Group:** Emails
 - **Scopes:** `https://www.googleapis.com/auth/gmail.readonly`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/google-mail/syncs/emails.ts)

--- a/integrations/gorgias/actions/create-ticket.md
+++ b/integrations/gorgias/actions/create-ticket.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a new ticket
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tickets
 - **Scopes:** `tickets:write, account:read, customers:write, customers:read`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gorgias/actions/create-ticket.ts)

--- a/integrations/gorgias/syncs/tickets.md
+++ b/integrations/gorgias/syncs/tickets.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of tickets with their associated messages
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Tickets
 - **Scopes:** `tickets:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gorgias/syncs/tickets.ts)

--- a/integrations/gusto/actions/create-user.md
+++ b/integrations/gusto/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Gusto.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `employees:manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto/actions/create-user.ts)

--- a/integrations/gusto/actions/delete-user.md
+++ b/integrations/gusto/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Gusto.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `employments:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto/actions/delete-user.ts)

--- a/integrations/gusto/syncs/users.md
+++ b/integrations/gusto/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Gusto.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `employees:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/gusto/syncs/users.ts)

--- a/integrations/hackerrank-work/actions/create-interview.md
+++ b/integrations/hackerrank-work/actions/create-interview.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create an interview on hackerrank work
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Interviews
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hackerrank-work/actions/create-interview.ts)

--- a/integrations/hackerrank-work/actions/create-test.md
+++ b/integrations/hackerrank-work/actions/create-test.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a test on hackerrank work
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Tests
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hackerrank-work/actions/create-test.ts)

--- a/integrations/hackerrank-work/syncs/interviews.md
+++ b/integrations/hackerrank-work/syncs/interviews.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of interviews from hackerrank work
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Interviews
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hackerrank-work/syncs/interviews.ts)

--- a/integrations/hackerrank-work/syncs/tests.md
+++ b/integrations/hackerrank-work/syncs/tests.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of tests from hackerrank work
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Tests
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hackerrank-work/syncs/tests.ts)

--- a/integrations/harvest/actions/create-user.md
+++ b/integrations/harvest/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Harvest
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `administrator, manager`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/harvest/actions/create-user.ts)

--- a/integrations/harvest/actions/delete-user.md
+++ b/integrations/harvest/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Harvest
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `administrator`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/harvest/actions/delete-user.ts)

--- a/integrations/harvest/syncs/users.md
+++ b/integrations/harvest/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the list of users in Harvest
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `administrator, manager`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/harvest/syncs/users.ts)

--- a/integrations/hubspot/actions/change-user-role.md
+++ b/integrations/hubspot/actions/change-user-role.md
@@ -5,7 +5,7 @@
 
 - **Description:** Change a user role. Requires an enterprise account.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Roles
 - **Scopes:** `oauth, settings.users.write (standard scope), crm.objects.users.write (granular scope)`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/change-user-role.ts)

--- a/integrations/hubspot/actions/create-company.md
+++ b/integrations/hubspot/actions/create-company.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a single company in Hubspot
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Companies
 - **Scopes:** `crm.objects.companies.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/create-company.ts)

--- a/integrations/hubspot/actions/create-contact.md
+++ b/integrations/hubspot/actions/create-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a single contact in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `crm.objects.contacts.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/create-contact.ts)

--- a/integrations/hubspot/actions/create-deal.md
+++ b/integrations/hubspot/actions/create-deal.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a single deal in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Deals
 - **Scopes:** `oauth, crm.objects.deals.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/create-deal.ts)

--- a/integrations/hubspot/actions/create-property.md
+++ b/integrations/hubspot/actions/create-property.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a property in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Properties
 - **Scopes:** `oauth, crm.schemas.orders.write, crm.objects.orders.write, crm.schemas.contacts.write, crm.schemas.carts.write, crm.schemas.deals.write, crm.objects.users.write, crm.schemas.companies.write, crm.objects.carts.write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/create-property.ts)

--- a/integrations/hubspot/actions/create-task.md
+++ b/integrations/hubspot/actions/create-task.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a single task in Hubspot
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** `crm.objects.contacts.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/create-task.ts)

--- a/integrations/hubspot/actions/create-user.md
+++ b/integrations/hubspot/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a single user in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `oauth, settings.users.write (standard scope), crm.objects.users.write (granular)`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/create-user.ts)

--- a/integrations/hubspot/actions/delete-company.md
+++ b/integrations/hubspot/actions/delete-company.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a company in Hubspot
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Companies
 - **Scopes:** `crm.objects.companies.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/delete-company.ts)

--- a/integrations/hubspot/actions/delete-contact.md
+++ b/integrations/hubspot/actions/delete-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a contact in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `crm.objects.contacts.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/delete-contact.ts)

--- a/integrations/hubspot/actions/delete-deal.md
+++ b/integrations/hubspot/actions/delete-deal.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a deal in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Deals
 - **Scopes:** `crm.objects.deals.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/delete-deal.ts)

--- a/integrations/hubspot/actions/delete-task.md
+++ b/integrations/hubspot/actions/delete-task.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a task in Hubspot
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** `crm.objects.contacts.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/delete-task.ts)

--- a/integrations/hubspot/actions/delete-user.md
+++ b/integrations/hubspot/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `oauth, settings.users.write (standard scope), crm.objects.users.write (granular)`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/delete-user.ts)

--- a/integrations/hubspot/actions/fetch-pipelines.md
+++ b/integrations/hubspot/actions/fetch-pipelines.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch all pipelines for an object type. Defaults to deals
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Pipelines
 - **Scopes:** `oauth, crm.objects.deals.read`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/fetch-pipelines.ts)

--- a/integrations/hubspot/actions/fetch-properties.md
+++ b/integrations/hubspot/actions/fetch-properties.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch the properties of a specified object
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Properties
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/fetch-properties.ts)

--- a/integrations/hubspot/actions/fetch-roles.md
+++ b/integrations/hubspot/actions/fetch-roles.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch the roles on an account. Requires an enterprise account.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Roles
 - **Scopes:** `oauth, settings.users.read (standard scope), crm.objects.users.read (granular scope)`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/fetch-roles.ts)

--- a/integrations/hubspot/actions/update-company.md
+++ b/integrations/hubspot/actions/update-company.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a single company in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Companies
 - **Scopes:** `crm.objects.companies.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/update-company.ts)

--- a/integrations/hubspot/actions/update-contact.md
+++ b/integrations/hubspot/actions/update-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Updates a single contact in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `crm.objects.contacts.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/update-contact.ts)

--- a/integrations/hubspot/actions/update-deal.md
+++ b/integrations/hubspot/actions/update-deal.md
@@ -5,7 +5,7 @@
 
 - **Description:** Updates a single deal in Hubspot
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Deals
 - **Scopes:** `crm.objects.deals.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/update-deal.ts)

--- a/integrations/hubspot/actions/update-task.md
+++ b/integrations/hubspot/actions/update-task.md
@@ -5,7 +5,7 @@
 
 - **Description:** Updates a single company in Hubspot
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** `crm.objects.contacts.write, oauth`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/update-task.ts)

--- a/integrations/hubspot/actions/whoami.md
+++ b/integrations/hubspot/actions/whoami.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch current user information
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/whoami.ts)

--- a/integrations/hubspot/syncs/companies.md
+++ b/integrations/hubspot/syncs/companies.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of companies from Hubspot
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Companies
 - **Scopes:** `crm.objects.companies.read, oauth`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/companies.ts)

--- a/integrations/hubspot/syncs/contacts.md
+++ b/integrations/hubspot/syncs/contacts.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of contacts from Hubspot
 
 - **Version:** 2.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `crm.objects.contacts.read, oauth`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/contacts.ts)

--- a/integrations/hubspot/syncs/deals.md
+++ b/integrations/hubspot/syncs/deals.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of deals from Hubspot with their associated companies and contacts
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Deals
 - **Scopes:** `crm.objects.deals.read, oauth, e-commerce (standard scope), crm.objects.line_items.read (granular scope)`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/deals.ts)

--- a/integrations/hubspot/syncs/owners.md
+++ b/integrations/hubspot/syncs/owners.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of owners from Hubspot
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Owners
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/owners.ts)

--- a/integrations/hubspot/syncs/products.md
+++ b/integrations/hubspot/syncs/products.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of products from Hubspot
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Products
 - **Scopes:** `e-commerce`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/products.ts)

--- a/integrations/hubspot/syncs/tasks.md
+++ b/integrations/hubspot/syncs/tasks.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of tasks from Hubspot
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tasks
 - **Scopes:** `crm.objects.contacts.read, oauth`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/tasks.ts)

--- a/integrations/hubspot/syncs/users.md
+++ b/integrations/hubspot/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Hubspot
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `oauth, settings.users.read (standard scope), crm.objects.users.read (granular scope)`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/syncs/users.ts)

--- a/integrations/jira-basic/actions/create-user.md
+++ b/integrations/jira-basic/actions/create-user.md
@@ -10,7 +10,7 @@ jira-software. Note that the last name isn't able to be set via the API and
 the first name defaults to the email address.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/jira-basic/actions/create-user.ts)

--- a/integrations/jira-basic/actions/delete-user.md
+++ b/integrations/jira-basic/actions/delete-user.md
@@ -7,7 +7,7 @@
 be deprecated in the future.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/jira-basic/actions/delete-user.ts)

--- a/integrations/jira-basic/syncs/users.md
+++ b/integrations/jira-basic/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Jira
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/jira-basic/syncs/users.ts)

--- a/integrations/jira/actions/create-issue.md
+++ b/integrations/jira/actions/create-issue.md
@@ -6,7 +6,7 @@
 - **Description:** An action that creates an Issue on Jira
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Issues
 - **Scopes:** `write:jira-work`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/jira/actions/create-issue.ts)

--- a/integrations/jira/syncs/issues.md
+++ b/integrations/jira/syncs/issues.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of issues from Jira
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Issues
 - **Scopes:** `read:jira-work`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/jira/syncs/issues.ts)

--- a/integrations/keeper-scim/actions/create-user.md
+++ b/integrations/keeper-scim/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Keeper
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/keeper-scim/actions/create-user.ts)

--- a/integrations/keeper-scim/actions/delete-user.md
+++ b/integrations/keeper-scim/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Keeper
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/keeper-scim/actions/delete-user.ts)

--- a/integrations/keeper-scim/syncs/users.md
+++ b/integrations/keeper-scim/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the list of users from Keeper
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/keeper-scim/syncs/users.ts)

--- a/integrations/lastpass/actions/create-user.md
+++ b/integrations/lastpass/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Lastpass.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lastpass/actions/create-user.ts)

--- a/integrations/lastpass/actions/delete-user.md
+++ b/integrations/lastpass/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Lastpass.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lastpass/actions/delete-user.ts)

--- a/integrations/lastpass/syncs/users.md
+++ b/integrations/lastpass/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Lastpass.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lastpass/syncs/users.ts)

--- a/integrations/lattice-scim/actions/create-user.md
+++ b/integrations/lattice-scim/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Lattice
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lattice-scim/actions/create-user.ts)

--- a/integrations/lattice-scim/actions/disable-user.md
+++ b/integrations/lattice-scim/actions/disable-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Disables a user in Lattice
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lattice-scim/actions/disable-user.ts)

--- a/integrations/lattice/syncs/users.md
+++ b/integrations/lattice/syncs/users.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of users from Lattice
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lattice/syncs/users.ts)

--- a/integrations/lever/actions/apply-posting.md
+++ b/integrations/lever/actions/apply-posting.md
@@ -6,7 +6,7 @@
 - **Description:** Submit an application on behalf of a candidate. This endpoint can only be used to submit applications to published or unlisted postings.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Posts
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/apply-posting.ts)

--- a/integrations/lever/actions/create-note.md
+++ b/integrations/lever/actions/create-note.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a note and add it to an opportunity.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Notes
 - **Scopes:** `notes:write:admin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/create-note.ts)

--- a/integrations/lever/actions/create-opportunity.md
+++ b/integrations/lever/actions/create-opportunity.md
@@ -6,7 +6,7 @@
 - **Description:** Create an opportunity and optionally candidates associated with the opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `opportunities:write:admin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/create-opportunity.ts)

--- a/integrations/lever/actions/get-archive-reasons.md
+++ b/integrations/lever/actions/get-archive-reasons.md
@@ -6,7 +6,7 @@
 - **Description:** Get all archived reasons
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Archived
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-archive-reasons.ts)

--- a/integrations/lever/actions/get-posting.md
+++ b/integrations/lever/actions/get-posting.md
@@ -6,7 +6,7 @@
 - **Description:** Get single post for your account in Lever
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Posts
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-posting.ts)

--- a/integrations/lever/actions/get-postings.md
+++ b/integrations/lever/actions/get-postings.md
@@ -8,7 +8,7 @@ not paginate the response so it is possible that not all postings
 are returned.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Posts
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-postings.ts)

--- a/integrations/lever/actions/get-stages.md
+++ b/integrations/lever/actions/get-stages.md
@@ -8,7 +8,7 @@ not paginate the response so it is possible that not all stages
 are returned.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Stages
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/get-stages.ts)

--- a/integrations/lever/actions/update-opportunity-archived.md
+++ b/integrations/lever/actions/update-opportunity-archived.md
@@ -6,7 +6,7 @@
 - **Description:** Update the archived state of an opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-archived.ts)

--- a/integrations/lever/actions/update-opportunity-links.md
+++ b/integrations/lever/actions/update-opportunity-links.md
@@ -6,7 +6,7 @@
 - **Description:** Update the links in an opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-links.ts)

--- a/integrations/lever/actions/update-opportunity-sources.md
+++ b/integrations/lever/actions/update-opportunity-sources.md
@@ -6,7 +6,7 @@
 - **Description:** Update the sources in an opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-sources.ts)

--- a/integrations/lever/actions/update-opportunity-stage.md
+++ b/integrations/lever/actions/update-opportunity-stage.md
@@ -6,7 +6,7 @@
 - **Description:** Update the stage in an opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-stage.ts)

--- a/integrations/lever/actions/update-opportunity-tags.md
+++ b/integrations/lever/actions/update-opportunity-tags.md
@@ -6,7 +6,7 @@
 - **Description:** Update the tags in an opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity-tags.ts)

--- a/integrations/lever/actions/update-opportunity.md
+++ b/integrations/lever/actions/update-opportunity.md
@@ -6,7 +6,7 @@
 - **Description:** Update an opportunity
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/update-opportunity.ts)

--- a/integrations/lever/actions/users.md
+++ b/integrations/lever/actions/users.md
@@ -6,7 +6,7 @@
 - **Description:** Lists all the users in your Lever account. Only active users are included by default.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/actions/users.ts)

--- a/integrations/lever/syncs/opportunities-applications.md
+++ b/integrations/lever/syncs/opportunities-applications.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all applications for a candidate in Lever
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Applications
 - **Scopes:** `applications:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-applications.ts)

--- a/integrations/lever/syncs/opportunities-feedbacks.md
+++ b/integrations/lever/syncs/opportunities-feedbacks.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all feedback forms for a candidate for every single opportunity
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `feedback:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-feedbacks.ts)

--- a/integrations/lever/syncs/opportunities-interviews.md
+++ b/integrations/lever/syncs/opportunities-interviews.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all interviews for every single opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `interviews:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-interviews.ts)

--- a/integrations/lever/syncs/opportunities-notes.md
+++ b/integrations/lever/syncs/opportunities-notes.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all notes for every single opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Notes
 - **Scopes:** `notes:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-notes.ts)

--- a/integrations/lever/syncs/opportunities-offers.md
+++ b/integrations/lever/syncs/opportunities-offers.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all offers for every single opportunity
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Offers
 - **Scopes:** `offers:write:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities-offers.ts)

--- a/integrations/lever/syncs/opportunities.md
+++ b/integrations/lever/syncs/opportunities.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all opportunities
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `opportunities:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/opportunities.ts)

--- a/integrations/lever/syncs/postings-questions.md
+++ b/integrations/lever/syncs/postings-questions.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all questions included in a posting’s application form in Lever
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Postings
 - **Scopes:** `postings:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/postings-questions.ts)

--- a/integrations/lever/syncs/postings.md
+++ b/integrations/lever/syncs/postings.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all postings in Lever
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Postings
 - **Scopes:** `postings:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/postings.ts)

--- a/integrations/lever/syncs/stages.md
+++ b/integrations/lever/syncs/stages.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of all pipeline stages in Lever
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Stages
 - **Scopes:** `stages:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/lever/syncs/stages.ts)

--- a/integrations/linear/actions/create-issue.md
+++ b/integrations/linear/actions/create-issue.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create an issue in Linear
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Issues
 - **Scopes:** `issues:create`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear/actions/create-issue.ts)

--- a/integrations/linear/syncs/issues.md
+++ b/integrations/linear/syncs/issues.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of issues from Linear
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Issues
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear/syncs/issues.ts)

--- a/integrations/linear/syncs/milestones.md
+++ b/integrations/linear/syncs/milestones.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of milesontes from Linear
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Milestones
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear/syncs/milestones.ts)

--- a/integrations/linear/syncs/projects.md
+++ b/integrations/linear/syncs/projects.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of projects from Linear
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Projects
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear/syncs/projects.ts)

--- a/integrations/linear/syncs/roadmaps.md
+++ b/integrations/linear/syncs/roadmaps.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of roadmaps from Linear
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Roadmaps
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear/syncs/roadmaps.ts)

--- a/integrations/linear/syncs/teams.md
+++ b/integrations/linear/syncs/teams.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of teams from Linear
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Teams
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/linear/syncs/teams.ts)

--- a/integrations/netsuite-tba/actions/credit-note-create.md
+++ b/integrations/netsuite-tba/actions/credit-note-create.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a credit note in Netsuite
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Credit Notes
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/credit-note-create.ts)

--- a/integrations/netsuite-tba/actions/credit-note-update.md
+++ b/integrations/netsuite-tba/actions/credit-note-update.md
@@ -5,7 +5,7 @@
 
 - **Description:** Updates a credit note in Netsuite
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Credit Notes
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/credit-note-update.ts)

--- a/integrations/netsuite-tba/actions/customer-create.md
+++ b/integrations/netsuite-tba/actions/customer-create.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a customer in Netsuite
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/customer-create.ts)

--- a/integrations/netsuite-tba/actions/customer-update.md
+++ b/integrations/netsuite-tba/actions/customer-update.md
@@ -5,7 +5,7 @@
 
 - **Description:** Updates a customer in Netsuite
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/customer-update.ts)

--- a/integrations/netsuite-tba/actions/invoice-create.md
+++ b/integrations/netsuite-tba/actions/invoice-create.md
@@ -6,7 +6,7 @@
 - **Description:** Creates an invoice in Netsuite
 
 - **Version:** 2.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/invoice-create.ts)

--- a/integrations/netsuite-tba/actions/invoice-update.md
+++ b/integrations/netsuite-tba/actions/invoice-update.md
@@ -6,7 +6,7 @@
 - **Description:** Updates an invoice in Netsuite
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/invoice-update.ts)

--- a/integrations/netsuite-tba/actions/payment-create.md
+++ b/integrations/netsuite-tba/actions/payment-create.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a payment in Netsuite
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/payment-create.ts)

--- a/integrations/netsuite-tba/actions/payment-update.md
+++ b/integrations/netsuite-tba/actions/payment-update.md
@@ -5,7 +5,7 @@
 
 - **Description:** Updates a payment in Netsuite
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/actions/payment-update.ts)

--- a/integrations/netsuite-tba/syncs/credit-notes.md
+++ b/integrations/netsuite-tba/syncs/credit-notes.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all credit notes in Netsuite
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Credit Notes
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/syncs/credit-notes.ts)

--- a/integrations/netsuite-tba/syncs/customers.md
+++ b/integrations/netsuite-tba/syncs/customers.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all customers in Netsuite
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/syncs/customers.ts)

--- a/integrations/netsuite-tba/syncs/invoices.md
+++ b/integrations/netsuite-tba/syncs/invoices.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all invoices in Netsuite
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/syncs/invoices.ts)

--- a/integrations/netsuite-tba/syncs/payments.md
+++ b/integrations/netsuite-tba/syncs/payments.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all payments received from customers in Netsuite
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/syncs/payments.ts)

--- a/integrations/notion/actions/fetch-content-metadata.md
+++ b/integrations/notion/actions/fetch-content-metadata.md
@@ -7,7 +7,7 @@
 fetch-database or fetch-rich-page based on the type.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Contents
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion/actions/fetch-content-metadata.ts)

--- a/integrations/notion/actions/fetch-database.md
+++ b/integrations/notion/actions/fetch-database.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch a specific Notion database by passing in the database id. This action fetches the database and outputs an object. Note that this should be used for small databases.
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Databases
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion/actions/fetch-database.ts)

--- a/integrations/notion/actions/fetch-rich-page.md
+++ b/integrations/notion/actions/fetch-rich-page.md
@@ -8,7 +8,7 @@ and its content and converts it into a full markdown. It transforms images,
 tables, uploaded files, etc., into their markdown counterparts, providing a complete markdown.
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Pages
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion/actions/fetch-rich-page.ts)

--- a/integrations/notion/syncs/content-metadata.md
+++ b/integrations/notion/syncs/content-metadata.md
@@ -7,7 +7,7 @@
 using a dedicated action
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Contents
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion/syncs/content-metadata.ts)

--- a/integrations/notion/syncs/databases.md
+++ b/integrations/notion/syncs/databases.md
@@ -7,7 +7,7 @@
 database information in the metadata to be able to reconcile the database
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Databases
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion/syncs/databases.ts)

--- a/integrations/notion/syncs/users.md
+++ b/integrations/notion/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Notion
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/notion/syncs/users.ts)

--- a/integrations/okta/actions/add-user-group.md
+++ b/integrations/okta/actions/add-user-group.md
@@ -5,7 +5,7 @@
 
 - **Description:** Assigns a user to a group with the OKTA_GROUP type
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** User Groups
 - **Scopes:** `okta.groups.manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/add-user-group.ts)

--- a/integrations/okta/actions/create-user.md
+++ b/integrations/okta/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a new user in your Okta org without credentials.
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `okta.users.manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/create-user.ts)

--- a/integrations/okta/actions/remove-user-group.md
+++ b/integrations/okta/actions/remove-user-group.md
@@ -5,7 +5,7 @@
 
 - **Description:** Unassigns a user from a group with the OKTA_GROUP type
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** User Groups
 - **Scopes:** `okta.groups.manage`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/actions/remove-user-group.ts)

--- a/integrations/okta/syncs/users.md
+++ b/integrations/okta/syncs/users.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches lists users in your org
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `okta.users.read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/okta/syncs/users.ts)

--- a/integrations/pennylane/actions/create-customer.md
+++ b/integrations/pennylane/actions/create-customer.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a customer in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/create-customer.ts)

--- a/integrations/pennylane/actions/create-invoice.md
+++ b/integrations/pennylane/actions/create-invoice.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create an invoice in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/create-invoice.ts)

--- a/integrations/pennylane/actions/create-product.md
+++ b/integrations/pennylane/actions/create-product.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a product in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Products
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/create-product.ts)

--- a/integrations/pennylane/actions/create-supplier.md
+++ b/integrations/pennylane/actions/create-supplier.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a supplier in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Suppliers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/create-supplier.ts)

--- a/integrations/pennylane/actions/update-customer.md
+++ b/integrations/pennylane/actions/update-customer.md
@@ -6,7 +6,7 @@
 - **Description:** Action to update a supplier in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/update-customer.ts)

--- a/integrations/pennylane/actions/update-invoice.md
+++ b/integrations/pennylane/actions/update-invoice.md
@@ -6,7 +6,7 @@
 - **Description:** Action to update an invoice in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/update-invoice.ts)

--- a/integrations/pennylane/actions/update-product.md
+++ b/integrations/pennylane/actions/update-product.md
@@ -6,7 +6,7 @@
 - **Description:** Action to update a product in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Products
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/update-product.ts)

--- a/integrations/pennylane/actions/update-supplier.md
+++ b/integrations/pennylane/actions/update-supplier.md
@@ -6,7 +6,7 @@
 - **Description:** Action to update a supplier in pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Suppliers
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/actions/update-supplier.ts)

--- a/integrations/pennylane/syncs/customers.md
+++ b/integrations/pennylane/syncs/customers.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of customers from pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** `accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/syncs/customers.ts)

--- a/integrations/pennylane/syncs/invoices.md
+++ b/integrations/pennylane/syncs/invoices.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of customer invoices from pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `customer_invoices`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/syncs/invoices.ts)

--- a/integrations/pennylane/syncs/products.md
+++ b/integrations/pennylane/syncs/products.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list products from pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Products
 - **Scopes:** `accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/syncs/products.ts)

--- a/integrations/pennylane/syncs/suppliers.md
+++ b/integrations/pennylane/syncs/suppliers.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of suppliers from pennylane
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Suppliers
 - **Scopes:** `supplier_invoices`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/pennylane/syncs/suppliers.ts)

--- a/integrations/perimeter81/actions/create-user.md
+++ b/integrations/perimeter81/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Perimeter81
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/perimeter81/actions/create-user.ts)

--- a/integrations/perimeter81/actions/delete-user.md
+++ b/integrations/perimeter81/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Perimeter81
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/perimeter81/actions/delete-user.ts)

--- a/integrations/perimeter81/syncs/users.md
+++ b/integrations/perimeter81/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the list of users from Perimeter81
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/perimeter81/syncs/users.ts)

--- a/integrations/quickbooks/actions/create-account.md
+++ b/integrations/quickbooks/actions/create-account.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a single account in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-account.ts)

--- a/integrations/quickbooks/actions/create-credit-memo.md
+++ b/integrations/quickbooks/actions/create-credit-memo.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a single credit memo in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Credit Memos
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-credit-memo.ts)

--- a/integrations/quickbooks/actions/create-customer.md
+++ b/integrations/quickbooks/actions/create-customer.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a single customer in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-customer.ts)

--- a/integrations/quickbooks/actions/create-invoice.md
+++ b/integrations/quickbooks/actions/create-invoice.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a single invoice in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-invoice.ts)

--- a/integrations/quickbooks/actions/create-item.md
+++ b/integrations/quickbooks/actions/create-item.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a single item in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Items
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-item.ts)

--- a/integrations/quickbooks/actions/create-payment.md
+++ b/integrations/quickbooks/actions/create-payment.md
@@ -6,7 +6,7 @@
 - **Description:** Creates a single payment in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/create-payment.ts)

--- a/integrations/quickbooks/actions/update-account.md
+++ b/integrations/quickbooks/actions/update-account.md
@@ -6,7 +6,7 @@
 - **Description:** Updates a single account in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-account.ts)

--- a/integrations/quickbooks/actions/update-credit-memo.md
+++ b/integrations/quickbooks/actions/update-credit-memo.md
@@ -6,7 +6,7 @@
 - **Description:** Updates a single credit memo in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Credit Memos
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-credit-memo.ts)

--- a/integrations/quickbooks/actions/update-customer.md
+++ b/integrations/quickbooks/actions/update-customer.md
@@ -6,7 +6,7 @@
 - **Description:** Update a single customer in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-customer.ts)

--- a/integrations/quickbooks/actions/update-invoice.md
+++ b/integrations/quickbooks/actions/update-invoice.md
@@ -6,7 +6,7 @@
 - **Description:** Updates a single invoice in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-invoice.ts)

--- a/integrations/quickbooks/actions/update-item.md
+++ b/integrations/quickbooks/actions/update-item.md
@@ -6,7 +6,7 @@
 - **Description:** Update a single item in QuickBooks.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Items
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/actions/update-item.ts)

--- a/integrations/quickbooks/syncs/accounts.md
+++ b/integrations/quickbooks/syncs/accounts.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all accounts in QuickBooks. Handles both active and archived accounts, saving or deleting them based on their status.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/accounts.ts)

--- a/integrations/quickbooks/syncs/customers.md
+++ b/integrations/quickbooks/syncs/customers.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all QuickBooks customers. Handles both active and archived customers, saving or deleting them based on their status.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Customers
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/customers.ts)

--- a/integrations/quickbooks/syncs/invoices.md
+++ b/integrations/quickbooks/syncs/invoices.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all invoices in QuickBooks. Handles both active and voided invoices, saving or deleting them based on their status.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/invoices.ts)

--- a/integrations/quickbooks/syncs/items.md
+++ b/integrations/quickbooks/syncs/items.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all items in QuickBooks. Handles both active and archived items, saving or deleting them based on their status.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Items
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/items.ts)

--- a/integrations/quickbooks/syncs/payments.md
+++ b/integrations/quickbooks/syncs/payments.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all payments in QuickBooks. Handles both active and voided payments, saving or deleting them based on their status.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** `com.intuit.quickbooks.accounting`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/quickbooks/syncs/payments.ts)

--- a/integrations/ramp/actions/create-user.md
+++ b/integrations/ramp/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Ramp
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `users:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp/actions/create-user.ts)

--- a/integrations/ramp/actions/disable-user.md
+++ b/integrations/ramp/actions/disable-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Ramp by id
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `users:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp/actions/disable-user.ts)

--- a/integrations/ramp/syncs/users.md
+++ b/integrations/ramp/syncs/users.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of users from Ramp
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `users:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ramp/syncs/users.ts)

--- a/integrations/ring-central/actions/create-user.md
+++ b/integrations/ring-central/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in RingCentral
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `EditAccounts`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central/actions/create-user.ts)

--- a/integrations/ring-central/actions/delete-user.md
+++ b/integrations/ring-central/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in RingCentral
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `EditAccounts`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central/actions/delete-user.ts)

--- a/integrations/ring-central/syncs/users.md
+++ b/integrations/ring-central/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the list of users from RingCentral
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `ReadAccounts`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/ring-central/syncs/users.ts)

--- a/integrations/salesforce/actions/create-account.md
+++ b/integrations/salesforce/actions/create-account.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a single account in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-account.ts)

--- a/integrations/salesforce/actions/create-contact.md
+++ b/integrations/salesforce/actions/create-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a single contact in salesforce
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-contact.ts)

--- a/integrations/salesforce/actions/create-lead.md
+++ b/integrations/salesforce/actions/create-lead.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a single lead in salesforce
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-lead.ts)

--- a/integrations/salesforce/actions/create-opportunity.md
+++ b/integrations/salesforce/actions/create-opportunity.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a single opportunity in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/create-opportunity.ts)

--- a/integrations/salesforce/actions/delete-account.md
+++ b/integrations/salesforce/actions/delete-account.md
@@ -5,7 +5,7 @@
 
 - **Description:** Delete a single account in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-account.ts)

--- a/integrations/salesforce/actions/delete-contact.md
+++ b/integrations/salesforce/actions/delete-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Delete a single contact in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-contact.ts)

--- a/integrations/salesforce/actions/delete-lead.md
+++ b/integrations/salesforce/actions/delete-lead.md
@@ -5,7 +5,7 @@
 
 - **Description:** Delete a single lead in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-lead.ts)

--- a/integrations/salesforce/actions/delete-opportunity.md
+++ b/integrations/salesforce/actions/delete-opportunity.md
@@ -5,7 +5,7 @@
 
 - **Description:** Delete a single opportunity in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/delete-opportunity.ts)

--- a/integrations/salesforce/actions/update-account.md
+++ b/integrations/salesforce/actions/update-account.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a single account in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-account.ts)

--- a/integrations/salesforce/actions/update-contact.md
+++ b/integrations/salesforce/actions/update-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a single contact in salesforce
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-contact.ts)

--- a/integrations/salesforce/actions/update-lead.md
+++ b/integrations/salesforce/actions/update-lead.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a single lead in salesforce
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-lead.ts)

--- a/integrations/salesforce/actions/update-opportunity.md
+++ b/integrations/salesforce/actions/update-opportunity.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a single opportunity in salesforce
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/actions/update-opportunity.ts)

--- a/integrations/salesforce/syncs/accounts.md
+++ b/integrations/salesforce/syncs/accounts.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of accounts from salesforce
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** _None_
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/accounts.ts)

--- a/integrations/salesforce/syncs/contacts.md
+++ b/integrations/salesforce/syncs/contacts.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of contacts from salesforce
 
 - **Version:** 1.0.3
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/contacts.ts)

--- a/integrations/salesforce/syncs/leads.md
+++ b/integrations/salesforce/syncs/leads.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of leads from salesforce
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/leads.ts)

--- a/integrations/salesforce/syncs/opportunities.md
+++ b/integrations/salesforce/syncs/opportunities.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of opportunities from salesforce
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Opportunities
 - **Scopes:** `offline_access, api`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/salesforce/syncs/opportunities.ts)

--- a/integrations/slack/actions/send-message.md
+++ b/integrations/slack/actions/send-message.md
@@ -6,7 +6,7 @@
 - **Description:** An action that sends a message to a slack channel.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Messages
 - **Scopes:** `chat:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/slack/actions/send-message.ts)

--- a/integrations/slack/syncs/messages.md
+++ b/integrations/slack/syncs/messages.md
@@ -12,7 +12,7 @@ channels:read, and at least one of
 channels:history, groups:history, mpim:history, im:history
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Messages
 - **Scopes:** `channels:read, channels:history`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/slack/syncs/messages.ts)

--- a/integrations/stripe-app/syncs/subscriptions.md
+++ b/integrations/stripe-app/syncs/subscriptions.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of subscriptions
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Subscriptions
 - **Scopes:** `subscription_read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/stripe-app/syncs/subscriptions.ts)

--- a/integrations/unanet/actions/create-contact.md
+++ b/integrations/unanet/actions/create-contact.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a contact in the system
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/unanet/actions/create-contact.ts)

--- a/integrations/unanet/actions/create-lead.md
+++ b/integrations/unanet/actions/create-lead.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a lead with with information about the federal agency, the name, due date, posted date, solicitation number, naics category or categories, the city, state, country, and description.
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/unanet/actions/create-lead.ts)

--- a/integrations/unanet/actions/get-leads.md
+++ b/integrations/unanet/actions/get-leads.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch all leads
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/unanet/actions/get-leads.ts)

--- a/integrations/unanet/actions/update-lead.md
+++ b/integrations/unanet/actions/update-lead.md
@@ -5,7 +5,7 @@
 
 - **Description:** Update a lead with any changed information about the federal agency, the name, due date, posted date, solicitation number, naics category or categories, the city, state, country, and description.
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Leads
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/unanet/actions/update-lead.ts)

--- a/integrations/workable/actions/create-candidate.md
+++ b/integrations/workable/actions/create-candidate.md
@@ -6,7 +6,7 @@
 - **Description:** Action to create a candidate at the specified job
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Candidates
 - **Scopes:** `w_candidates`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/workable/actions/create-candidate.ts)

--- a/integrations/workable/syncs/candidates.md
+++ b/integrations/workable/syncs/candidates.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of candidates from workable
 
 - **Version:** 1.0.0
-- **Group:** Others
+- **Group:** Candidates
 - **Scopes:** `r_candidates`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/workable/syncs/candidates.ts)

--- a/integrations/xero/actions/create-contact.md
+++ b/integrations/xero/actions/create-contact.md
@@ -7,7 +7,7 @@
 Note: Does NOT check if these contacts already exist.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `accounting.contacts`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/create-contact.ts)

--- a/integrations/xero/actions/create-credit-note.md
+++ b/integrations/xero/actions/create-credit-note.md
@@ -7,7 +7,7 @@
 Note: Does NOT check if the credit note already exists.
 
 - **Version:** 1.0.3
-- **Group:** Others
+- **Group:** Credit Notes
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/create-credit-note.ts)

--- a/integrations/xero/actions/create-invoice.md
+++ b/integrations/xero/actions/create-invoice.md
@@ -7,7 +7,7 @@
 Note: Does NOT check if the invoice already exists.
 
 - **Version:** 1.0.3
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/create-invoice.ts)

--- a/integrations/xero/actions/create-item.md
+++ b/integrations/xero/actions/create-item.md
@@ -7,7 +7,7 @@
 Note: Does NOT check if the item already exists.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Items
 - **Scopes:** `accounting.settings`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/create-item.ts)

--- a/integrations/xero/actions/create-payment.md
+++ b/integrations/xero/actions/create-payment.md
@@ -7,7 +7,7 @@
 Note: Does NOT check if the payment already exists.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/create-payment.ts)

--- a/integrations/xero/actions/get-tenants.md
+++ b/integrations/xero/actions/get-tenants.md
@@ -7,7 +7,7 @@
 This can be used to set the metadata to the selected tenant.
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Tenants
 - **Scopes:** _None_
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/get-tenants.ts)

--- a/integrations/xero/actions/update-contact.md
+++ b/integrations/xero/actions/update-contact.md
@@ -6,7 +6,7 @@
 - **Description:** Updates one or multiple contacts in Xero. Only fields that are passed in are modified. If a field should not be changed, omit it in the input. The id field is mandatory.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `accounting.contacts`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/update-contact.ts)

--- a/integrations/xero/actions/update-credit-note.md
+++ b/integrations/xero/actions/update-credit-note.md
@@ -6,7 +6,7 @@
 - **Description:** Updates one or more credit notes in Xero.
 
 - **Version:** 1.0.3
-- **Group:** Others
+- **Group:** Credit Notes
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/update-credit-note.ts)

--- a/integrations/xero/actions/update-invoice.md
+++ b/integrations/xero/actions/update-invoice.md
@@ -9,7 +9,7 @@ invoice has been AUTHORISED it can't be deleted but you can set
 the status to VOIDED.
 
 - **Version:** 1.0.3
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/update-invoice.ts)

--- a/integrations/xero/actions/update-item.md
+++ b/integrations/xero/actions/update-item.md
@@ -6,7 +6,7 @@
 - **Description:** Updates one or more items in Xero.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Items
 - **Scopes:** `accounting.settings`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/actions/update-item.ts)

--- a/integrations/xero/syncs/accounts.md
+++ b/integrations/xero/syncs/accounts.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all accounts in Xero (chart of accounts). Incremental sync, detects deletes, metadata is not required.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Accounts
 - **Scopes:** `accounting.settings`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/syncs/accounts.ts)

--- a/integrations/xero/syncs/contacts.md
+++ b/integrations/xero/syncs/contacts.md
@@ -7,7 +7,7 @@
 Details: incremental sync, detects deletes, metadata is not required.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Contacts
 - **Scopes:** `accounting.contacts`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/syncs/contacts.ts)

--- a/integrations/xero/syncs/general-ledger.md
+++ b/integrations/xero/syncs/general-ledger.md
@@ -6,7 +6,7 @@
 - **Description:** Fetch all general ledger entries in Xero
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** General Ledger
 - **Scopes:** `accounting.journals.read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/syncs/general-ledger.ts)

--- a/integrations/xero/syncs/invoices.md
+++ b/integrations/xero/syncs/invoices.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all invoices in Xero. Incremental sync.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Invoices
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/syncs/invoices.ts)

--- a/integrations/xero/syncs/items.md
+++ b/integrations/xero/syncs/items.md
@@ -7,7 +7,7 @@
 required.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Items
 - **Scopes:** `accounting.settings`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/syncs/items.ts)

--- a/integrations/xero/syncs/payments.md
+++ b/integrations/xero/syncs/payments.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches all payments in Xero. Incremental sync.
 
 - **Version:** 1.0.2
-- **Group:** Others
+- **Group:** Payments
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/xero/syncs/payments.ts)

--- a/integrations/zendesk/actions/create-category.md
+++ b/integrations/zendesk/actions/create-category.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a category within the help center
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Categories
 - **Scopes:** `hc:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/actions/create-category.ts)

--- a/integrations/zendesk/actions/create-section.md
+++ b/integrations/zendesk/actions/create-section.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a section within a category in the help center
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Sections
 - **Scopes:** `hc:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/actions/create-section.ts)

--- a/integrations/zendesk/actions/create-ticket.md
+++ b/integrations/zendesk/actions/create-ticket.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create a Zendesk ticket
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Tickets
 - **Scopes:** `tickets:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/actions/create-ticket.ts)

--- a/integrations/zendesk/actions/create-user.md
+++ b/integrations/zendesk/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Create an admin or agent user in Zendesk. Defaults to agent if a role is not provided
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `users:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/actions/create-user.ts)

--- a/integrations/zendesk/actions/delete-user.md
+++ b/integrations/zendesk/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Delete a user in Zendesk
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `users:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/actions/delete-user.ts)

--- a/integrations/zendesk/syncs/categories.md
+++ b/integrations/zendesk/syncs/categories.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of help center categories
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Categories
 - **Scopes:** `hc:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/syncs/categories.ts)

--- a/integrations/zendesk/syncs/sections.md
+++ b/integrations/zendesk/syncs/sections.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of sections in Help center from Zendesk
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Sections
 - **Scopes:** `hc:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/syncs/sections.ts)

--- a/integrations/zendesk/syncs/tickets.md
+++ b/integrations/zendesk/syncs/tickets.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of tickets from Zendesk
 
 - **Version:** 1.0.1
-- **Group:** Others
+- **Group:** Tickets
 - **Scopes:** `tickets:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zendesk/syncs/tickets.ts)

--- a/integrations/zoom/actions/create-meeting.md
+++ b/integrations/zoom/actions/create-meeting.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a meeting in Zoom.
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Meetings
 - **Scopes:** `meeting:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/actions/create-meeting.ts)

--- a/integrations/zoom/actions/create-user.md
+++ b/integrations/zoom/actions/create-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Creates a user in Zoom. Requires Pro account or higher
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user:write, user:write:admin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/actions/create-user.ts)

--- a/integrations/zoom/actions/delete-meeting.md
+++ b/integrations/zoom/actions/delete-meeting.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a meeting in Zoom
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Meetings
 - **Scopes:** `meeting:write`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/actions/delete-meeting.ts)

--- a/integrations/zoom/actions/delete-user.md
+++ b/integrations/zoom/actions/delete-user.md
@@ -5,7 +5,7 @@
 
 - **Description:** Deletes a user in Zoom. Requires Pro account or higher
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user:write, user:write:admin`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/actions/delete-user.ts)

--- a/integrations/zoom/syncs/meetings.md
+++ b/integrations/zoom/syncs/meetings.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of meetings from Zoom
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Meetings
 - **Scopes:** `meeting:read`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/syncs/meetings.ts)

--- a/integrations/zoom/syncs/recording-files.md
+++ b/integrations/zoom/syncs/recording-files.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of recordings from Zoom
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Cloud Recordings
 - **Scopes:** `cloud_recording:read:list_user_recordings, cloud_recording:read:list_recording_files`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/syncs/recording-files.ts)

--- a/integrations/zoom/syncs/users.md
+++ b/integrations/zoom/syncs/users.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches a list of users from Zoom
 
 - **Version:** 0.0.1
-- **Group:** Others
+- **Group:** Users
 - **Scopes:** `user:read, user:read:admin`
 - **Endpoint Type:** Sync
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/zoom/syncs/users.ts)

--- a/scripts/generate-readmes.ts
+++ b/scripts/generate-readmes.ts
@@ -79,12 +79,14 @@ function generalInfo(scriptPath: string, endpointType: string, scriptConfig: any
         console.warn(`Warning: no description for ${scriptPath}`);
     }
 
+    const endpoints = Array.isArray(scriptConfig.endpoint) ? scriptConfig.endpoint : [scriptConfig.endpoint];
+
     return [
         `## General Information`,
         ``,
         `- **Description:** ${scriptConfig.description ?? ''}`,
         `- **Version:** ${scriptConfig.version ? scriptConfig.version : '0.0.1'}`,
-        `- **Group:** ${scriptConfig.group || 'Others'}`,
+        `- **Group:** ${endpoints[0].group || 'Others'}`,
         `- **Scopes:** ${scopes ? `\`${scopes}\`` : '_None_'}`,
         `- **Endpoint Type:** ${endpointType.slice(0, 1).toUpperCase()}${endpointType.slice(1)}`,
         `- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/${scriptPath}.ts)`,


### PR DESCRIPTION
## Describe your changes
Fixes group name in readmes where it wasn't generated correctly.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
