### PR TITLE
fix(cursor): Fix cursor and document

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -104,3 +104,4 @@ reviews:
               - Only use `ActionError` for specific error messages:
               - Always return objects, not arrays
               - Always define API calls using a typed `ProxyConfiguration` object with retries set to 3:
+              - When implementing pagination in actions, always return a cursor-based response to allow users to paginate through results:

--- a/.cursor/rules/nango-script-best-practices.mdc
+++ b/.cursor/rules/nango-script-best-practices.mdc
@@ -290,6 +290,56 @@ const proxyConfig: ProxyConfiguration = {
 const { data } = await nango.get(proxyConfig);
 ```
 
+- When implementing pagination in actions, always return a cursor-based response to allow users to paginate through results:
+
+```typescript
+// ✅ Define input type with optional cursor
+interface ListUsersInput {
+    cursor?: string;
+    limit?: number;
+}
+
+// ✅ Define response type with next_cursor
+interface ListUsersResponse {
+    users: User[];
+    next_cursor?: string; // undefined means no more results
+}
+
+// ✅ Example action implementation with pagination
+export default async function runAction(
+    nango: NangoAction,
+    input: ListUsersInput
+): Promise<ListUsersResponse> {
+    const proxyConfig: ProxyConfiguration = {
+        endpoint: '/users',
+        params: {
+            limit: input.limit || 50,
+            cursor: input.cursor
+        },
+        retries: 3
+    };
+    
+    const { data } = await nango.get(proxyConfig);
+    
+    return {
+        users: data.users,
+        next_cursor: data.next_cursor // Pass through the API's cursor if available
+    };
+}
+
+// ❌ Don't paginate without returning a cursor
+export default async function runAction(
+    nango: NangoAction,
+    input: ListUsersInput
+): Promise<User[]> { // Wrong: Returns array without pagination info
+    const { data } = await nango.get({
+        endpoint: '/users',
+        params: { cursor: input.cursor }
+    });
+    return data.users;
+}
+```
+
 ```typescript
 // Complete action example:
 import type { NangoAction, ProxyConfiguration, FolderContentInput, FolderContent } from '../../models';

--- a/flows.yaml
+++ b/flows.yaml
@@ -3948,7 +3948,7 @@ integrations:
                     Fetches the top-level content (files and folders) of a Dropbox folder
                     given its path. If no path is provided, it fetches content from the
                     root folder.
-                version: 1.0.0
+                version: 2.0.0
                 endpoint:
                     method: POST
                     path: /folder-content
@@ -4016,7 +4016,7 @@ integrations:
             FolderContent:
                 files: Document[]
                 folders: Document[]
-                cursor?: string
+                next_cursor?: string
     evaluagent:
         syncs:
             users:
@@ -5470,6 +5470,7 @@ integrations:
 
                     If no folder ID is provided, it fetches content from the root folder.
                 output: FolderContent
+                version: 1.0.0
                 endpoint:
                     method: GET
                     path: /folder-content
@@ -5503,6 +5504,7 @@ integrations:
                     path: /drives
                     group: Drives
                 output: DriveListResponse
+                version: 1.0.0
                 scopes:
                     - https://www.googleapis.com/auth/drive.readonly
         models:
@@ -5573,7 +5575,7 @@ integrations:
             FolderContent:
                 files: GoogleDocument[]
                 folders: GoogleDocument[]
-                cursor?: string
+                next_cursor?: string
             Drive:
                 id: string
                 name: string
@@ -5614,7 +5616,7 @@ integrations:
                 cursor: string | undefined
             DriveListResponse:
                 drives: Drive[]
-                cursor: string | undefined
+                next_cursor: string | undefined
                 kind: string
     google-mail:
         syncs:

--- a/guides/WRITING_SCRIPTS.md
+++ b/guides/WRITING_SCRIPTS.md
@@ -281,6 +281,56 @@ const proxyConfig: ProxyConfiguration = {
 const { data } = await nango.get(proxyConfig);
 ```
 
+- When implementing pagination in actions, always return a cursor-based response to allow users to paginate through results:
+
+```typescript
+// ✅ Define input type with optional cursor
+interface ListUsersInput {
+    cursor?: string;
+    limit?: number;
+}
+
+// ✅ Define response type with next_cursor
+interface ListUsersResponse {
+    users: User[];
+    next_cursor?: string; // undefined means no more results
+}
+
+// ✅ Example action implementation with pagination
+export default async function runAction(
+    nango: NangoAction,
+    input: ListUsersInput
+): Promise<ListUsersResponse> {
+    const proxyConfig: ProxyConfiguration = {
+        endpoint: '/users',
+        params: {
+            limit: input.limit || 50,
+            cursor: input.cursor
+        },
+        retries: 3
+    };
+    
+    const { data } = await nango.get(proxyConfig);
+    
+    return {
+        users: data.users,
+        next_cursor: data.next_cursor // Pass through the API's cursor if available
+    };
+}
+
+// ❌ Don't paginate without returning a cursor
+export default async function runAction(
+    nango: NangoAction,
+    input: ListUsersInput
+): Promise<User[]> { // Wrong: Returns array without pagination info
+    const { data } = await nango.get({
+        endpoint: '/users',
+        params: { cursor: input.cursor }
+    });
+    return data.users;
+}
+```
+
 ```typescript
 // Complete action example:
 import type { NangoAction, ProxyConfiguration, FolderContentInput, FolderContent } from '../../models';

--- a/guides/rules-for-custom-nango-integrations/nango-best-practices.mdc
+++ b/guides/rules-for-custom-nango-integrations/nango-best-practices.mdc
@@ -292,6 +292,56 @@ const proxyConfig: ProxyConfiguration = {
 const { data } = await nango.get(proxyConfig);
 ```
 
+- When implementing pagination in actions, always return a cursor-based response to allow users to paginate through results:
+
+```typescript
+// ✅ Define input type with optional cursor
+interface ListUsersInput {
+    cursor?: string;
+    limit?: number;
+}
+
+// ✅ Define response type with next_cursor
+interface ListUsersResponse {
+    users: User[];
+    next_cursor?: string; // undefined means no more results
+}
+
+// ✅ Example action implementation with pagination
+export default async function runAction(
+    nango: NangoAction,
+    input: ListUsersInput
+): Promise<ListUsersResponse> {
+    const proxyConfig: ProxyConfiguration = {
+        endpoint: '/users',
+        params: {
+            limit: input.limit || 50,
+            cursor: input.cursor
+        },
+        retries: 3
+    };
+    
+    const { data } = await nango.get(proxyConfig);
+    
+    return {
+        users: data.users,
+        next_cursor: data.next_cursor // Pass through the API's cursor if available
+    };
+}
+
+// ❌ Don't paginate without returning a cursor
+export default async function runAction(
+    nango: NangoAction,
+    input: ListUsersInput
+): Promise<User[]> { // Wrong: Returns array without pagination info
+    const { data } = await nango.get({
+        endpoint: '/users',
+        params: { cursor: input.cursor }
+    });
+    return data.users;
+}
+```
+
 ```typescript
 // Complete action example:
 import type { NangoAction, ProxyConfiguration, FolderContentInput, FolderContent } from '../../models';

--- a/integrations/dropbox/.nango/schema.json
+++ b/integrations/dropbox/.nango/schema.json
@@ -120,7 +120,7 @@
                         "$ref": "#/definitions/Document"
                     }
                 },
-                "cursor": {
+                "next_cursor": {
                     "type": "string"
                 }
             },

--- a/integrations/dropbox/.nango/schema.ts
+++ b/integrations/dropbox/.nango/schema.ts
@@ -44,7 +44,7 @@ export interface FolderContentInput {
 export interface FolderContent {
     files: Document[];
     folders: Document[];
-    cursor?: string;
+    next_cursor?: string;
 }
 
 /** @deprecated It is recommended to use a Model */

--- a/integrations/dropbox/actions/folder-content.md
+++ b/integrations/dropbox/actions/folder-content.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetches the top-level content (files and folders) of a Dropbox folder given its path. If no path is provided, it fetches content from the root folder.
-- **Version:** 1.0.0
+- **Version:** 2.0.0
 - **Group:** Folders
 - **Scopes:** `files.metadata.read`
 - **Endpoint Type:** Action
@@ -50,7 +50,7 @@ _No request parameters_
       "modified_date": "<string>"
     }
   ],
