### PR TITLE
feat: update checkpoint handling in Airtable sync

### DIFF
--- a/integrations/airtable/syncs/bases.ts
+++ b/integrations/airtable/syncs/bases.ts
@@ -70,7 +70,7 @@ const sync = createSync({
                 }
             } while (offset);
 
-            await nango.clearCheckpoint();
+            await nango.saveCheckpoint({ offset: '' });
         } finally {
             await nango.trackDeletesEnd('Base');
         }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Save an empty checkpoint (`{ offset: '' }`) at the end of the Airtable bases sync instead of clearing it. This keeps pagination state predictable for the next run and avoids wiping metadata used by delete tracking.

<sup>Written for commit 5e79f197866f442ae5887ce545cb66ba48036431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

