### PR TITLE
fix(g-cal): tighten up types

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -4620,63 +4620,63 @@ integrations:
                 etag: string
                 id: string
                 status: string
-                htmlLink: string
-                created: string
-                updated: string
-                summary: string
-                description: string
-                location: string
-                colorId: string
-                creator:
-                    id: string
+                htmlLink?: string
+                created?: string
+                updated?: string
+                summary?: string
+                description?: string
+                location?: string
+                colorId?: string
+                creator?:
+                    id?: string
                     email: string
-                    displayName: string
-                    self: boolean
-                organizer:
-                    id: string
+                    displayName?: string
+                    self?: boolean
+                organizer?:
+                    id?: string
                     email: string
-                    displayName: string
-                    self: boolean
-                start:
-                    date: date
-                    dateTime: string
-                    timeZone: string
-                end:
-                    date: date
-                    string: string
-                    timeZone: string
-                endTimeUnspecified: boolean
-                recurrence:
+                    displayName?: string
+                    self?: boolean
+                start?:
+                    date?: string
+                    dateTime?: string
+                    timeZone?: string
+                end?:
+                    date?: string
+                    dateTime?: string
+                    timeZone?: string
+                endTimeUnspecified?: boolean
+                recurrence?:
                     - string
-                recurringEventId: string
-                originalStartTime:
-                    date: date
-                    dateTime: string
-                    timeZone: string
-                transparency: string
-                visibility: string
-                iCalUID: string
-                sequence: integer
-                attendees:
-                    - id: string
+                recurringEventId?: string
+                originalStartTime?:
+                    date?: string
+                    dateTime?: string
+                    timeZone?: string
+                transparency?: string
+                visibility?: string
+                iCalUID?: string
+                sequence?: integer
+                attendees?:
+                    - id?: string
                       email: string
-                      displayName: string
-                      organizer: boolean
-                      self: boolean
-                      resource: boolean
-                      optional: boolean
+                      displayName?: string
+                      organizer?: boolean
+                      self?: boolean
+                      resource?: boolean
+                      optional?: boolean
                       responseStatus: string
-                      comment: string
-                      additionalGuests: integer
-                attendeesOmitted: boolean
-                extendedProperties:
-                    private:
-                        key: string
-                    shared:
-                        key: string
-                hangoutLink: string
-                conferenceData:
-                    createRequest:
+                      comment?: string
+                      additionalGuests?: integer
+                attendeesOmitted?: boolean
+                extendedProperties?:
+                    private?:
+                        __string: string
+                    shared?:
+                        __string: string
+                hangoutLink?: string
+                conferenceData?:
+                    createRequest?:
                         requestId: string
                         conferenceSolutionKey:
                             type: string
@@ -4685,21 +4685,26 @@ integrations:
                     entryPoints:
                         - entryPointType: string
                           uri: string
-                          label: string
-                          pin: string
-                          accessCode: string
-                          meetingCode: string
-                          passcode: string
-                          password: string
+                          label?: string
+                          pin?: string
+                          accessCode?: string
+                          meetingCode?: string
+                          passcode?: string
+                          password?: string
+                          regionCode?: string
                     conferenceSolution:
                         key:
                             type: string
                         name: string
                         iconUri: string
                     conferenceId: string
-                    signature: string
-                    notes: string
-                gadget:
+                    signature?: string
+                    notes?: string
+                    parameters?:
+                        addOnParameters?:
+                            parameters:
+                                __string: string
+                gadget?:
                     type: string
                     title: string
                     link: string
@@ -4709,21 +4714,24 @@ integrations:
                     display: string
                     preferences:
                         key: string
-                anyoneCanAddSelf: boolean
-                guestsCanInviteOthers: boolean
-                guestsCanModify: boolean
-                guestsCanSeeOtherGuests: boolean
-                privateCopy: boolean
-                locked: boolean
-                reminders:
+                anyoneCanAddSelf?: boolean
+                guestsCanInviteOthers?: boolean
+                guestsCanModify?: boolean
+                guestsCanSeeOtherGuests?: boolean
+                privateCopy?: boolean
+                locked?: boolean
+                reminders?:
                     useDefault: boolean
-                    overrides:
+                    overrides?:
                         - method: string
                           minutes: integer
-                source:
+                outOfOfficeProperties?:
+                    autoDeclineMode: string
+                    declineMessage: string
+                source?:
                     url: string
                     title: string
-                workingLocationProperties:
+                workingLocationProperties?:
                     type: string
                     homeOffice: string
                     customLocation:
@@ -4734,13 +4742,13 @@ integrations:
                         floorSectionId: string
                         deskId: string
                         label: string
-                attachments:
+                attachments?:
                     - fileUrl: string
                       title: string
                       mimeType: string
                       iconLink: string
                       fileId: string
-                eventType: string
+                eventType?: string
     google-docs:
         actions:
             fetch-document:

--- a/integrations/google-calendar/nango.yaml
+++ b/integrations/google-calendar/nango.yaml
@@ -56,63 +56,63 @@ models:
         etag: string
         id: string
         status: string
-        htmlLink: string
-        created: string
-        updated: string
-        summary: string
-        description: string
-        location: string
-        colorId: string
-        creator:
-            id: string
+        htmlLink?: string
+        created?: string
+        updated?: string
+        summary?: string
+        description?: string
+        location?: string
+        colorId?: string
+        creator?:
+            id?: string
             email: string
-            displayName: string
-            self: boolean
-        organizer:
-            id: string
+            displayName?: string
+            self?: boolean
+        organizer?:
+            id?: string
             email: string
-            displayName: string
-            self: boolean
-        start:
-            date: date
-            dateTime: string
-            timeZone: string
-        end:
-            date: date
-            string: string
-            timeZone: string
-        endTimeUnspecified: boolean
-        recurrence:
+            displayName?: string
+            self?: boolean
+        start?:
+            date?: string
+            dateTime?: string
+            timeZone?: string
+        end?:
+            date?: string
+            dateTime?: string
+            timeZone?: string
+        endTimeUnspecified?: boolean
+        recurrence?:
             - string
-        recurringEventId: string
-        originalStartTime:
-            date: date
-            dateTime: string
-            timeZone: string
-        transparency: string
-        visibility: string
-        iCalUID: string
-        sequence: integer
-        attendees:
-            - id: string
+        recurringEventId?: string
+        originalStartTime?:
+            date?: string
+            dateTime?: string
+            timeZone?: string
+        transparency?: string
+        visibility?: string
+        iCalUID?: string
+        sequence?: integer
+        attendees?:
+            - id?: string
               email: string
-              displayName: string
-              organizer: boolean
-              self: boolean
-              resource: boolean
-              optional: boolean
+              displayName?: string
+              organizer?: boolean
+              self?: boolean
+              resource?: boolean
+              optional?: boolean
               responseStatus: string
-              comment: string
-              additionalGuests: integer
-        attendeesOmitted: boolean
-        extendedProperties:
-            private:
-                key: string
-            shared:
-                key: string
-        hangoutLink: string
-        conferenceData:
-            createRequest:
+              comment?: string
+              additionalGuests?: integer
+        attendeesOmitted?: boolean
+        extendedProperties?:
+            private?:
+                __string: string
+            shared?:
+                __string: string
+        hangoutLink?: string
+        conferenceData?:
+            createRequest?:
                 requestId: string
                 conferenceSolutionKey:
                     type: string
@@ -121,21 +121,26 @@ models:
             entryPoints:
                 - entryPointType: string
                   uri: string
-                  label: string
-                  pin: string
-                  accessCode: string
-                  meetingCode: string
-                  passcode: string
-                  password: string
+                  label?: string
+                  pin?: string
+                  accessCode?: string
+                  meetingCode?: string
+                  passcode?: string
+                  password?: string
+                  regionCode?: string
             conferenceSolution:
                 key:
                     type: string
                 name: string
                 iconUri: string
             conferenceId: string
-            signature: string
-            notes: string
-        gadget:
+            signature?: string
+            notes?: string
+            parameters?:
+                addOnParameters?:
+                    parameters:
+                        __string: string
+        gadget?:
             type: string
             title: string
             link: string
