### PR TITLE
fix(one-drive): remove download_url from sync model

### DIFF
--- a/integrations/one-drive/mappers/to-file.ts
+++ b/integrations/one-drive/mappers/to-file.ts
@@ -10,6 +10,8 @@ export function toFile(item: DriveItem, driveId: string): any {
     const isFolder = !!item.folder;
     const path = item.parentReference?.path ? `${item.parentReference.path}/${item.name}` : `/${item.name}`;
 
+    const { ['@microsoft.graph.downloadUrl']: _downloadUrl, ...sanitizedRaw } = item;
+
     return {
         id: item.id,
         name: item.name,
@@ -18,9 +20,8 @@ export function toFile(item: DriveItem, driveId: string): any {
         is_folder: isFolder,
         mime_type: item.file?.mimeType || null,
         path,
-        raw_source: item,
+        raw_source: sanitizedRaw,
         updated_at: item.lastModifiedDateTime,
-        download_url: item['@microsoft.graph.downloadUrl'] || null,
         created_at: item.createdDateTime,
         blob_size: item.size,
         drive_id: driveId

--- a/integrations/one-drive/models.ts
+++ b/integrations/one-drive/models.ts
@@ -10,7 +10,6 @@ export const OneDriveFile = z.object({
   path: z.string(),
   raw_source: z.object({}),
   updated_at: z.string(),
-  download_url: z.union([z.string(), z.null()]),
   created_at: z.string(),
   blob_size: z.number(),
   drive_id: z.string()
@@ -28,7 +27,6 @@ export const OneDriveFileSelection = z.object({
   path: z.string(),
   raw_source: z.object({}),
   updated_at: z.string(),
-  download_url: z.union([z.string(), z.null()]),
   created_at: z.string(),
   blob_size: z.number(),
   drive_id: z.string()

--- a/integrations/one-drive/schema.zod.ts
+++ b/integrations/one-drive/schema.zod.ts
@@ -10,7 +10,6 @@ export const oneDriveFileSchema = z.object({
     path: z.string(),
     raw_source: z.record(z.any()),
     updated_at: z.string(),
-    download_url: z.string().nullable(),
     created_at: z.string(),
     blob_size: z.number(),
     drive_id: z.string()

--- a/integrations/one-drive/syncs/user-files-selection.md
+++ b/integrations/one-drive/syncs/user-files-selection.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetch selected files from a user's OneDrive based on provided metadata.
-- **Version:** 1.0.0
+- **Version:** 1.0.1
 - **Group:** Files
 - **Scopes:** `Files.Read, Files.Read.All, offline_access`
 - **Endpoint Type:** Sync
@@ -43,7 +43,6 @@ _No request body_
   "path": "<string>",
   "raw_source": {},
   "updated_at": "<string>",
-  "download_url": "<string | null>",
   "created_at": "<string>",
   "blob_size": "<number>",
   "drive_id": "<string>"

--- a/integrations/one-drive/syncs/user-files-selection.ts
+++ b/integrations/one-drive/syncs/user-files-selection.ts
@@ -7,7 +7,7 @@ import { OneDriveFileSelection, OneDriveMetadata } from '../models.js';
 
 const sync = createSync({
     description: "Fetch selected files from a user's OneDrive based on provided metadata.",
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     syncType: 'full',

--- a/integrations/one-drive/syncs/user-files.md
+++ b/integrations/one-drive/syncs/user-files.md
@@ -4,7 +4,7 @@
 ## General Information
 
 - **Description:** Fetch all files from the user's OneDrive and sync the metadata for each file.
-- **Version:** 2.0.0
+- **Version:** 2.0.1
 - **Group:** Files
 - **Scopes:** `Files.Read, Files.Read.All, offline_access`
 - **Endpoint Type:** Sync
@@ -43,7 +43,6 @@ _No request body_
   "path": "<string>",
   "raw_source": {},
   "updated_at": "<string>",
-  "download_url": "<string | null>",
   "created_at": "<string>",
   "blob_size": "<number>",
   "drive_id": "<string>"

--- a/integrations/one-drive/syncs/user-files.ts
+++ b/integrations/one-drive/syncs/user-files.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 
 const sync = createSync({
     description: "Fetch all files from the user's OneDrive and sync the metadata for each file.",
-    version: '2.0.0',
+    version: '2.0.1',
     frequency: 'every hour',
     autoStart: true,
     syncType: 'full',


### PR DESCRIPTION
## Describe your changes
- Remove `download_url` from the response, as it always marks records as updated. Users can use the action instead to retrieve the `download_url`.
## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
