### PR TITLE
fix(jira): throw error instead of logging when metadata is not found

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -9262,6 +9262,7 @@ integrations:
                 description: |
                     Fetches a list of issues from Jira
                 output: Issue
+                version: 1.0.1
                 sync_type: incremental
                 input: JiraIssueMetadata
                 auto_start: false
@@ -9287,6 +9288,7 @@ integrations:
                 runs: every day
                 description: Fetches a list of issue types for a project
                 output: IssueType
+                version: 1.0.1
                 scopes:
                     - read:jira-work
                 sync_type: full

--- a/integrations/jira/nango.yaml
+++ b/integrations/jira/nango.yaml
@@ -6,6 +6,7 @@ integrations:
                 description: |
                     Fetches a list of issues from Jira
                 output: Issue
+                version: 1.0.1
                 sync_type: incremental
                 input: JiraIssueMetadata
                 auto_start: false
@@ -31,6 +32,7 @@ integrations:
                 runs: every day
                 description: Fetches a list of issue types for a project
                 output: IssueType
+                version: 1.0.1
                 scopes:
                     - read:jira-work
                 sync_type: full

--- a/integrations/jira/syncs/issue-types.md
+++ b/integrations/jira/syncs/issue-types.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetches a list of issue types for a project
-- **Version:** 0.0.1
+- **Version:** 1.0.1
 - **Group:** Others
 - **Scopes:** `read:jira-work`
 - **Endpoint Type:** Sync

--- a/integrations/jira/syncs/issue-types.ts
+++ b/integrations/jira/syncs/issue-types.ts
@@ -35,7 +35,6 @@ export default async function fetchData(nango: NangoSync) {
             }
         }
     } else {
-        await nango.log('No IssueTypes to sync');
-        return;
+        throw new Error('No IssueTypes to sync');
     }
 }

--- a/integrations/jira/syncs/issues.md
+++ b/integrations/jira/syncs/issues.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches a list of issues from Jira
 
-- **Version:** 0.0.1
+- **Version:** 1.0.1
 - **Group:** Issues
 - **Scopes:** `read:jira-work`
 - **Endpoint Type:** Sync

--- a/integrations/jira/syncs/issues.ts
+++ b/integrations/jira/syncs/issues.ts
@@ -22,8 +22,7 @@ export default async function fetchData(nango: NangoSync) {
         const projectIdsString = metadata.projectIdsToSync.map((project) => `"${project.id.trim()}"`).join(',');
         projectJql = `project in (${projectIdsString})`;
     } else {
-        await nango.log('No projects to sync');
-        return;
+        throw new Error('No projects to sync');
     }
 
     const finalJql = jql ? `${jql}${projectJql ? ` AND ${projectJql}` : ''}` : projectJql;


### PR DESCRIPTION
## Describe your changes

- Throw error instead of logging when there is no metadata found

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
