### PR TITLE
feat: Add sync input info to readmes

### DIFF
--- a/integrations/avalara/syncs/transactions.md
+++ b/integrations/avalara/syncs/transactions.md
@@ -203,6 +203,15 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "company": "<string>",
+  "backfillPeriodMs?": "<number>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/avalara/syncs/transactions.ts)

--- a/integrations/basecamp/syncs/todos.md
+++ b/integrations/basecamp/syncs/todos.md
@@ -45,6 +45,19 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "projects": [
+    {
+      "projectId": "<number>",
+      "todoSetId": "<number>"
+    }
+  ]
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/basecamp/syncs/todos.ts)

--- a/integrations/dropbox/syncs/files.md
+++ b/integrations/dropbox/syncs/files.md
@@ -39,6 +39,15 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "files": "<string[] | undefined>",
+  "folders": "<string[] | undefined>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/dropbox/syncs/files.ts)

--- a/integrations/github/syncs/list-files.md
+++ b/integrations/github/syncs/list-files.md
@@ -40,6 +40,16 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "owner": "<string>",
+  "repo": "<string>",
+  "branch": "<string>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/github/syncs/list-files.ts)

--- a/integrations/google-drive/syncs/documents.md
+++ b/integrations/google-drive/syncs/documents.md
@@ -47,6 +47,15 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "files": "<string[] | undefined>",
+  "folders": "<string[] | undefined>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/google-drive/syncs/documents.ts)

--- a/integrations/google-mail/syncs/emails.md
+++ b/integrations/google-mail/syncs/emails.md
@@ -53,6 +53,14 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "backfillPeriodMs": "<number>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/google-mail/syncs/emails.ts)

--- a/integrations/google/syncs/workspace-users.md
+++ b/integrations/google/syncs/workspace-users.md
@@ -52,6 +52,19 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "orgsToSync": [
+    {
+      "id": "<string>",
+      "path": "<string>"
+    }
+  ]
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/google/syncs/workspace-users.ts)

--- a/integrations/jira/syncs/issue-types.md
+++ b/integrations/jira/syncs/issue-types.md
@@ -40,6 +40,20 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "projectIdsToSync": [
+    {
+      "id": "<string>"
+    }
+  ],
+  "cloudId?": "<string>",
+  "baseUrl?": "<string>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/jira/syncs/issue-types.ts)

--- a/integrations/jira/syncs/issues.md
+++ b/integrations/jira/syncs/issues.md
@@ -63,6 +63,20 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "projectIdsToSync": [
+    {
+      "id": "<string>"
+    }
+  ],
+  "cloudId?": "<string>",
+  "baseUrl?": "<string>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/jira/syncs/issues.ts)

--- a/integrations/microsoft-teams/syncs/users.md
+++ b/integrations/microsoft-teams/syncs/users.md
@@ -58,6 +58,16 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "orgsToSync": [
+    "<string>"
+  ]
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/microsoft-teams/syncs/users.ts)

--- a/integrations/outlook/syncs/emails.md
+++ b/integrations/outlook/syncs/emails.md
@@ -53,6 +53,14 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "backfillPeriodMs": "<number>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/outlook/syncs/emails.ts)

--- a/integrations/salesforce/syncs/articles.md
+++ b/integrations/salesforce/syncs/articles.md
@@ -40,6 +40,16 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "customFields": [
+    "<string>"
+  ]
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/salesforce/syncs/articles.ts)

--- a/integrations/sharepoint-online/syncs/shared-sites-selection.md
+++ b/integrations/sharepoint-online/syncs/shared-sites-selection.md
@@ -49,6 +49,24 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "sharedSites": [
+    "<string>"
+  ],
+  "pickedFiles": [
+    {
+      "siteId": "<string>",
+      "fileIds": [
+        "<string>"
+      ]
+    }
+  ]
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/sharepoint-online/syncs/shared-sites-selection.ts)

--- a/integrations/sharepoint-online/syncs/user-files-selection.md
+++ b/integrations/sharepoint-online/syncs/user-files-selection.md
@@ -48,6 +48,24 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "sharedSites": [
+    "<string>"
+  ],
+  "pickedFiles": [
+    {
+      "siteId": "<string>",
+      "fileIds": [
+        "<string>"
+      ]
+    }
+  ]
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/sharepoint-online/syncs/user-files-selection.ts)

--- a/integrations/zoom/syncs/recording-files.md
+++ b/integrations/zoom/syncs/recording-files.md
@@ -52,6 +52,14 @@ _No request body_
 }
 ```
 
+### Expected Metadata
+
+```json
+{
+  "backfillPeriodDays": "<number>"
+}
+```
+
 ## Changelog
 
 - [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/zoom/syncs/recording-files.ts)

--- a/scripts/generate-readmes.ts
+++ b/scripts/generate-readmes.ts
@@ -66,8 +66,11 @@ function updateReadme(markdown: string, scriptName: string, scriptPath: string, 
         requestParams(endpointType),
         requestBody(scriptConfig, endpointType, models),
         requestResponse(scriptConfig, models),
+        expectedMetadata(scriptConfig, endpointType, models),
         changelog(scriptPath)
-    ].join('\n');
+    ]
+        .filter((lines) => lines !== undefined)
+        .join('\n');
 
     return `${generatedLines}\n${divider}\n${custom.trim()}\n`;
 }
@@ -151,6 +154,18 @@ function requestResponse(scriptConfig: any, models: any) {
     }
 
     return out.join('\n');
+}
+
+function expectedMetadata(scriptConfig: any, endpointType: string, models: any) {
+    if (endpointType === 'sync' && scriptConfig.input) {
+        const out = ['### Expected Metadata'];
+
+        const expanded = expandModels(scriptConfig.input, models);
+        const expandedLines = JSON.stringify(expanded, null, 2).split('\n');
+        out.push(``, `\`\`\`json`, ...expandedLines, `\`\`\``, ``);
+
+        return out.join('\n');
+    }
 }
 
 function changelog(scriptPath: string) {


### PR DESCRIPTION
## Describe your changes
Adds expected metadata segment to readmes

## Issue ticket number and link
See https://linear.app/nango/issue/NAN-2639/add-input-type-info-to-syncs

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
