### PR TITLE
fix(compilation): remove schema usage

### DIFF
--- a/integrations/keeper-scim/actions/create-user.ts
+++ b/integrations/keeper-scim/actions/create-user.ts
@@ -1,5 +1,4 @@
-import type { NangoAction, ProxyConfiguration } from '../../models';
-import type { User, KeeperCreateUser } from '../.nango/schema';
+import type { NangoAction, User, KeeperCreateUser, ProxyConfiguration } from '../../models';
 import { toUser } from '../mappers/to-user.js';
 import { keeperCreateUserSchema } from '../schema.zod.js';
 import type { KeeperUser } from '../types';

--- a/integrations/zoom/actions/create-user.ts
+++ b/integrations/zoom/actions/create-user.ts
@@ -1,5 +1,4 @@
-import type { NangoAction, ProxyConfiguration } from '../../models';
-import type { ZoomCreateUser, User } from '../.nango/schema';
+import type { NangoAction, ProxyConfiguration, ZoomCreateUser, User } from '../../models';
 import type { ZoomCreatedUser } from '../types';
 import { createUserSchema } from '../schema.zod.js';
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
