### PR TITLE
fix(scopes): add more explicit scopes

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -5647,6 +5647,21 @@ integrations:
                     method: GET
                     path: /properties
                     group: Properties
+                scopes:
+                    - oauth
+                    - media_bridge.read
+                    - crm.objects.marketing_events.write
+                    - crm.schemas.custom.read
+                    - crm.pipelines.orders.read
+                    - tickets
+                    - crm.objects.feedback_submissions.read
+                    - crm.objects.goals.read
+                    - crm.objects.custom.write
+                    - crm.objects.custom.read
+                    - crm.objects.marketing_events.read
+                    - timeline
+                    - e-commerce
+                    - automation
             create-property:
                 description: Create a property in Hubspot
                 input: CreatePropertyInput

--- a/integrations/hubspot/actions/fetch-properties.md
+++ b/integrations/hubspot/actions/fetch-properties.md
@@ -6,7 +6,7 @@
 - **Description:** Fetch the properties of a specified object
 - **Version:** 0.0.1
 - **Group:** Properties
-- **Scopes:** _None_
+- **Scopes:** `oauth, media_bridge.read, crm.objects.marketing_events.write, crm.schemas.custom.read, crm.pipelines.orders.read, tickets, crm.objects.feedback_submissions.read, crm.objects.goals.read, crm.objects.custom.write, crm.objects.custom.read, crm.objects.marketing_events.read, timeline, e-commerce, automation`
 - **Endpoint Type:** Action
 - **Code:** [github.com](https://github.com/NangoHQ/integration-templates/tree/main/integrations/hubspot/actions/fetch-properties.ts)
 

--- a/integrations/hubspot/nango.yaml
+++ b/integrations/hubspot/nango.yaml
@@ -149,6 +149,21 @@ integrations:
                     method: GET
                     path: /properties
                     group: Properties
+                scopes:
+                    - oauth
+                    - media_bridge.read
+                    - crm.objects.marketing_events.write
+                    - crm.schemas.custom.read
+                    - crm.pipelines.orders.read
+                    - tickets
+                    - crm.objects.feedback_submissions.read
+                    - crm.objects.goals.read
+                    - crm.objects.custom.write
+                    - crm.objects.custom.read
+                    - crm.objects.marketing_events.read
+                    - timeline
+                    - e-commerce
+                    - automation
             create-property:
                 description: Create a property in Hubspot
                 input: CreatePropertyInput


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
