### PR TITLE
fix(google-drive): id should be an object

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -4318,7 +4318,7 @@ integrations:
                 scopes: https://www.googleapis.com/auth/drive.readonly
         actions:
             fetch-document:
-                input: string
+                input: DocumentId
                 description: >
                     Fetches the content of a file given its ID, processes the data using
 
@@ -4328,12 +4328,14 @@ integrations:
                     string can be used to recreate the file in its original format using
                     an external tool.
                 output: string
-                version: 1.0.2
+                version: 2.0.0
                 endpoint:
                     method: GET
                     path: /fetch-document
                 scopes: https://www.googleapis.com/auth/drive.readonly
         models:
+            DocumentId:
+                id: string
             DocumentMetadata:
                 files: string[] | undefined
                 folders: string[] | undefined

--- a/integrations/google-drive/actions/fetch-document.md
+++ b/integrations/google-drive/actions/fetch-document.md
@@ -7,7 +7,7 @@
 a response stream, and encodes it into a base64 string. This base64-encoded
 string can be used to recreate the file in its original format using an external tool.
 
-- **Version:** 1.0.2
+- **Version:** 2.0.0
 - **Group:** Others
 - **Scopes:** `https://www.googleapis.com/auth/drive.readonly`
 - **Endpoint Type:** Action
@@ -27,7 +27,9 @@ _No request parameters_
 ### Request Body
 
 ```json
-"<string>"
+{
+  "id": "<string>"
+}
 ```
 
 ### Request Response

--- a/integrations/google-drive/actions/fetch-document.ts
+++ b/integrations/google-drive/actions/fetch-document.ts
@@ -1,4 +1,4 @@
-import type { NangoAction, ProxyConfiguration } from '../../models';
+import type { NangoAction, ProxyConfiguration, DocumentId } from '../../models';
 import type { GoogleDriveFileResponse } from '../types.js';
 import { mimeTypeMapping } from '../types.js';
 
@@ -14,15 +14,18 @@ import { mimeTypeMapping } from '../types.js';
  * @returns The base64-encoded content of the file.
  * @throws Error if the input is invalid, or if the file metadata or content retrieval fails.
  */
-export default async function runAction(nango: NangoAction, input: string): Promise<string> {
-    if (!input || typeof input !== 'string') {
-        throw new Error('Missing or invalid input: a file ID is required and should be a string');
+export default async function runAction(nango: NangoAction, input: DocumentId): Promise<string> {
+    if (!input || !input.id) {
+        throw new nango.ActionError({
+            message: 'Invalid input',
+            details: 'The input must be an object with an "id" property.'
+        });
     }
 
     // Fetch the file metadata first to get the MIME type
     const Config: ProxyConfiguration = {
         // https://developers.google.com/drive/api/reference/rest/v3/files/get
-        endpoint: `drive/v3/files/${input}`,
+        endpoint: `drive/v3/files/${input.id}`,
         params: {
             fields: 'id, name, mimeType',
             supportsAllDrives: 'true'

--- a/integrations/google-drive/nango.yaml
+++ b/integrations/google-drive/nango.yaml
@@ -25,18 +25,20 @@ integrations:
                 scopes: https://www.googleapis.com/auth/drive.readonly
         actions:
             fetch-document:
-                input: string
+                input: DocumentId
                 description: |
                     Fetches the content of a file given its ID, processes the data using
                     a response stream, and encodes it into a base64 string. This base64-encoded
                     string can be used to recreate the file in its original format using an external tool.
                 output: string
-                version: 1.0.2
+                version: 2.0.0
                 endpoint:
                     method: GET
                     path: /fetch-document
                 scopes: https://www.googleapis.com/auth/drive.readonly
 models:
+    DocumentId:
+        id: string
     DocumentMetadata:
         files: string[] | undefined
         folders: string[] | undefined


### PR DESCRIPTION
## Describe your changes
Take in an object instead of a string

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