-  "cursor?": "<string>"
+  "next_cursor?": "<string>"
 }
 ```
 

--- a/integrations/dropbox/actions/folder-content.ts
+++ b/integrations/dropbox/actions/folder-content.ts
@@ -75,6 +75,6 @@ export default async function runAction(nango: NangoAction, input: FolderContent
     return {
         folders,
         files,
-        ...(response.data.has_more ? { cursor: response.data.cursor } : {})
+        ...(response.data.has_more ? { next_cursor: response.data.cursor } : {})
     };
 }

--- a/integrations/dropbox/nango.yaml
+++ b/integrations/dropbox/nango.yaml
@@ -38,7 +38,7 @@ integrations:
             folder-content:
                 description: Fetches the top-level content (files and folders) of a Dropbox folder given its path.
                     If no path is provided, it fetches content from the root folder.
-                version: 1.0.0
+                version: 2.0.0
                 endpoint:
                     method: POST
                     path: /folder-content
@@ -113,4 +113,4 @@ models:
     FolderContent:
         files: Document[]
         folders: Document[]
-        cursor?: string
+        next_cursor?: string

--- a/integrations/google-drive/.nango/schema.json
+++ b/integrations/google-drive/.nango/schema.json
@@ -289,7 +289,7 @@
                         "$ref": "#/definitions/GoogleDocument"
                     }
                 },
-                "cursor": {
+                "next_cursor": {
                     "type": "string"
                 }
             },
@@ -432,7 +432,7 @@
                         "$ref": "#/definitions/Drive"
                     }
                 },
-                "cursor": {
+                "next_cursor": {
                     "type": "string"
                 },
                 "kind": {

--- a/integrations/google-drive/.nango/schema.ts
+++ b/integrations/google-drive/.nango/schema.ts
@@ -88,7 +88,7 @@ export interface FolderContentInput {
 export interface FolderContent {
     files: GoogleDocument[];
     folders: GoogleDocument[];
-    cursor?: string;
+    next_cursor?: string;
 }
 
 export interface DriveCapabilities {
@@ -139,7 +139,7 @@ export interface ListDrivesInput {
 
 export interface DriveListResponse {
     drives: Drive[];
-    cursor: string | undefined;
+    next_cursor: string | undefined;
     kind: string;
 }
 

--- a/integrations/google-drive/actions/fetch-document.md
+++ b/integrations/google-drive/actions/fetch-document.md
@@ -9,7 +9,7 @@ string can be used to recreate the file in its original format using an external
 If this is a native google file type then use the fetch-google-sheet or fetch-google-doc
 actions.
 
-- **Version:** 2.0.1
+- **Version:** 2.0.2
 - **Group:** Documents
 - **Scopes:** `https://www.googleapis.com/auth/drive.readonly`
 - **Endpoint Type:** Action

