### PR TITLE
fix(xero): cleanup endpoint

### DIFF
--- a/flows.yaml
+++ b/flows.yaml
@@ -20292,11 +20292,11 @@ integrations:
                 sync_type: incremental
                 endpoint:
                     method: GET
-                    path: /BankTransactions
+                    path: /bank-transactions
                     group: Bank Transactions
                 scopes:
                     - accounting.transactions
-                version: 1.0.1
+                version: 2.0.0
             general-ledger:
                 description: |
                     Fetch all general ledger entries in Xero

--- a/integrations/xero/.nango/nango.json
+++ b/integrations/xero/.nango/nango.json
@@ -97,7 +97,7 @@
                 "sync_type": "incremental",
                 "usedModels": ["BankTransaction", "BankTransactionLineItem", "TrackingCategory"],
                 "runs": "every hour",
-                "version": "1.0.1",
+                "version": "2.0.0",
                 "track_deletes": false,
                 "auto_start": true,
                 "input": null,
@@ -106,7 +106,7 @@
                 "endpoints": [
                     {
                         "method": "GET",
-                        "path": "/BankTransactions",
+                        "path": "/bank-transactions",
                         "group": "Bank Transactions"
                     }
                 ],

--- a/integrations/xero/nango.yaml
+++ b/integrations/xero/nango.yaml
@@ -63,11 +63,11 @@ integrations:
                 sync_type: incremental
                 endpoint:
                     method: GET
-                    path: /BankTransactions
+                    path: /bank-transactions
                     group: Bank Transactions
                 scopes:
                     - accounting.transactions
-                version: 1.0.1
+                version: 2.0.0
             general-ledger:
                 description: |
                     Fetch all general ledger entries in Xero

--- a/integrations/xero/syncs/bank-transactions.md
+++ b/integrations/xero/syncs/bank-transactions.md
@@ -5,7 +5,7 @@
 
 - **Description:** Fetches all bank transactions in Xero. Incremental sync, detects deletes, metadata is not required.
 
-- **Version:** 1.0.1
+- **Version:** 2.0.0
 - **Group:** Bank Transactions
 - **Scopes:** `accounting.transactions`
 - **Endpoint Type:** Sync
@@ -17,7 +17,7 @@
 
 ### Request Endpoint
 
-`GET /BankTransactions`
+`GET /bank-transactions`
 
 ### Request Query Parameters
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
