### PR TITLE
fix(types): clean up types

### DIFF
--- a/integrations/box/actions/folder-content.ts
+++ b/integrations/box/actions/folder-content.ts
@@ -1,4 +1,4 @@
-import type { NangoAction, ProxyConfiguration } from '../../models';
+import type { NangoAction, FolderContentInput, FolderContent, ProxyConfiguration } from '../../models';
 
 /**
  * Fetches the top-level content (files and folders) of a Box folder.
@@ -10,14 +10,7 @@ import type { NangoAction, ProxyConfiguration } from '../../models';
  * @returns {Promise<object>} - A promise that resolves to the folder content with files, folders, and pagination info.
  * @throws {Error} - Throws an error if the API request fails.
  */
-export default async function runAction(
-    nango: NangoAction,
-    input: { id?: string; marker?: string } = {}
-): Promise<{
-    files: { id: string; name: string; download_url: string; modified_at: string }[];
-    folders: { id: string; name: string; modified_at: string; url: string | null }[];
-    next_marker?: string;
-}> {
+export default async function runAction(nango: NangoAction, input: FolderContentInput): Promise<FolderContent> {
     // Use folder ID if provided, otherwise use root folder (ID "0")
     const folderId = input.id || '0';
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
