### PR TITLE
fix(outlook): add pagination param

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -14038,6 +14038,7 @@ integrations:
                 runs: every hour
                 output: OutlookCalendar
                 sync_type: full
+                version: 1.0.0
                 endpoint:
                     method: GET
                     path: /calendars

--- a/integrations/outlook/.nango/nango.json
+++ b/integrations/outlook/.nango/nango.json
@@ -60,7 +60,7 @@
                 "sync_type": "full",
                 "usedModels": ["OutlookCalendar", "EmailAddress"],
                 "runs": "every hour",
-                "version": "",
+                "version": "1.0.0",
                 "track_deletes": true,
                 "auto_start": true,
                 "input": null,

--- a/integrations/outlook/nango.yaml
+++ b/integrations/outlook/nango.yaml
@@ -36,6 +36,7 @@ integrations:
                 runs: every hour
                 output: OutlookCalendar
                 sync_type: full
+                version: 1.0.0
                 endpoint:
                     method: GET
                     path: /calendars

--- a/integrations/outlook/syncs/calendars.ts
+++ b/integrations/outlook/syncs/calendars.ts
@@ -11,7 +11,8 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
             type: 'link',
             response_path: 'value',
             link_path_in_response_body: '@odata.nextLink',
-            limit: 100
+            limit: 100,
+            limit_name_in_request: '$top'
         },
         retries: 10
     };


### PR DESCRIPTION
## Describe your changes
fix pagination param

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