@@ -145,21 +150,24 @@ models:
             display: string
             preferences:
                 key: string
-        anyoneCanAddSelf: boolean
-        guestsCanInviteOthers: boolean
-        guestsCanModify: boolean
-        guestsCanSeeOtherGuests: boolean
-        privateCopy: boolean
-        locked: boolean
-        reminders:
+        anyoneCanAddSelf?: boolean
+        guestsCanInviteOthers?: boolean
+        guestsCanModify?: boolean
+        guestsCanSeeOtherGuests?: boolean
+        privateCopy?: boolean
+        locked?: boolean
+        reminders?:
             useDefault: boolean
-            overrides:
+            overrides?:
                 - method: string
                   minutes: integer
-        source:
+        outOfOfficeProperties?:
+            autoDeclineMode: string
+            declineMessage: string
+        source?:
             url: string
             title: string
-        workingLocationProperties:
+        workingLocationProperties?:
             type: string
             homeOffice: string
             customLocation:
@@ -170,10 +178,10 @@ models:
                 floorSectionId: string
                 deskId: string
                 label: string
-        attachments:
+        attachments?:
             - fileUrl: string
               title: string
               mimeType: string
               iconLink: string
               fileId: string
-        eventType: string
+        eventType?: string

--- a/integrations/google-calendar/syncs/events.md
+++ b/integrations/google-calendar/syncs/events.md
@@ -39,75 +39,75 @@ _No request body_
   "etag": "<string>",
   "id": "<string>",
   "status": "<string>",
