### PR TITLE
fix(calendar): Add timeMin and timeMax which are configurable

### DIFF
--- a/integrations/google-calendar/.nango/nango.json
+++ b/integrations/google-calendar/.nango/nango.json
@@ -72,7 +72,7 @@
           "GoogleCalendarEvent",
           "SyncMetadata_google_calendar_events"
         ],
-        "version": "3.0.0",
+        "version": "4.0.0",
         "webhookSubscriptions": []
       },
       {

--- a/integrations/google-calendar/.nango/schema.json
+++ b/integrations/google-calendar/.nango/schema.json
@@ -10,6 +10,12 @@
             "type": "string"
           }
         },
+        "timeMin": {
+          "type": "string"
+        },
+        "timeMax": {
+          "type": "string"
+        },
         "singleEvents": {
           "type": "boolean"
         }

--- a/integrations/google-calendar/.nango/schema.ts
+++ b/integrations/google-calendar/.nango/schema.ts
@@ -5,6 +5,8 @@
 
 export interface SyncMetadata_google_calendar_events {
   calendarsToSync: string[];
+  timeMin?: string | undefined;
+  timeMax?: string | undefined;
   singleEvents?: boolean | undefined;
 };
 

--- a/integrations/google-calendar/models.ts
+++ b/integrations/google-calendar/models.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export const CalendarMetadata = z.object({
   calendarsToSync: z.string().optional().array(),
+  timeMin: z.string().optional(),
+  timeMax: z.string().optional(),
   singleEvents: z.boolean().optional()
 });
 

--- a/integrations/google-calendar/syncs/events.md
+++ b/integrations/google-calendar/syncs/events.md
@@ -5,7 +5,7 @@
 
 - **Description:** Sync calendar events on the primary calendar going back one month and
 save the entire object as specified by the Google API
-- **Version:** 3.0.0
+- **Version:** 4.0.0
 - **Group:** Events
 - **Scopes:** `https://www.googleapis.com/auth/calendar.readonly`
 - **Endpoint Type:** Sync
@@ -204,6 +204,8 @@ _No request body_
 ```json
 {
   "calendarsToSync": "<string[]>",
+  "timeMin?": "<string>",
+  "timeMax?": "<string>",
   "singleEvents?": "<boolean>"
 }
 ```

--- a/integrations/google-calendar/syncs/events.ts
+++ b/integrations/google-calendar/syncs/events.ts
@@ -7,7 +7,7 @@ import { GoogleCalendarEvent, CalendarMetadata } from '../models.js';
 
 const sync = createSync({
     description: 'Sync calendar events on the primary calendar going back one month and\nsave the entire object as specified by the Google API',
-    version: '3.0.0',
+    version: '4.0.0',
     frequency: 'every 5 minutes',
     autoStart: true,
     syncType: 'incremental',
@@ -31,11 +31,22 @@ const sync = createSync({
 
     exec: async (nango) => {
         const metadata = await nango.getMetadata();
+        const now = new Date();
+        const timeMin =
+            metadata?.timeMin ??
+            new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days back
+
+        const timeMax =
+            metadata?.timeMax ??
+            new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString(); // 12 months ahead
+
         const params: Record<string, string> = {
             maxResults: '100',
             // shows a calendar view of actual event instances
             // set to false to allow editing or canceling the full recurring series
-            singleEvents: metadata?.singleEvents?.toString() ?? 'true'
+            singleEvents: metadata?.singleEvents?.toString() ?? 'true',
+            timeMin,
+            timeMax
         };
 
         if (nango.lastSyncDate) {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
