### PR TITLE
fix(jira): reduce pagination to 50

### DIFF
--- a/integrations/jira/syncs/projects.ts
+++ b/integrations/jira/syncs/projects.ts
@@ -23,7 +23,7 @@ export default async function fetchData(nango: NangoSync) {
             offset_name_in_request: 'startAt',
             response_path: 'values',
             limit_name_in_request: 'maxResults',
-            limit: 100
+            limit: 50
         },
         headers: {
             'X-Atlassian-Token': 'no-check'


### PR DESCRIPTION
## Describe your changes
Jira has a pagination issue with a limit over 50

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