-  "htmlLink": "<string>",
-  "created": "<string>",
-  "updated": "<string>",
-  "summary": "<string>",
-  "description": "<string>",
-  "location": "<string>",
-  "colorId": "<string>",
-  "creator": {
-    "id": "<string>",
+  "htmlLink?": "<string>",
+  "created?": "<string>",
+  "updated?": "<string>",
+  "summary?": "<string>",
+  "description?": "<string>",
+  "location?": "<string>",
+  "colorId?": "<string>",
+  "creator?": {
+    "id?": "<string>",
     "email": "<string>",
-    "displayName": "<string>",
-    "self": "<boolean>"
+    "displayName?": "<string>",
+    "self?": "<boolean>"
   },
-  "organizer": {
-    "id": "<string>",
+  "organizer?": {
+    "id?": "<string>",
     "email": "<string>",
-    "displayName": "<string>",
-    "self": "<boolean>"
+    "displayName?": "<string>",
+    "self?": "<boolean>"
   },
-  "start": {
-    "date": "<date>",
-    "dateTime": "<string>",
-    "timeZone": "<string>"
+  "start?": {
+    "date?": "<string>",
+    "dateTime?": "<string>",
+    "timeZone?": "<string>"
   },
-  "end": {
-    "date": "<date>",
-    "string": "<string>",
-    "timeZone": "<string>"
+  "end?": {
+    "date?": "<string>",
+    "dateTime?": "<string>",
+    "timeZone?": "<string>"
   },
-  "endTimeUnspecified": "<boolean>",
-  "recurrence": {
+  "endTimeUnspecified?": "<boolean>",
+  "recurrence?": {
     "0": "<string>"
   },
-  "recurringEventId": "<string>",
-  "originalStartTime": {
-    "date": "<date>",
-    "dateTime": "<string>",
-    "timeZone": "<string>"
+  "recurringEventId?": "<string>",
+  "originalStartTime?": {
+    "date?": "<string>",
+    "dateTime?": "<string>",
+    "timeZone?": "<string>"
   },
-  "transparency": "<string>",
-  "visibility": "<string>",
-  "iCalUID": "<string>",
-  "sequence": "<integer>",
-  "attendees": {
+  "transparency?": "<string>",
+  "visibility?": "<string>",
+  "iCalUID?": "<string>",
+  "sequence?": "<integer>",
+  "attendees?": {
     "0": {
-      "id": "<string>",
+      "id?": "<string>",
       "email": "<string>",
-      "displayName": "<string>",
-      "organizer": "<boolean>",
-      "self": "<boolean>",
-      "resource": "<boolean>",
-      "optional": "<boolean>",
+      "displayName?": "<string>",
+      "organizer?": "<boolean>",
+      "self?": "<boolean>",
+      "resource?": "<boolean>",
+      "optional?": "<boolean>",
       "responseStatus": "<string>",
-      "comment": "<string>",
-      "additionalGuests": "<integer>"
+      "comment?": "<string>",
+      "additionalGuests?": "<integer>"
     }
   },
-  "attendeesOmitted": "<boolean>",
-  "extendedProperties": {
-    "private": {
-      "key": "<string>"
+  "attendeesOmitted?": "<boolean>",
+  "extendedProperties?": {
+    "private?": {
+      "__string": "<string>"
     },
-    "shared": {
-      "key": "<string>"
+    "shared?": {
+      "__string": "<string>"
     }
   },
-  "hangoutLink": "<string>",
-  "conferenceData": {
-    "createRequest": {
+  "hangoutLink?": "<string>",
+  "conferenceData?": {
+    "createRequest?": {
       "requestId": "<string>",
       "conferenceSolutionKey": {
         "type": "<string>"
@@ -120,12 +120,13 @@ _No request body_
       "0": {
         "entryPointType": "<string>",
         "uri": "<string>",
-        "label": "<string>",
-        "pin": "<string>",
-        "accessCode": "<string>",
-        "meetingCode": "<string>",
-        "passcode": "<string>",
-        "password": "<string>"
+        "label?": "<string>",
+        "pin?": "<string>",
+        "accessCode?": "<string>",
+        "meetingCode?": "<string>",
+        "passcode?": "<string>",
+        "password?": "<string>",
+        "regionCode?": "<string>"
       }
     },
     "conferenceSolution": {
@@ -136,10 +137,17 @@ _No request body_
       "iconUri": "<string>"
     },
     "conferenceId": "<string>",
-    "signature": "<string>",
-    "notes": "<string>"
+    "signature?": "<string>",
+    "notes?": "<string>",
+    "parameters?": {
+      "addOnParameters?": {
+        "parameters": {
+          "__string": "<string>"
+        }
+      }
+    }
   },
-  "gadget": {
+  "gadget?": {
     "type": "<string>",
     "title": "<string>",
     "link": "<string>",
@@ -151,26 +159,30 @@ _No request body_
       "key": "<string>"
     }
   },
-  "anyoneCanAddSelf": "<boolean>",
-  "guestsCanInviteOthers": "<boolean>",
-  "guestsCanModify": "<boolean>",
-  "guestsCanSeeOtherGuests": "<boolean>",
-  "privateCopy": "<boolean>",
-  "locked": "<boolean>",
-  "reminders": {
+  "anyoneCanAddSelf?": "<boolean>",
+  "guestsCanInviteOthers?": "<boolean>",
+  "guestsCanModify?": "<boolean>",
+  "guestsCanSeeOtherGuests?": "<boolean>",
+  "privateCopy?": "<boolean>",
+  "locked?": "<boolean>",
+  "reminders?": {
     "useDefault": "<boolean>",
-    "overrides": {
+    "overrides?": {
       "0": {
         "method": "<string>",
         "minutes": "<integer>"
       }
     }
   },
-  "source": {
+  "outOfOfficeProperties?": {
+    "autoDeclineMode": "<string>",
+    "declineMessage": "<string>"
+  },
+  "source?": {
     "url": "<string>",
     "title": "<string>"
   },
-  "workingLocationProperties": {
+  "workingLocationProperties?": {
     "type": "<string>",
     "homeOffice": "<string>",
     "customLocation": {
@@ -184,7 +196,7 @@ _No request body_
       "label": "<string>"
     }
   },
-  "attachments": {
+  "attachments?": {
     "0": {
       "fileUrl": "<string>",
       "title": "<string>",
@@ -193,7 +205,7 @@ _No request body_
       "fileId": "<string>"
     }
   },
-  "eventType": "<string>"
+  "eventType?": "<string>"
 }
 ```
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
