### PR TITLE
fix(integration): always dereference symbolic links when copying files

### DIFF
--- a/scripts/run-integration-template.bash
+++ b/scripts/run-integration-template.bash
@@ -68,7 +68,7 @@ shift
 
 rm -rf $TEMP_DIRECTORY
 mkdir -p $TEMP_DIRECTORY/nango-integrations
-cp -r integrations/$INTEGRATION $TEMP_DIRECTORY/nango-integrations
+cp -rL integrations/$INTEGRATION $TEMP_DIRECTORY/nango-integrations
 
 mv $TEMP_DIRECTORY/nango-integrations/$INTEGRATION/nango.yaml $TEMP_DIRECTORY/nango-integrations/nango.yaml
 eval "$SED_CMD 's|\${PWD}|$INTEGRATION|g' $TEMP_DIRECTORY/nango-integrations/nango.yaml"


### PR DESCRIPTION
## Describe your changes
Add dereference flag to copy(cp) command to ensure symbolic links are followed when running script in linux environments
