### PR TITLE
fix: deploy script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,13 +59,19 @@ jobs:
                     dirs=$(find integrations -maxdepth 1 -type d | tail -n +2 | sort)
                   else
                     echo "Automatic trigger detected. Uploading changed templates."
-                    all_dirs=$(echo "${{ steps.templates-updated.outputs.all_changed_files }}" | cut -d'/' -f1,2 | sort -u)
+                    all_files=$(echo "${{ steps.templates-updated.outputs.all_changed_files }}" | tr ' ' '\n')
+                    all_dirs=$(echo "$all_files" | cut -d'/' -f1,2 | sort -u)
 
-                    dirs=$(for dir in $all_dirs; do
-                      integration=$(basename "$dir")
-                      echo "$dir"
-                      find integrations -maxdepth 1 -type d -name "$integration-*"
-                    done | sort -u)
+                    if echo "$all_files" | grep -Eq '^integrations/[^/]+$|^integrations/\.nango/'; then
+                      echo "Shared integration files changed. Uploading all templates."
+                      dirs=$(find integrations -maxdepth 1 -type d | tail -n +2 | sort)
+                    else
+                      dirs=$(for dir in $all_dirs; do
+                        integration=$(basename "$dir")
+                        echo "$dir"
+                        find integrations -maxdepth 1 -type d -name "$integration-*"
+                      done | sort -u)
+                    fi
                   fi
 
                   for dir in $dirs; do
@@ -79,7 +85,7 @@ jobs:
                       continue
                     fi
 
-                    if [ ! -d "$dir/.nango" ]; then
+                    if [ ! -d "$dir/build" ]; then
                       continue
                     fi
 


### PR DESCRIPTION
## Describe your changes
Fixes a few issues with the deploy script
- Presence of .nango to validate whether a folder is an integration or not doesn't work anymore after we removed .nango folders from inside integrations. This was a hard failure-mode that broke the pipeline
- While investigating that I noticed that the string parsing is also broken and didn't work when a) only a shared file changed or b) multiple integrations changed

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc
