### PR TITLE
fix(docs): batch save instead of return

### DIFF
--- a/.cursor/rules/nango-script-best-practices.mdc
+++ b/.cursor/rules/nango-script-best-practices.mdc
@@ -586,14 +586,12 @@ Example sync implementation:
 import type { NangoSync } from '@nangohq/node';
 import type { DynamicFieldMetadata, OutputData } from '../models.js';
 
-const SF_VERSION = 'v51.0';
+const SF_VERSION = 'v59.0';
 
 export default async function fetchData(
     nango: NangoSync,
     metadata: DynamicFieldMetadata
-): Promise<OutputData[]> {
-    const results: OutputData[] = [];
-    
+): Promise<void> {
     // Process each model configuration
     for (const config of metadata.configurations) {
         const { model, fields } = config;
@@ -604,13 +602,13 @@ export default async function fetchData(
         
         // Query Salesforce API using SOQL
         const response = await nango.get({
-            endpoint: `/services/data/v59.0/query`,
+            endpoint: `/services/data/${SF_VERSION}/query`,
             params: {
                 q: soqlQuery
             }
         });
 
-        // Map response to OutputData format
+        // Map response to OutputData format and save
         const mappedData = response.data.records.map(record => ({
             id: record.Id,
             model: model,
@@ -620,10 +618,9 @@ export default async function fetchData(
             }, {} as Record<string, any>)
         }));
 
-        results.push(...mappedData);
+        // Save the batch of records
+        await nango.batchSave(mappedData);
     }
-
-    return results;
 }
 ```
 

--- a/ADVANCED_INTEGRATION_SCRIPT_PATTERNS.md
+++ b/ADVANCED_INTEGRATION_SCRIPT_PATTERNS.md
@@ -86,14 +86,12 @@ Example sync implementation:
 import type { NangoSync } from '@nangohq/node';
 import type { DynamicFieldMetadata, OutputData } from '../models.js';
 
-const SF_VERSION = 'v51.0';
+const SF_VERSION = 'v59.0';
 
 export default async function fetchData(
     nango: NangoSync,
     metadata: DynamicFieldMetadata
-): Promise<OutputData[]> {
-    const results: OutputData[] = [];
-    
+): Promise<void> {
     // Process each model configuration
     for (const config of metadata.configurations) {
         const { model, fields } = config;
@@ -104,13 +102,13 @@ export default async function fetchData(
         
         // Query Salesforce API using SOQL
         const response = await nango.get({
-            endpoint: `/services/data/v59.0/query`,
+            endpoint: `/services/data/${SF_VERSION}/query`,
             params: {
                 q: soqlQuery
             }
         });
 
-        // Map response to OutputData format
+        // Map response to OutputData format and save
         const mappedData = response.data.records.map(record => ({
             id: record.Id,
             model: model,
@@ -120,10 +118,9 @@ export default async function fetchData(
             }, {} as Record<string, any>)
         }));
 
-        results.push(...mappedData);
+        // Save the batch of records
+        await nango.batchSave(mappedData);
     }
-
-    return results;
 }
 ```
 

--- a/rules-for-custom-nango-integrations/nango-best-practices.mdc
+++ b/rules-for-custom-nango-integrations/nango-best-practices.mdc
@@ -576,14 +576,12 @@ Example sync implementation:
 import type { NangoSync } from '@nangohq/node';
 import type { DynamicFieldMetadata, OutputData } from '../models.js';
 
-const SF_VERSION = 'v51.0';
+const SF_VERSION = 'v59.0';
 
 export default async function fetchData(
     nango: NangoSync,
     metadata: DynamicFieldMetadata
-): Promise<OutputData[]> {
-    const results: OutputData[] = [];
-    
+): Promise<void> {
     // Process each model configuration
     for (const config of metadata.configurations) {
         const { model, fields } = config;
@@ -594,13 +592,13 @@ export default async function fetchData(
         
         // Query Salesforce API using SOQL
         const response = await nango.get({
-            endpoint: `/services/data/v59.0/query`,
+            endpoint: `/services/data/${SF_VERSION}/query`,
             params: {
                 q: soqlQuery
             }
         });
 
-        // Map response to OutputData format
+        // Map response to OutputData format and save
         const mappedData = response.data.records.map(record => ({
             id: record.Id,
             model: model,
@@ -610,10 +608,9 @@ export default async function fetchData(
             }, {} as Record<string, any>)
         }));
 
-        results.push(...mappedData);
+        // Save the batch of records
+        await nango.batchSave(mappedData);
     }
-
-    return results;
 }
 ```
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/WRITING_INTEGRATION_SCRIPTS.md) doc
