### PR TITLE
feat(basecamp): add action to do a user lookup

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -1744,6 +1744,13 @@ integrations:
                 status: string
     basecamp:
         actions:
+            fetch-accounts:
+                description: Fetch account list and user information from Basecamp
+                endpoint:
+                    method: GET
+                    path: /accounts
+                    group: Accounts
+                output: UserInformation
             fetch-projects:
                 description: Fetch all projects from Basecamp
                 endpoint:
@@ -1776,6 +1783,20 @@ integrations:
                     path: /todos
                     group: Todos
         models:
+            UserInformation:
+                identity:
+                    id: number
+                    firstName: string
+                    lastName: string
+                    email: string
+                accounts: Account[]
+            Account:
+                id: number
+                name: string
+                product: string
+                href: string
+                app_href: string
+                hidden?: boolean
             BasecampProjectsResponse:
                 projects: BasecampProject[]
             BasecampCreateTodoInput:

--- a/integrations/basecamp/actions/fetch-accounts.md
+++ b/integrations/basecamp/actions/fetch-accounts.md
@@ -1,0 +1,57 @@
+<!-- BEGIN GENERATED CONTENT -->
+# Fetch Accounts
+
+## General Information
+
+- **Description:** Fetch account list and user information from Basecamp
+- **Version:** 0.0.1
+- **Group:** Accounts
+- **Scopes:** _None_
+- **Endpoint Type:** Action
+- **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/basecamp/actions/fetch-accounts.ts)
+
+
+## Endpoint Reference
+
+### Request Endpoint
+
+`GET /accounts`
+
+### Request Query Parameters
+
+_No request parameters_
+
+### Request Body
+
+_No request body_
+
+### Request Response
+
+```json
+{
+  "identity": {
+    "id": "<number>",
+    "firstName": "<string>",
+    "lastName": "<string>",
+    "email": "<string>"
+  },
+  "accounts": [
+    {
+      "id": "<number>",
+      "name": "<string>",
+      "product": "<string>",
+      "href": "<string>",
+      "app_href": "<string>",
+      "hidden?": "<boolean>"
+    }
+  ]
+}
+```
+
+## Changelog
+
+- [Script History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/basecamp/actions/fetch-accounts.ts)
+- [Documentation History](https://github.com/NangoHQ/integration-templates/commits/main/integrations/basecamp/actions/fetch-accounts.md)
+
+<!-- END  GENERATED CONTENT -->
+

--- a/integrations/basecamp/actions/fetch-accounts.ts
+++ b/integrations/basecamp/actions/fetch-accounts.ts
@@ -1,0 +1,24 @@
+import type { UserInformation, NangoAction, ProxyConfiguration } from '../../models';
+import type { BasecampAuthorizationResponse } from '../types';
+
+export default async function runAction(nango: NangoAction): Promise<UserInformation> {
+    const config: ProxyConfiguration = {
+        baseUrlOverride: 'https://launchpad.37signals.com',
+        // https://github.com/basecamp/api/blob/master/sections/authentication.md#get-authorization
+        endpoint: '/authorization.json',
+        retries: 10
+    };
+
+    const { data } = await nango.get<BasecampAuthorizationResponse>(config);
+    const { identity, accounts } = data;
+
+    return {
+        identity: {
+            id: identity.id,
+            email: identity.email_address,
+            firstName: identity.first_name,
+            lastName: identity.last_name
+        },
+        accounts
+    };
+}

--- a/integrations/basecamp/nango.yaml
+++ b/integrations/basecamp/nango.yaml
@@ -1,6 +1,13 @@
 integrations:
     basecamp:
         actions:
+            fetch-accounts:
+                description: Fetch account list and user information from Basecamp
+                endpoint:
+                    method: GET
+                    path: /accounts
+                    group: Accounts
+                output: UserInformation
             fetch-projects:
                 description: Fetch all projects from Basecamp
                 endpoint:
@@ -34,6 +41,20 @@ integrations:
                     group: Todos
 
 models:
+    UserInformation:
+        identity:
+            id: number
+            firstName: string
+            lastName: string
+            email: string
+        accounts: Account[]
+    Account:
+        id: number
+        name: string
+        product: string
+        href: string
+        app_href: string
+        hidden?: boolean
     BasecampProjectsResponse:
         projects: BasecampProject[]
 

--- a/integrations/basecamp/types.ts
+++ b/integrations/basecamp/types.ts
@@ -1,0 +1,16 @@
+export interface BasecampAuthorizationResponse {
+    expires_at: string;
+    identity: {
+        id: number;
+        first_name: string;
+        last_name: string;
+        email_address: string;
+    };
+    accounts: {
+        product: string;
+        id: number;
+        name: string;
+        href: string;
+        app_href: string;
+    }[];
+}


### PR DESCRIPTION
## Describe your changes
Added so that our users can show an option for their users to select a particular account

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
