### PR TITLE
fix(confluence): confluence type issue

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -3057,6 +3057,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /pages
+                version: 1.0.0
         models:
             ConfluenceSpace:
                 id: string

--- a/flows.yaml
+++ b/flows.yaml
@@ -3071,13 +3071,12 @@ integrations:
             ConfluencePage:
                 id: string
                 title: string
-                type: string
                 status: string
                 authorId: string
                 createdAt: string
                 spaceId: string
-                parentId: string
-                parentType: string
+                parentId?: string | null
+                parentType: string | null
                 position: number
                 version:
                     createdAt: string
@@ -3085,9 +3084,12 @@ integrations:
                     number: number
                     minorEdit: boolean
                     authorId: string
-                body:
-                    storage: object
-                    atlas_doc_format: object
+                body?:
+                    storage?: Storage | undefined
+                    atlas_doc_format?: string | undefined
+            Storage:
+                value?: string | undefined
+                representation?: string | undefined
     datadog:
         actions:
             create-user:

--- a/integrations/confluence/nango.yaml
+++ b/integrations/confluence/nango.yaml
@@ -21,6 +21,7 @@ integrations:
                 endpoint:
                     method: GET
                     path: /pages
+                version: 1.0.0
 models:
     ConfluenceSpace:
         id: string

--- a/integrations/confluence/nango.yaml
+++ b/integrations/confluence/nango.yaml
@@ -35,13 +35,12 @@ models:
     ConfluencePage:
         id: string
         title: string
-        type: string
         status: string
         authorId: string
         createdAt: string
         spaceId: string
-        parentId: string
-        parentType: string
+        parentId?: string | null
+        parentType: string | null
         position: number
         version:
             createdAt: string
@@ -49,6 +48,9 @@ models:
             number: number
             minorEdit: boolean
             authorId: string
-        body:
-            storage: object
-            atlas_doc_format: object
+        body?:
+            storage?: Storage | undefined
+            atlas_doc_format?: string | undefined
+    Storage:
+        value?: string | undefined
+        representation?: string | undefined

--- a/integrations/confluence/syncs/pages.md
+++ b/integrations/confluence/syncs/pages.md
@@ -36,13 +36,12 @@ _No request body_
 {
   "id": "<string>",
   "title": "<string>",
-  "type": "<string>",
   "status": "<string>",
   "authorId": "<string>",
   "createdAt": "<string>",
   "spaceId": "<string>",
-  "parentId": "<string>",
-  "parentType": "<string>",
+  "parentId?": "<string | null>",
+  "parentType": "<string | null>",
   "position": "<number>",
   "version": {
     "createdAt": "<string>",
@@ -51,9 +50,9 @@ _No request body_
     "minorEdit": "<boolean>",
     "authorId": "<string>"
   },
-  "body": {
-    "storage": "<object>",
-    "atlas_doc_format": "<object>"
+  "body?": {
+    "storage?": "<Storage | undefined>",
+    "atlas_doc_format?": "<string | undefined>"
   }
 }
 ```

--- a/integrations/confluence/syncs/pages.md
+++ b/integrations/confluence/syncs/pages.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of pages from confluence
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** `read:page:confluence`
 - **Endpoint Type:** Sync

--- a/integrations/confluence/syncs/pages.ts
+++ b/integrations/confluence/syncs/pages.ts
@@ -1,4 +1,5 @@
 import type { NangoSync, ConfluencePage, ProxyConfiguration } from '../../models';
+import type { PageResponse } from '../types';
 
 export default async function fetchData(nango: NangoSync) {
     let totalRecords = 0;
@@ -23,12 +24,11 @@ export default async function fetchData(nango: NangoSync) {
     }
 }
 
-function mapConfluencePages(results: any[]): ConfluencePage[] {
-    return results.map((page: any) => {
+function mapConfluencePages(results: PageResponse[]): ConfluencePage[] {
+    return results.map((page: PageResponse) => {
         return {
             id: page.id,
             title: page.title,
-            type: page.type,
             status: page.status,
             authorId: page.authorId,
             createdAt: page.createdAt,
@@ -44,8 +44,8 @@ function mapConfluencePages(results: any[]): ConfluencePage[] {
                 authorId: page.version.authorId
             },
             body: {
-                storage: page.body.storage,
-                atlas_doc_format: page.body.atlas_doc_format
+                storage: page.body?.storage,
+                atlas_doc_format: page.body?.atlas_doc_format
             }
         };
     });

--- a/integrations/confluence/types.ts
+++ b/integrations/confluence/types.ts
@@ -1,0 +1,37 @@
+interface Version {
+    number: number;
+    message: string;
+    minorEdit: boolean;
+    authorId: string;
+    createdAt: string; // ISO date string
+}
+
+interface Links {
+    editui: string;
+    webui: string;
+    edituiv2: string;
+    tinyui: string;
+}
+
+export interface PageResponse {
+    parentType: string | null;
+    parentId: string | null;
+    ownerId: string;
+    lastOwnerId: string | null;
+    createdAt: string;
+    authorId: string;
+    position: number;
+    version: Version;
+    body?: {
+        storage?: {
+            value?: string;
+            representation?: string;
+        };
+        atlas_doc_format?: string;
+    };
+    status: string;
+    title: string;
+    spaceId: string;
+    id: string;
+    _links: Links;
+}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
