### PR TITLE
chore(slack): add removeBlockIds function to clean message data

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -18819,7 +18819,7 @@ integrations:
                     - channels:read
                     - channels:join
             messages:
-                version: 1.0.2
+                version: 1.0.3
                 runs: every hour
                 description: |
                     Syncs Slack messages, thread replies and reactions from messages &

--- a/integrations/slack/nango.yaml
+++ b/integrations/slack/nango.yaml
@@ -33,7 +33,7 @@ integrations:
                     - channels:read
                     - channels:join
             messages:
-                version: 1.0.2
+                version: 1.0.3
                 runs: every hour
                 description: |
                     Syncs Slack messages, thread replies and reactions from messages &

--- a/integrations/slack/syncs/messages.md
+++ b/integrations/slack/syncs/messages.md
@@ -11,7 +11,7 @@ threads & reactions from the last 10 days. Scopes required:
 channels:read, and at least one of
 channels:history, groups:history, mpim:history, im:history
 
-- **Version:** 1.0.2
+- **Version:** 1.0.3
 - **Group:** Messages
 - **Scopes:** `channels:read, channels:history`
 - **Endpoint Type:** Sync

--- a/integrations/slack/syncs/messages.ts
+++ b/integrations/slack/syncs/messages.ts
@@ -192,23 +192,23 @@ async function saveReactions(nango: NangoSync, currentChannelId: string, message
     await nango.batchSave<SlackMessageReaction>(batchReactions, 'SlackMessageReaction');
 }
 
-function removeBlockIds<T>(data: T): T {
+function removeBlockIds(data: any): any {
     // The block_id is not reliable and could change between two runs of this sync causing the messages to show as updated
     // We remove it from the raw_json to avoid unnecessary updates.
     // This can be reinstated if required by removing this function.
     if (Array.isArray(data)) {
-        return data.map(removeBlockIds) as unknown as T;
+        return data.map(removeBlockIds);
     }
 
     if (data && typeof data === 'object' && data !== null) {
-        const newObj: { [key: string]: any } = {};
+        const newObj: Record<string, any> = {};
         for (const key of Object.keys(data)) {
             if (key === 'block_id') {
                 continue;
             }
-            newObj[key] = removeBlockIds((data as any)[key]);
+            newObj[key] = removeBlockIds(data[key]);
         }
-        return newObj as T;
+        return newObj;
     }
 
     return data;


### PR DESCRIPTION
## Describe your changes
### Summary

This PR addresses an issue in the Slack messages sync where messages were being unnecessarily marked as updated on every run. This was caused by the `block_id` field in the Slack API response, which is not stable and can change between
API calls.

To resolve this, we now remove the `block_id` from the message and reply payloads before they are stringified and saved to the `raw_json` field.

### Changes

-   **Removed `block_id` from `raw_json`**: Implemented logic to recursively find and delete the `block_id` from the `blocks` array, whether it's at the top level or nested within `attachments`.

## Issue ticket number and link
[EXT-748](https://linear.app/nango/issue/EXT-748/update-slack-messages-template-to-remove-block-id)

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
