### PR TITLE
fix(netsuite-tba): handle optional timeZone reference in location sync

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -9751,7 +9751,7 @@ integrations:
                 returnAddress:
                     addressText: string
                     country: string
-                timeZone?: string
+                timeZone?: string | null
                 useBins: boolean
     next-cloud-ocs:
         syncs:

--- a/flows.yaml
+++ b/flows.yaml
@@ -9751,7 +9751,7 @@ integrations:
                 returnAddress:
                     addressText: string
                     country: string
-                timeZone: string
+                timeZone?: string
                 useBins: boolean
     next-cloud-ocs:
         syncs:

--- a/integrations/netsuite-tba/nango.yaml
+++ b/integrations/netsuite-tba/nango.yaml
@@ -330,5 +330,5 @@ models:
         returnAddress:
             addressText: string
             country: string
-        timeZone?: string
+        timeZone?: string | null
         useBins: boolean

--- a/integrations/netsuite-tba/nango.yaml
+++ b/integrations/netsuite-tba/nango.yaml
@@ -330,5 +330,5 @@ models:
         returnAddress:
             addressText: string
             country: string
-        timeZone: string
+        timeZone?: string
         useBins: boolean

--- a/integrations/netsuite-tba/syncs/locations.md
+++ b/integrations/netsuite-tba/syncs/locations.md
@@ -50,7 +50,7 @@ _No request body_
     "addressText": "<string>",
     "country": "<string>"
   },
-  "timeZone": "<string>",
+  "timeZone?": "<string>",
   "useBins": "<boolean>"
 }
 ```

--- a/integrations/netsuite-tba/syncs/locations.md
+++ b/integrations/netsuite-tba/syncs/locations.md
@@ -50,7 +50,7 @@ _No request body_
     "addressText": "<string>",
     "country": "<string>"
   },
-  "timeZone?": "<string>",
+  "timeZone?": "<string | null>",
   "useBins": "<boolean>"
 }
 ```

--- a/integrations/netsuite-tba/syncs/locations.ts
+++ b/integrations/netsuite-tba/syncs/locations.ts
@@ -45,7 +45,7 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
                     addressText: location.data.returnAddress.addrText,
                     country: location.data.returnAddress.country.refName
                 },
-                timeZone: location.data.timeZone.refName,
+                timeZone: location.data.timeZone?.refName ?? null,
                 useBins: location.data.useBins
             };
 


### PR DESCRIPTION
## Describe your changes
update netsuite-tba locations sync to handle optional timeZone reference
## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
