### PR TITLE
fix(microsoft-teams): fix pagination and org unit

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -10303,6 +10303,7 @@ integrations:
                     path: /microsoft-teams/microsoft-org-unit
                 scopes:
                     - GroupMember.Read.All
+                version: 1.0.0
             users:
                 runs: every hour
                 description: |
@@ -10321,6 +10322,7 @@ integrations:
                     path: /microsoft-teams/microsoft-users
                 scopes:
                     - User.Read.All
+                version: 1.0.0
         models:
             Metadata:
                 orgsToSync: string[]

--- a/integrations/microsoft-teams/nango.yaml
+++ b/integrations/microsoft-teams/nango.yaml
@@ -15,6 +15,7 @@ integrations:
                     path: /microsoft-teams/microsoft-org-unit
                 scopes:
                     - GroupMember.Read.All
+                version: 1.0.0
             users:
                 runs: every hour
                 description: |
@@ -33,6 +34,7 @@ integrations:
                     path: /microsoft-teams/microsoft-users
                 scopes:
                     - User.Read.All
+                version: 1.0.0
 models:
     Metadata:
         orgsToSync: string[]

--- a/integrations/microsoft-teams/syncs/org-units.md
+++ b/integrations/microsoft-teams/syncs/org-units.md
@@ -8,7 +8,7 @@ Directory.
 Details: full refresh, support deletes, goes back all time, metadata
 is not required.
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** `GroupMember.Read.All`
 - **Endpoint Type:** Sync

--- a/integrations/microsoft-teams/syncs/org-units.ts
+++ b/integrations/microsoft-teams/syncs/org-units.ts
@@ -59,6 +59,8 @@ async function fetchAndUpdateOrgs(nango: NangoSync, initialEndpoint: string, run
 
         if (data['@odata.nextLink']) {
             endpoint = data['@odata.nextLink'];
+        } else {
+            break;
         }
     }
 }

--- a/integrations/microsoft-teams/syncs/users.md
+++ b/integrations/microsoft-teams/syncs/users.md
@@ -10,7 +10,7 @@ array of organization ids.
 Details: full refresh, doesn't support deletes, goes back all time,
 metadata is required.
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Others
 - **Scopes:** `User.Read.All`
 - **Endpoint Type:** Sync

--- a/integrations/microsoft-teams/syncs/users.ts
+++ b/integrations/microsoft-teams/syncs/users.ts
@@ -54,7 +54,7 @@ async function fetchAndUpdateUsers(nango: NangoSync, endpoint: string, runDelete
 
         const { data } = response;
 
-        if (!data.value) {
+        if (!data?.value) {
             await nango.log(`No ${runDelete ? 'deleted ' : ''}users found.`);
             break;
         }
@@ -109,6 +109,8 @@ async function fetchAndUpdateUsers(nango: NangoSync, endpoint: string, runDelete
 
         if (data['@odata.nextLink']) {
             endpoint = data['@odata.nextLink'];
+        } else {
+            break;
         }
     } while (endpoint);
 }


### PR DESCRIPTION
## Describe your changes
Fix pagination and null objects

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
