### PR TITLE
fix(hubspot): clean up typing

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -6348,6 +6348,7 @@ integrations:
                     - timeline
                     - e-commerce
                     - automation
+                version: 1.0.0
             create-property:
                 description: Create a property in Hubspot
                 input: CreatePropertyInput
@@ -6604,10 +6605,10 @@ integrations:
             InputProperty:
                 name: string
             PropertyResponse:
-                result: Property
+                results: Property[]
             Property:
-                updatedAt: string
-                createdAt: string
+                createdAt?: string
+                updatedAt?: string
                 name: string
                 label: string
                 type: string
@@ -6620,14 +6621,17 @@ integrations:
                 externalOptions: boolean
                 hasUniqueValue: boolean
                 hidden: boolean
-                hubspotDefined: boolean
-                showCurrencySymbol: boolean
-                modificationMetadata:
-                    archivable: boolean
-                    readOnlyDefinition: boolean
-                    readOnlyValue: boolean
+                options?: any[]
+                hubspotDefined?: boolean
+                showCurrencySymbol?: boolean
+                modificationMetadata?:
+                    archivable?: boolean
+                    readOnlyDefinition?: boolean
+                    readOnlyValue?: boolean
+                    readOnlyOptions?: boolean
                 formField: boolean
                 dataSensitivity: string
+                __string: any
             Option:
                 label: string
                 value: string

--- a/integrations/hubspot/actions/fetch-properties.md
+++ b/integrations/hubspot/actions/fetch-properties.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetch the properties of a specified object
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Properties
 - **Scopes:** `oauth, media_bridge.read, crm.objects.marketing_events.write, crm.schemas.custom.read, crm.pipelines.orders.read, tickets, crm.objects.feedback_submissions.read, crm.objects.goals.read, crm.objects.custom.write, crm.objects.custom.read, crm.objects.marketing_events.read, timeline, e-commerce, automation`
 - **Endpoint Type:** Action
@@ -33,38 +33,45 @@ _No request parameters_
 
 ```json
 {
-  "result": {
-    "updatedAt": "<string>",
-    "createdAt": "<string>",
-    "name": "<string>",
-    "label": "<string>",
-    "type": "<string>",
-    "fieldType": "<string>",
-    "description": "<string>",
-    "groupName": "<string>",
-    "options": [
-      {
-        "label": "<string>",
-        "value": "<string>",
-        "displayOrder": "<number>",
-        "hidden": "<boolean>"
-      }
-    ],
-    "displayOrder": "<number>",
-    "calculated": "<boolean>",
-    "externalOptions": "<boolean>",
-    "hasUniqueValue": "<boolean>",
-    "hidden": "<boolean>",
-    "hubspotDefined": "<boolean>",
-    "showCurrencySymbol": "<boolean>",
-    "modificationMetadata": {
-      "archivable": "<boolean>",
-      "readOnlyDefinition": "<boolean>",
-      "readOnlyValue": "<boolean>"
-    },
-    "formField": "<boolean>",
-    "dataSensitivity": "<string>"
-  }
+  "results": [
+    {
+      "createdAt?": "<string>",
+      "updatedAt?": "<string>",
+      "name": "<string>",
+      "label": "<string>",
+      "type": "<string>",
+      "fieldType": "<string>",
+      "description": "<string>",
+      "groupName": "<string>",
+      "options": [
+        {
+          "label": "<string>",
+          "value": "<string>",
+          "displayOrder": "<number>",
+          "hidden": "<boolean>"
+        }
+      ],
+      "displayOrder": "<number>",
+      "calculated": "<boolean>",
+      "externalOptions": "<boolean>",
+      "hasUniqueValue": "<boolean>",
+      "hidden": "<boolean>",
+      "options?": [
+        "<any>"
+      ],
+      "hubspotDefined?": "<boolean>",
+      "showCurrencySymbol?": "<boolean>",
+      "modificationMetadata?": {
+        "archivable?": "<boolean>",
+        "readOnlyDefinition?": "<boolean>",
+        "readOnlyValue?": "<boolean>",
+        "readOnlyOptions?": "<boolean>"
+      },
+      "formField": "<boolean>",
+      "dataSensitivity": "<string>",
+      "__string": "<any>"
+    }
+  ]
 }
 ```
 

--- a/integrations/hubspot/nango.yaml
+++ b/integrations/hubspot/nango.yaml
@@ -164,6 +164,7 @@ integrations:
                     - timeline
                     - e-commerce
                     - automation
+                version: 1.0.0
             create-property:
                 description: Create a property in Hubspot
                 input: CreatePropertyInput
@@ -422,9 +423,10 @@ models:
     InputProperty:
         name: string
     PropertyResponse:
-        result: Property
+        results: Property[]
     Property:
-        __extends: Timestamps
+        createdAt?: string
+        updatedAt?: string
         name: string
         label: string
         type: string
@@ -437,14 +439,17 @@ models:
         externalOptions: boolean
         hasUniqueValue: boolean
         hidden: boolean
-        hubspotDefined: boolean
-        showCurrencySymbol: boolean
-        modificationMetadata:
-            archivable: boolean
-            readOnlyDefinition: boolean
-            readOnlyValue: boolean
+        options?: any[]
+        hubspotDefined?: boolean
+        showCurrencySymbol?: boolean
+        modificationMetadata?:
+            archivable?: boolean
+            readOnlyDefinition?: boolean
+            readOnlyValue?: boolean
+            readOnlyOptions?: boolean
         formField: boolean
         dataSensitivity: string
+        __string: any
     Option:
         label: string
         value: string


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