--- a/integrations/google-drive/actions/folder-content.md
+++ b/integrations/google-drive/actions/folder-content.md
@@ -6,7 +6,7 @@
 - **Description:** Fetches the top-level content (files and folders) of a folder given its ID.
 If no folder ID is provided, it fetches content from the root folder.
 
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Folders
 - **Scopes:** `https://www.googleapis.com/auth/drive.readonly`
 - **Endpoint Type:** Action
@@ -64,7 +64,7 @@ _No request parameters_
       "kind?": "<string>"
     }
   ],
-  "cursor?": "<string>"
+  "next_cursor?": "<string>"
 }
 ```
 

--- a/integrations/google-drive/actions/folder-content.ts
+++ b/integrations/google-drive/actions/folder-content.ts
@@ -64,6 +64,6 @@ export default async function runAction(nango: NangoAction, input: FolderContent
     return {
         folders,
         files,
-        ...(response.data.cursor ? { cursor: response.data.nextPageToken } : {})
+        ...(response.data.cursor ? { next_cursor: response.data.nextPageToken } : {})
     };
 }

--- a/integrations/google-drive/actions/list-drives.md
+++ b/integrations/google-drive/actions/list-drives.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Lists all shared drives the user has access to. Returns paginated results with up to 100 drives per page.
-- **Version:** 0.0.1
+- **Version:** 1.0.0
 - **Group:** Drives
 - **Scopes:** `https://www.googleapis.com/auth/drive.readonly`
 - **Endpoint Type:** Action
@@ -44,7 +44,7 @@ _No request parameters_
       "restrictions": "<DriveRestrictions | undefined>"
     }
   ],
-  "cursor": "<string | undefined>",
+  "next_cursor": "<string | undefined>",
   "kind": "<string>"
 }
 ```

--- a/integrations/google-drive/actions/list-drives.ts
+++ b/integrations/google-drive/actions/list-drives.ts
@@ -1,5 +1,5 @@
-import type { NangoAction, ProxyConfiguration } from '../../models';
-import type { DriveListResponse, ListDrivesInput } from '../types';
+import type { NangoAction, DriveListResponse, ProxyConfiguration } from '../../models';
+import type { ListDrivesInput } from '../types';
 
 /**
  * Lists all shared drives the user has access to.
@@ -27,7 +27,7 @@ export default async function runAction(nango: NangoAction, input?: ListDrivesIn
 
     return {
         drives: response.data.drives || [],
-        cursor: response.data.nextPageToken,
+        next_cursor: response.data.nextPageToken,
         kind: response.data.kind
     };
 }

--- a/integrations/google-drive/nango.yaml
+++ b/integrations/google-drive/nango.yaml
@@ -80,6 +80,7 @@ integrations:
                     Fetches the top-level content (files and folders) of a folder given its ID.
                     If no folder ID is provided, it fetches content from the root folder.
                 output: FolderContent
+                version: 1.0.0
                 endpoint:
                     method: GET
                     path: /folder-content
@@ -106,6 +107,7 @@ integrations:
                     path: /drives
                     group: Drives
                 output: DriveListResponse
+                version: 1.0.0
                 scopes:
                     - https://www.googleapis.com/auth/drive.readonly
 models:
@@ -172,7 +174,7 @@ models:
     FolderContent:
         files: GoogleDocument[]
         folders: GoogleDocument[]
-        cursor?: string
+        next_cursor?: string
     Drive:
         id: string
         name: string
@@ -217,5 +219,5 @@ models:
 
     DriveListResponse:
         drives: Drive[]
-        cursor: string | undefined
+        next_cursor: string | undefined
         kind: string

--- a/integrations/google-drive/syncs/documents.md
+++ b/integrations/google-drive/syncs/documents.md
@@ -13,7 +13,7 @@ by using the Google Picker API
 and using the ID field provided by the response
 (https://developers.google.com/drive/picker/reference/results)
 
-- **Version:** 3.0.0
+- **Version:** 3.0.1
 - **Group:** Documents
 - **Scopes:** `https://www.googleapis.com/auth/drive.readonly`
 - **Endpoint Type:** Sync

--- a/integrations/google-drive/syncs/folders.md
+++ b/integrations/google-drive/syncs/folders.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Sync the folders at the root level of a google drive.
-- **Version:** 1.0.0
+- **Version:** 1.0.1
 - **Group:** Folders
 - **Scopes:** `https://www.googleapis.com/auth/drive.readonly`
 - **Endpoint Type:** Sync


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
