### PR TITLE
fix(linear): add project milestone and mapping logic

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -9147,6 +9147,7 @@ integrations:
                     group: Issues
                 scopes:
                     - issues:create
+                version: 1.0.0
         syncs:
             issues:
                 runs: every 5min

--- a/integrations/linear/actions/create-issue.md
+++ b/integrations/linear/actions/create-issue.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Create an issue in Linear
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Issues
 - **Scopes:** `issues:create`
 - **Endpoint Type:** Action

--- a/integrations/linear/actions/create-issue.ts
+++ b/integrations/linear/actions/create-issue.ts
@@ -27,8 +27,14 @@ export default async function runAction(nango: NangoAction, input: CreateIssue):
     `;
 
     const variables = {
-        input: parsedInput.data
+        input: {
+            ...parsedInput.data,
+            ...(parsedInput.data.milestoneId && {
+                projectMilestoneId: parsedInput.data.milestoneId
+            })
+        }
     };
+    delete variables.input.milestoneId;
 
     const config: ProxyConfiguration = {
         // https://studio.apollographql.com/public/Linear-API/variant/current/explorer

--- a/integrations/linear/fields/issue.ts
+++ b/integrations/linear/fields/issue.ts
@@ -30,4 +30,7 @@ export const issueFields = `
         id
         name
     }
+    projectMilestone {
+        id
+    }
 `;

--- a/integrations/linear/nango.yaml
+++ b/integrations/linear/nango.yaml
@@ -11,6 +11,7 @@ integrations:
                     group: Issues
                 scopes:
                     - issues:create
+                version: 1.0.0
         syncs:
             issues:
                 runs: every 5min


### PR DESCRIPTION
## Describe your changes
Add support for a milestone

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
