### PR TITLE
feat(netsuite): add journal-entry sync and mapping functionality

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -9501,6 +9501,18 @@ integrations:
                     method: GET
                     path: /locations
                 track_deletes: true
+            journal-entries:
+                version: 1.0.0
+                description: |
+                    Fetches all JournalEntries in Netsuite
+                runs: every hour
+                output: NetsuiteJournalEntry
+                sync_type: full
+                auto_start: true
+                endpoint:
+                    method: GET
+                    path: /journalEntry
+                track_deletes: true
         actions:
             customer-create:
                 version: 1.0.0
@@ -9753,6 +9765,28 @@ integrations:
                     country: string
                 timeZone: string
                 useBins: boolean
+            NetsuiteJournalEntry:
+                id: string
+                date: string
+                transactionId: string
+                void: boolean
+                approved: boolean
+                currency: string
+                createdDate: string
+                updatedDate: string
+                isReversal: boolean
+                subsidiary:
+                    id: string
+                    name: string
+                lines: NetsuiteJournalLine[]
+            NetsuiteJournalLine:
+                journalLineId: string
+                accountId: string
+                accountName: string
+                cleared: boolean
+                credit?: number
+                debit?: number
+                description: string
     next-cloud-ocs:
         syncs:
             users:

--- a/integrations/netsuite-tba/mappers/to-journal-entry.ts
+++ b/integrations/netsuite-tba/mappers/to-journal-entry.ts
@@ -1,0 +1,37 @@
+import type { NS_JournalEntry } from '../types';
+import type { NetsuiteJournalEntry, NetsuiteJournalLine } from '../../models';
+
+/**
+ * Maps a NetSuite journal entry to a unified journal entry format.
+ *
+ * @param entry - The NetSuite journal entry to be mapped.
+ * @returns The mapped unified journal entry.
+ */
+export function mapNetSuiteToUnified(entry: NS_JournalEntry): NetsuiteJournalEntry {
+    return {
+        id: entry.id,
+        date: new Date(entry.tranDate).toISOString(),
+        transactionId: entry.id,
+        void: entry.void,
+        approved: entry.approved,
+        currency: entry.currency?.refName ?? '',
+        createdDate: new Date(entry.createdDate).toISOString(),
+        updatedDate: new Date(entry.lastModifiedDate).toISOString(),
+        isReversal: entry.isReversal,
+        subsidiary: {
+            id: entry.subsidiary?.id ?? '',
+            name: entry.subsidiary?.refName ?? ''
+        },
+        lines: entry.line.items.map(
+            (line): NetsuiteJournalLine => ({
+                journalLineId: line.line.toString(),
+                accountId: line.account?.id ?? '',
+                accountName: line.account?.refName ?? '',
+                cleared: line.cleared,
+                credit: line.credit ?? 0,
+                debit: line.debit ?? 0,
+                description: line.memo ?? ''
+            })
+        )
+    };
+}

--- a/integrations/netsuite-tba/nango.yaml
+++ b/integrations/netsuite-tba/nango.yaml
@@ -75,6 +75,20 @@ integrations:
                     path: /locations
                 track_deletes: true
 
+            # JournalEntry
+            journal-entries:
+                version: 1.0.0
+                description: |
+                    Fetches all JournalEntries in Netsuite
+                runs: every hour
+                output: NetsuiteJournalEntry
+                sync_type: full
+                auto_start: true
+                endpoint:
+                    method: GET
+                    path: /journalEntry
+                track_deletes: true
+
         actions:
             # Customers
             customer-create:
@@ -332,3 +346,28 @@ models:
             country: string
         timeZone: string
         useBins: boolean
+
+    # JournalEntry
+    NetsuiteJournalEntry:
+        id: string
+        date: string
+        transactionId: string
+        void: boolean
+        approved: boolean
+        currency: string
+        createdDate: string
+        updatedDate: string
+        isReversal: boolean
+        subsidiary:
+            id: string
+            name: string
+        lines: NetsuiteJournalLine[]
+
+    NetsuiteJournalLine:
+        journalLineId: string
+        accountId: string
+        accountName: string
+        cleared: boolean
+        credit?: number
+        debit?: number
+        description: string

