### PR TITLE
fix: Update basecamp docs to fix mintlify error

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -1764,8 +1764,8 @@ integrations:
                 runs: every 1 day
                 description: >
                     Syncs to-dos from Basecamp for the specified projects. Example of a
-                    metadata input Example: { projects: [ { projectId: 1234, todoSetId:
-                    9999 }, ... ] }
+                    metadata input Example: `{ projects: [ { projectId: 1234, todoSetId:
+                    9999 }, ... ] }`
                 sync_type: full
                 track_deletes: true
                 input: TodosMetadata

--- a/integrations/basecamp/nango.yaml
+++ b/integrations/basecamp/nango.yaml
@@ -22,7 +22,7 @@ integrations:
             todos:
                 runs: every 1 day
                 description: |
-                    Syncs to-dos from Basecamp for the specified projects. Example of a metadata input Example: { projects: [ { projectId: 1234, todoSetId: 9999 }, ... ] }
+                    Syncs to-dos from Basecamp for the specified projects. Example of a metadata input Example: `{ projects: [ { projectId: 1234, todoSetId: 9999 }, ... ] }`
                 sync_type: full
                 track_deletes: true
                 input: TodosMetadata

--- a/integrations/basecamp/syncs/todos.md
+++ b/integrations/basecamp/syncs/todos.md
@@ -3,7 +3,7 @@
 
 ## General Information
 
-- **Description:** Syncs to-dos from Basecamp for the specified projects. Example of a metadata input Example: { projects: [ { projectId: 1234, todoSetId: 9999 }, ... ] }
+- **Description:** Syncs to-dos from Basecamp for the specified projects. Example of a metadata input Example: `{ projects: [ { projectId: 1234, todoSetId: 9999 }, ... ] }`
 
 - **Version:** 0.0.1
 - **Group:** Todos


### PR DESCRIPTION
## Describe your changes
We were seeing a mintlify error in the main repo because it doesn't like inline json

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
