### PR TITLE
fix(basecamp): bump versions

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -1758,6 +1758,7 @@ integrations:
                     path: /projects
                     group: Projects
                 output: BasecampProjectsResponse
+                version: 1.0.0
             fetch-todolists:
                 description: >
                     Fetch all todolists in a project.Fetch your projects via the
@@ -1769,6 +1770,7 @@ integrations:
                     path: /todolists
                     group: Todolists
                 output: BasecampTodolistsResponse
+                version: 1.0.0
             create-todo:
                 description: >-
                     Create a new to-do in a specific project + list. Fetch your todolists
@@ -1780,6 +1782,7 @@ integrations:
                     group: Todos
                 input: BasecampCreateTodoInput
                 output: BasecampTodoResponse
+                version: 1.0.0
         syncs:
             todos:
                 runs: every 1 day
@@ -1796,6 +1799,7 @@ integrations:
                     method: GET
                     path: /todos
                     group: Todos
+                version: 1.0.0
         models:
             UserInformation:
                 identity:

--- a/integrations/basecamp/actions/create-todo.md
+++ b/integrations/basecamp/actions/create-todo.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Create a new to-do in a specific project + list. Fetch your todolists via the fetch-todolists action. Identify the list you want to add the todo to and retrieve the id from there.
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Todos
 - **Scopes:** _None_
 - **Endpoint Type:** Action

--- a/integrations/basecamp/actions/fetch-projects.md
+++ b/integrations/basecamp/actions/fetch-projects.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetch all projects from Basecamp
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Projects
 - **Scopes:** _None_
 - **Endpoint Type:** Action

--- a/integrations/basecamp/actions/fetch-todolists.md
+++ b/integrations/basecamp/actions/fetch-todolists.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetch all todolists in a project.Fetch your projects via the fetch-projects action, then locate the project's dock item where "name": "todoset". The id there is your todoSetId.
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Todolists
 - **Scopes:** _None_
 - **Endpoint Type:** Action

--- a/integrations/basecamp/nango.yaml
+++ b/integrations/basecamp/nango.yaml
@@ -15,15 +15,17 @@ integrations:
                     path: /projects
                     group: Projects
                 output: BasecampProjectsResponse
+                version: 1.0.0
             fetch-todolists:
                 description: |
-                  Fetch all todolists in a project.Fetch your projects via the fetch-projects action, then locate the project's dock item where "name": "todoset". The id there is your todoSetId.
+                    Fetch all todolists in a project.Fetch your projects via the fetch-projects action, then locate the project's dock item where "name": "todoset". The id there is your todoSetId.
                 input: BasecampFetchTodolistsInput
                 endpoint:
                     method: GET
                     path: /todolists
                     group: Todolists
                 output: BasecampTodolistsResponse
+                version: 1.0.0
             create-todo:
                 description: Create a new to-do in a specific project + list. Fetch your todolists via the fetch-todolists action. Identify the list you want to add the todo to and retrieve the id from there.
                 endpoint:
@@ -32,6 +34,7 @@ integrations:
                     group: Todos
                 input: BasecampCreateTodoInput
                 output: BasecampTodoResponse
+                version: 1.0.0
 
         syncs:
             todos:
@@ -47,6 +50,7 @@ integrations:
                     method: GET
                     path: /todos
                     group: Todos
+                version: 1.0.0
 
 models:
     UserInformation:

--- a/integrations/basecamp/syncs/todos.md
+++ b/integrations/basecamp/syncs/todos.md
@@ -5,7 +5,7 @@
 
 - **Description:** Syncs to-dos from Basecamp for the specified projects. Example of a metadata input Example: `{ projects: [ { projectId: 1234, todoSetId: 9999 }, ... ] }`
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Todos
 - **Scopes:** _None_
 - **Endpoint Type:** Sync


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