--- a/integrations/netsuite-tba/syncs/journal-entries.md
+++ b/integrations/netsuite-tba/syncs/journal-entries.md
@@ -1,0 +1,69 @@
+<!-- BEGIN GENERATED CONTENT -->
+# Journal Entries
+
+## General Information
+
+- **Description:** Fetches all JournalEntries in Netsuite
+
+- **Version:** 1.0.0
+- **Group:** Others
+- **Scopes:** _None_
+- **Endpoint Type:** Sync
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/netsuite-tba/syncs/journal-entries.ts)
+
+
+## Endpoint Reference
+
+### Request Endpoint
+
+`GET /journalEntry`
+
+### Request Query Parameters
+
+- **modified_after:** `(optional, string)` A timestamp (e.g., `2023-05-31T11:46:13.390Z`) used to fetch records modified after this date and time. If not provided, all records are returned. The modified_after parameter is less precise than cursor, as multiple records may share the same modification timestamp.
+- **limit:** `(optional, integer)` The maximum number of records to return per page. Defaults to 100.
+- **cursor:** `(optional, string)` A marker used to fetch records modified after a specific point in time.If not provided, all records are returned.Each record includes a cursor value found in _nango_metadata.cursor.Save the cursor from the last record retrieved to track your sync progress.Use the cursor parameter together with the limit parameter to paginate through records.The cursor is more precise than modified_after, as it can differentiate between records with the same modification timestamp.
+- **filter:** `(optional, added | updated | deleted)` Filter to only show results that have been added or updated or deleted.
+
+### Request Body
+
+_No request body_
+
+### Request Response
+
+```json
+{
+  "id": "<string>",
+  "date": "<string>",
+  "transactionId": "<string>",
+  "void": "<boolean>",
+  "approved": "<boolean>",
+  "currency": "<string>",
+  "createdDate": "<string>",
+  "updatedDate": "<string>",
+  "isReversal": "<boolean>",
+  "subsidiary": {
+    "id": "<string>",
+    "name": "<string>"
+  },
+  "lines": [
+    {
+      "journalLineId": "<string>",
+      "accountId": "<string>",
+      "accountName": "<string>",
+      "cleared": "<boolean>",
+      "credit?": "<number>",
+      "debit?": "<number>",
+      "description": "<string>"
+    }
+  ]
+}
+```
+
+## Changelog
+
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/netsuite-tba/syncs/journal-entries.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/netsuite-tba/syncs/journal-entries.md)
+
+<!-- END  GENERATED CONTENT -->
+

--- a/integrations/netsuite-tba/syncs/journal-entries.ts
+++ b/integrations/netsuite-tba/syncs/journal-entries.ts
@@ -1,0 +1,49 @@
+import type { NangoSync, NetsuiteJournalEntry, ProxyConfiguration } from '../../models';
+import type { NS_JournalEntry, NSAPI_GetResponse } from '../types';
+import { paginate } from '../helpers/pagination.js';
+import { mapNetSuiteToUnified } from '../mappers/to-journal-entry.js';
+
+const retries = 3;
+
+/**
+ * Fetches data from NetSuite and processes journal entries.
+ *
+ * This function uses the NangoSync instance to fetch journal entries from NetSuite,
+ * maps them to a unified format, and saves them in batches.
+ *
+ * @param {NangoSync} nango - The NangoSync instance used for fetching and logging data.
+ * @returns {Promise<void>} A promise that resolves when the data fetching and processing is complete.
+ *
+ * @remarks
+ * The function uses pagination to fetch journal entries in chunks. For each entry, it retrieves
+ * detailed information, maps it to a unified format, and saves the mapped entries in batches.
+ */
+
+export default async function fetchData(nango: NangoSync): Promise<void> {
+    const proxyConfig: ProxyConfiguration = {
+        // https://system.netsuite.com/help/helpcenter/en_US/APIs/REST_API_Browser/record/v1/2022.1/index.html#tag-journalEntry
+        endpoint: '/journalEntry',
+        retries
+    };
+    for await (const entries of paginate<{ id: string }>({ nango, proxyConfig })) {
+        await nango.log('Listed journalEntries', { total: entries.length });
+
+        const mappedEntries: NetsuiteJournalEntry[] = [];
+        for (const entryLink of entries) {
+            const nsJournalEntry: NSAPI_GetResponse<NS_JournalEntry> = await nango.get({
+                endpoint: `/journalentry/${entryLink.id}`,
+                params: {
+                    expandSubResources: 'true'
+                },
+                retries
+            });
+            if (!nsJournalEntry.data) {
+                await nango.log('Journal not found', { id: entryLink.id });
+                continue;
+            }
+            const mappedEntry: NetsuiteJournalEntry = mapNetSuiteToUnified(nsJournalEntry.data);
+            mappedEntries.push(mappedEntry);
+        }
+        await nango.batchSave<NetsuiteJournalEntry>(mappedEntries, 'NetsuiteJournalEntry');
+    }
+}

--- a/integrations/netsuite-tba/types.ts
+++ b/integrations/netsuite-tba/types.ts
@@ -183,3 +183,38 @@ interface NS_TimeZone {
     id: string;
     refName: string;
 }
+export interface NS_Reference {
+    id: string;
+    refName: string;
+}
+
+export interface NS_JournalLine {
+    line: number;
+    account: NS_Reference;
+    cleared: boolean;
+    credit?: number;
+    debit?: number;
+    memo?: string;
+    department?: NS_Reference;
+    location?: NS_Reference;
+}
+
+export interface NS_JournalEntry {
+    id: string;
+    tranDate: string;
+    void: boolean;
+    approved: boolean;
+    createdDate: string;
+    lastModifiedDate: string;
+    isReversal: boolean;
+    reversalDefer: boolean;
+    exchangeRate: number;
+    currency: NS_Reference;
+    subsidiary: NS_Reference;
+    customForm: NS_Reference;
+    postingPeriod: NS_Reference;
+    line: {
+        items: NS_JournalLine[];
+        totalResults?: number;
+    };
+}


### PR DESCRIPTION
## Describe your changes
Add Netsuite journalEntry sync and map data to a general format
## Issue ticket number and link
[EXT 447](https://linear.app/nango/issue/EXT-447/netsuite-general-ledger-sync)
## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
