### PR TITLE
fix: add os type check on integrations scripts for better linux support

### DIFF
--- a/scripts/generate-integration-template-tests.bash
+++ b/scripts/generate-integration-template-tests.bash
@@ -8,6 +8,13 @@ pushd () {
 popd () {
     command popd "$@" > /dev/null
 }
+if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS
+    SED_CMD="sed -i ''"
+else
+    # Linux or others
+    SED_CMD="sed -i"
+fi
 
 # Check if pre-commit flag is set
 if [ -n "$npm_config_pre_commit" ]; then
@@ -37,7 +44,7 @@ for integration in "${integrations[@]}" ; do
     cp -r integrations/$integration $TEMP_DIRECTORY/nango-integrations
 
     mv $TEMP_DIRECTORY/nango-integrations/$integration/nango.yaml $TEMP_DIRECTORY/nango-integrations/nango.yaml
-    sed -i '' "s|\${PWD}|$integration|g" $TEMP_DIRECTORY/nango-integrations/nango.yaml
+    eval "$SED_CMD  's|\${PWD}|$integration|g' $TEMP_DIRECTORY/nango-integrations/nango.yaml"
 
     [ -f $TEMP_DIRECTORY/nango-integrations/*.ts ] && mv $TEMP_DIRECTORY/nango-integrations/*.ts $TEMP_DIRECTORY/nango-integrations/$integration/
 

--- a/scripts/run-integration-template.bash
+++ b/scripts/run-integration-template.bash
@@ -12,6 +12,14 @@ if [ -f .env ]; then
     export $(cat .env | xargs)
 fi
 
+if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS
+    SED_CMD="sed -i ''"
+else
+    # Linux or others
+    SED_CMD="sed -i"
+fi
+
 TEMP_DIRECTORY=tmp-run-integration-template
 
 NANGO_HOSTPORT_DEFAULT=https://api.nango.dev
@@ -63,7 +71,7 @@ mkdir -p $TEMP_DIRECTORY/nango-integrations
 cp -r integrations/$INTEGRATION $TEMP_DIRECTORY/nango-integrations
 
 mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/nango.yaml $TEMP_DIRECTORY/nango-integrations/nango.yaml
-sed -i '' "s|\${PWD}|$INTEGRATION|g" $TEMP_DIRECTORY/nango-integrations/nango.yaml
+eval "$SED_CMD 's|\${PWD}|$INTEGRATION|g' $TEMP_DIRECTORY/nango-integrations/nango.yaml"
 
 [ -f $TEMP_DIRECTORY/nango-integrations/*.ts ] && mv $TEMP_DIRECTORY/nango-integrations/*.ts $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/
 
@@ -81,7 +89,7 @@ fi
 for ((i=1; i<=ITERATIONS; i++)); do
     if $USE_ITERATIONS && [ -n "$INPUT_JSON" ] && [[ "$INPUT_JSON" == *.json ]]; then
         PRE_REPLACE_CONTENTS=$(cat $INPUT_JSON)
-        sed -i '' -e "s/\${iteration}/$i/g" "$INPUT_JSON"
+        eval "$SED_CMD -e 's/\${iteration}/$i/g' '$INPUT_JSON'"
     fi
 
     NANGO_MOCKS_RESPONSE_DIRECTORY="../../integrations/" NANGO_SECRET_KEY_DEV=$NANGO_SECRET_KEY_DEV NANGO_HOSTPORT=$NANGO_HOSTPORT npx nango $nango_command "$@"


### PR DESCRIPTION
## Describe your changes
update to check os type before running sed commands --  no windows comatibility yet
## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
