### PR TITLE
fix(outlook): bring down paginate size

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -14027,7 +14027,7 @@ integrations:
                 output: OutlookCalendarEvent
                 sync_type: full
                 track_deletes: true
-                version: 1.0.0
+                version: 1.0.1
                 endpoint:
                     method: GET
                     path: /events

--- a/integrations/outlook/.nango/nango.json
+++ b/integrations/outlook/.nango/nango.json
@@ -39,7 +39,7 @@
                     "OptionalBackfillSetting"
                 ],
                 "runs": "every 5 minutes",
-                "version": "1.0.0",
+                "version": "1.0.1",
                 "track_deletes": true,
                 "auto_start": true,
                 "input": "OptionalBackfillSetting",

--- a/integrations/outlook/nango.yaml
+++ b/integrations/outlook/nango.yaml
@@ -24,7 +24,7 @@ integrations:
                 output: OutlookCalendarEvent
                 sync_type: full
                 track_deletes: true
-                version: 1.0.0
+                version: 1.0.1
                 endpoint:
                     method: GET
                     path: /events

--- a/integrations/outlook/syncs/events.ts
+++ b/integrations/outlook/syncs/events.ts
@@ -25,7 +25,7 @@ export default async function fetchData(nango: NangoSync): Promise<void> {
             type: 'link',
             response_path: 'value',
             link_path_in_response_body: '@odata.nextLink',
-            limit: 100,
+            limit: 50,
             limit_name_in_request: '$top'
         },
         retries: 10


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
