### PR TITLE
fix(templates): use the correct directory

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,8 +35,8 @@ jobs:
               uses: tj-actions/changed-files@v41
               with:
                   files: |
-                      templates/*
-                      templates/**/*
+                      integrations/*
+                      integrations/**/*
 
             - name: Upload to S3 (Zero)
               if: steps.templates-updated.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
@@ -47,7 +47,7 @@ jobs:
               run: |
                   if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
                     echo "Manual trigger detected. Uploading all templates."
-                    dirs=$(find templates -maxdepth 1 -type d | tail -n +2 | sort)
+                    dirs=$(find integrations -maxdepth 1 -type d | tail -n +2 | sort)
                   else
                     echo "Automatic trigger detected. Uploading changed templates."
                     all_dirs=$(echo "${{ steps.templates-updated.outputs.all_changed_files }}" | cut -d'/' -f1,2 | sort -u)
@@ -55,7 +55,7 @@ jobs:
                     dirs=$(for dir in $all_dirs; do
                       integration=$(basename "$dir")
                       echo "$dir"
-                      find templates -maxdepth 1 -type d -name "$integration-*"
+                      find integrations -maxdepth 1 -type d -name "$integration-*"
                     done | sort -u)
                   fi
 
@@ -67,5 +67,5 @@ jobs:
                     fi
                     npm run cli -- $integration compile
                     aws s3 sync $dir s3://${{ secrets.AWS_BUCKET_NAME }}/templates-zero/$integration
-                    aws s3 sync templates/build s3://${{ secrets.AWS_BUCKET_NAME }}/templates-zero/$integration/build
+                    aws s3 sync integrations/build s3://${{ secrets.AWS_BUCKET_NAME }}/templates-zero/$integration/build
                   done


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
