### PR TITLE
feat: bump nango version to 0.70.1

### DIFF
--- a/integrations/package-lock.json
+++ b/integrations/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nango-integrations",
       "version": "1.0.0",
       "devDependencies": {
-        "nango": "0.69.46",
+        "nango": "0.70.1",
         "vitest": "4.0.15",
         "zod": "4.3.6"
       },
@@ -1760,16 +1760,6 @@
         }
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1809,9 +1799,9 @@
       }
     },
     "node_modules/@nangohq/nango-yaml": {
-      "version": "0.69.46",
-      "resolved": "https://registry.npmjs.org/@nangohq/nango-yaml/-/nango-yaml-0.69.46.tgz",
-      "integrity": "sha512-yOigWN+4/67eVvUF3ayIYjylHiUt+K3m2VZNpzRAKTNeD72Ebh2Z1hlh/zwP5whumQvGIRUkb81DQ7BJu865rQ==",
+      "version": "0.70.1",
+      "resolved": "https://registry.npmjs.org/@nangohq/nango-yaml/-/nango-yaml-0.70.1.tgz",
+      "integrity": "sha512-rvTU11ODe9b/ni9AgzWIzPjyUFmcAl3LbIYZ0EsLBnX8jvEw6g4aJAYtT9N65f3PSyZACDXyDfImN7x/s4gvZA==",
       "dev": true,
       "dependencies": {
         "js-yaml": "4.1.1",
@@ -1819,39 +1809,39 @@
       }
     },
     "node_modules/@nangohq/node": {
-      "version": "0.69.46",
-      "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.69.46.tgz",
-      "integrity": "sha512-5rLsspDKHnLgdVtN75v87vbMhESszUHbmOlvX00PMKxgZAV9t6dZWUHeHaD5/4UOSuRmFq9/eyOKJa8qFYuXiQ==",
+      "version": "0.70.1",
+      "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.70.1.tgz",
+      "integrity": "sha512-WupMNpp96GCCNTs5e5UtEoo/snpnJ6tGNPf58hXqDANwFuZG7ePdjN5giyH1AePoqi0QkcXNNHuqPtLZPr8z5g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
       "dependencies": {
-        "@nangohq/types": "0.69.46",
-        "axios": "1.13.5"
+        "@nangohq/types": "0.70.1",
+        "axios": "1.15.0"
       },
       "engines": {
         "node": ">=20.0"
       }
     },
     "node_modules/@nangohq/providers": {
-      "version": "0.69.46",
-      "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.69.46.tgz",
-      "integrity": "sha512-Fa/rp4A9hr3zRualscPWYBDEHCffuoegrcJ7KPs7TI6L+cVaGXZibWZfC5VK8vwQMXet/9GXzsfBO1iJYSgKPw==",
+      "version": "0.70.1",
+      "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.70.1.tgz",
+      "integrity": "sha512-kDOM8WyfExgheJIyBMT/E5uF+vjICWuInw1ZA1i3liAxrEdu6OMA1jL3jNYVBUpXO8G4eWTqWFKvXCBRFGwJQQ==",
       "dev": true,
       "dependencies": {
         "js-yaml": "4.1.1"
       }
     },
     "node_modules/@nangohq/runner-sdk": {
-      "version": "0.69.46",
-      "resolved": "https://registry.npmjs.org/@nangohq/runner-sdk/-/runner-sdk-0.69.46.tgz",
-      "integrity": "sha512-PM5Vx/mKV4tpSAnrkSnQDZKwRGLK07AXyq7edR0EMsJUUXe3Lq1J+72JGKnivtO/yKSKrfdEZPAZoTpsc4Xr9g==",
+      "version": "0.70.1",
+      "resolved": "https://registry.npmjs.org/@nangohq/runner-sdk/-/runner-sdk-0.70.1.tgz",
+      "integrity": "sha512-wiyMC0q7ubuZO/dfij8HtfccyCVFAqCE7GM3oFVvWzWdAJLEKOLQjEQFzLJ4Ho/S+/OLZXz4KEmRk0IIHMN+5Q==",
       "dev": true,
       "dependencies": {
-        "@nangohq/node": "0.69.46",
-        "@nangohq/providers": "0.69.46",
+        "@nangohq/node": "0.70.1",
+        "@nangohq/providers": "0.70.1",
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
-        "lodash-es": "4.17.23",
+        "lodash-es": "4.18.1",
         "parse-link-header": "2.0.0"
       },
       "peerDependencies": {
@@ -1859,13 +1849,13 @@
       }
     },
     "node_modules/@nangohq/types": {
-      "version": "0.69.46",
-      "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.46.tgz",
-      "integrity": "sha512-lN6EimkBqBO3zNftkCjwKSNT2F6WtS/ncOEq497y7n1+rxfse5Z77HHgDoK8sPO2sboYbwPgnDoT50ETub/eWg==",
+      "version": "0.70.1",
+      "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.70.1.tgz",
+      "integrity": "sha512-hcmlDwKK5rI2+KSroh4lz6BIH93mLiv9cRle8T3msrgILp14efB8FZVHHGS6UAUziKDtA6d1aS/SU8bUtgEo6Q==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
       "dependencies": {
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "json-schema": "0.4.0",
         "type-fest": "4.41.0"
       }
@@ -2439,13 +2429,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
@@ -2751,15 +2734,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3269,21 +3252,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/debounce-fn": {
       "version": "5.1.2",
@@ -3822,23 +3790,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -4315,13 +4266,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4330,22 +4274,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jake": {
@@ -4552,9 +4480,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -4780,9 +4708,9 @@
       }
     },
     "node_modules/nango": {
-      "version": "0.69.46",
-      "resolved": "https://registry.npmjs.org/nango/-/nango-0.69.46.tgz",
-      "integrity": "sha512-blWsYvIm9tbquSZ5/FfuBjE31mtgVh54oYP1W0Mqc0wG4kqtU3tqiXO5P4nx5dv2XFB85T8m0gRE3JMq8y7fyQ==",
+      "version": "0.70.1",
+      "resolved": "https://registry.npmjs.org/nango/-/nango-0.70.1.tgz",
+      "integrity": "sha512-Q+W4wxB1ko7jNYonXod6jgUe7UyARuQ6DYHvYcFWIXR+ViuqJxTkvfAP5W3knn5+/5qNchVl0/hWnH6IMOHlUA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
       "dependencies": {
@@ -4791,15 +4719,15 @@
         "@babel/preset-typescript": "7.27.1",
         "@babel/traverse": "7.28.0",
         "@babel/types": "7.28.2",
-        "@nangohq/nango-yaml": "0.69.46",
-        "@nangohq/node": "0.69.46",
-        "@nangohq/providers": "0.69.46",
-        "@nangohq/runner-sdk": "0.69.46",
+        "@nangohq/nango-yaml": "0.70.1",
+        "@nangohq/node": "0.70.1",
+        "@nangohq/providers": "0.70.1",
+        "@nangohq/runner-sdk": "0.70.1",
         "@swc/core": "1.13.2",
         "@types/unzipper": "0.10.11",
         "ajv": "8.18.0",
         "ajv-errors": "3.0.0",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "chalk": "5.4.1",
         "chokidar": "3.5.3",
         "columnify": "1.6.0",
@@ -4821,7 +4749,6 @@
         "promptly": "3.2.0",
         "semver": "7.5.4",
         "serialize-error": "11.0.3",
-        "ts-json-schema-generator": "2.4.0",
         "ts-node": "10.9.2",
         "tsup": "8.5.1",
         "typescript": "5.8.3",
@@ -5032,13 +4959,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parse-link-header": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
@@ -5067,16 +4987,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
@@ -5276,11 +5186,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/read": {
       "version": "1.0.7",
@@ -5460,16 +5373,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5551,29 +5454,6 @@
       "dependencies": {
         "kind-of": "^6.0.2"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5949,103 +5829,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/ts-json-schema-generator": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.4.0.tgz",
-      "integrity": "sha512-HbmNsgs58CfdJq0gpteRTxPXG26zumezOs+SB9tgky6MpqiFgQwieCn2MW70+sxpHouZ/w9LW0V6L4ZQO4y1Ug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "commander": "^13.1.0",
-        "glob": "^11.0.1",
-        "json5": "^2.2.3",
-        "normalize-path": "^3.0.0",
-        "safe-stable-stringify": "^2.5.0",
-        "tslib": "^2.8.1",
-        "typescript": "^5.8.2"
-      },
-      "bin": {
-        "ts-json-schema-generator": "bin/ts-json-schema-generator.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -7478,22 +7261,6 @@
       "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -12,7 +12,7 @@
     "test": "vitest"
   },
   "devDependencies": {
-    "nango": "0.69.46",
+    "nango": "0.70.1",
     "vitest": "4.0.15",
     "zod": "4.3.6"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "js-yaml": "4.1.0",
                 "lint-staged": "15.2.9",
                 "lodash-es": "^4.17.21",
-                "nango": "0.69.46",
+                "nango": "0.70.1",
                 "onchange": "7.1.0",
                 "parse-link-header": "^2.0.0",
                 "soap": "1.1.2",
@@ -3136,16 +3136,6 @@
                 }
             }
         },
-        "node_modules/@isaacs/cliui": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3526,16 +3516,16 @@
             }
         },
         "node_modules/@nangohq/runner-sdk": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/runner-sdk/-/runner-sdk-0.69.46.tgz",
-            "integrity": "sha512-PM5Vx/mKV4tpSAnrkSnQDZKwRGLK07AXyq7edR0EMsJUUXe3Lq1J+72JGKnivtO/yKSKrfdEZPAZoTpsc4Xr9g==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/runner-sdk/-/runner-sdk-0.70.1.tgz",
+            "integrity": "sha512-wiyMC0q7ubuZO/dfij8HtfccyCVFAqCE7GM3oFVvWzWdAJLEKOLQjEQFzLJ4Ho/S+/OLZXz4KEmRk0IIHMN+5Q==",
             "dev": true,
             "dependencies": {
-                "@nangohq/node": "0.69.46",
-                "@nangohq/providers": "0.69.46",
+                "@nangohq/node": "0.70.1",
+                "@nangohq/providers": "0.70.1",
                 "ajv": "8.18.0",
                 "ajv-formats": "3.0.1",
-                "lodash-es": "4.17.23",
+                "lodash-es": "4.18.1",
                 "parse-link-header": "2.0.0"
             },
             "peerDependencies": {
@@ -3543,50 +3533,50 @@
             }
         },
         "node_modules/@nangohq/runner-sdk/node_modules/@nangohq/node": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.69.46.tgz",
-            "integrity": "sha512-5rLsspDKHnLgdVtN75v87vbMhESszUHbmOlvX00PMKxgZAV9t6dZWUHeHaD5/4UOSuRmFq9/eyOKJa8qFYuXiQ==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.70.1.tgz",
+            "integrity": "sha512-WupMNpp96GCCNTs5e5UtEoo/snpnJ6tGNPf58hXqDANwFuZG7ePdjN5giyH1AePoqi0QkcXNNHuqPtLZPr8z5g==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/types": "0.69.46",
-                "axios": "1.13.5"
+                "@nangohq/types": "0.70.1",
+                "axios": "1.15.0"
             },
             "engines": {
                 "node": ">=20.0"
             }
         },
         "node_modules/@nangohq/runner-sdk/node_modules/@nangohq/providers": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.69.46.tgz",
-            "integrity": "sha512-Fa/rp4A9hr3zRualscPWYBDEHCffuoegrcJ7KPs7TI6L+cVaGXZibWZfC5VK8vwQMXet/9GXzsfBO1iJYSgKPw==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.70.1.tgz",
+            "integrity": "sha512-kDOM8WyfExgheJIyBMT/E5uF+vjICWuInw1ZA1i3liAxrEdu6OMA1jL3jNYVBUpXO8G4eWTqWFKvXCBRFGwJQQ==",
             "dev": true,
             "dependencies": {
                 "js-yaml": "4.1.1"
             }
         },
         "node_modules/@nangohq/runner-sdk/node_modules/@nangohq/types": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.46.tgz",
-            "integrity": "sha512-lN6EimkBqBO3zNftkCjwKSNT2F6WtS/ncOEq497y7n1+rxfse5Z77HHgDoK8sPO2sboYbwPgnDoT50ETub/eWg==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.70.1.tgz",
+            "integrity": "sha512-hcmlDwKK5rI2+KSroh4lz6BIH93mLiv9cRle8T3msrgILp14efB8FZVHHGS6UAUziKDtA6d1aS/SU8bUtgEo6Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "axios": "1.13.5",
+                "axios": "1.15.0",
                 "json-schema": "0.4.0",
                 "type-fest": "4.41.0"
             }
         },
         "node_modules/@nangohq/runner-sdk/node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/@nangohq/runner-sdk/node_modules/form-data": {
@@ -3617,6 +3607,16 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@nangohq/runner-sdk/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@nangohq/runner-sdk/node_modules/type-fest": {
@@ -8189,13 +8189,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -11387,23 +11380,6 @@
                 "is-callable": "^1.1.3"
             }
         },
-        "node_modules/foreground-child": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -12609,22 +12585,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/jackspeak": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^9.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/jake": {
             "version": "10.9.2",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
@@ -13183,9 +13143,9 @@
             "dev": true
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "dev": true,
             "license": "MIT"
         },
@@ -13688,9 +13648,9 @@
             }
         },
         "node_modules/nango": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/nango/-/nango-0.69.46.tgz",
-            "integrity": "sha512-blWsYvIm9tbquSZ5/FfuBjE31mtgVh54oYP1W0Mqc0wG4kqtU3tqiXO5P4nx5dv2XFB85T8m0gRE3JMq8y7fyQ==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/nango/-/nango-0.70.1.tgz",
+            "integrity": "sha512-Q+W4wxB1ko7jNYonXod6jgUe7UyARuQ6DYHvYcFWIXR+ViuqJxTkvfAP5W3knn5+/5qNchVl0/hWnH6IMOHlUA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
@@ -13699,15 +13659,15 @@
                 "@babel/preset-typescript": "7.27.1",
                 "@babel/traverse": "7.28.0",
                 "@babel/types": "7.28.2",
-                "@nangohq/nango-yaml": "0.69.46",
-                "@nangohq/node": "0.69.46",
-                "@nangohq/providers": "0.69.46",
-                "@nangohq/runner-sdk": "0.69.46",
+                "@nangohq/nango-yaml": "0.70.1",
+                "@nangohq/node": "0.70.1",
+                "@nangohq/providers": "0.70.1",
+                "@nangohq/runner-sdk": "0.70.1",
                 "@swc/core": "1.13.2",
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.18.0",
                 "ajv-errors": "3.0.0",
-                "axios": "1.13.5",
+                "axios": "1.15.0",
                 "chalk": "5.4.1",
                 "chokidar": "3.5.3",
                 "columnify": "1.6.0",
@@ -13729,7 +13689,6 @@
                 "promptly": "3.2.0",
                 "semver": "7.5.4",
                 "serialize-error": "11.0.3",
-                "ts-json-schema-generator": "2.4.0",
                 "ts-node": "10.9.2",
                 "tsup": "8.5.1",
                 "typescript": "5.8.3",
@@ -13744,9 +13703,9 @@
             }
         },
         "node_modules/nango/node_modules/@nangohq/nango-yaml": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/nango-yaml/-/nango-yaml-0.69.46.tgz",
-            "integrity": "sha512-yOigWN+4/67eVvUF3ayIYjylHiUt+K3m2VZNpzRAKTNeD72Ebh2Z1hlh/zwP5whumQvGIRUkb81DQ7BJu865rQ==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/nango-yaml/-/nango-yaml-0.70.1.tgz",
+            "integrity": "sha512-rvTU11ODe9b/ni9AgzWIzPjyUFmcAl3LbIYZ0EsLBnX8jvEw6g4aJAYtT9N65f3PSyZACDXyDfImN7x/s4gvZA==",
             "dev": true,
             "dependencies": {
                 "js-yaml": "4.1.1",
@@ -13754,50 +13713,50 @@
             }
         },
         "node_modules/nango/node_modules/@nangohq/node": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.69.46.tgz",
-            "integrity": "sha512-5rLsspDKHnLgdVtN75v87vbMhESszUHbmOlvX00PMKxgZAV9t6dZWUHeHaD5/4UOSuRmFq9/eyOKJa8qFYuXiQ==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.70.1.tgz",
+            "integrity": "sha512-WupMNpp96GCCNTs5e5UtEoo/snpnJ6tGNPf58hXqDANwFuZG7ePdjN5giyH1AePoqi0QkcXNNHuqPtLZPr8z5g==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/types": "0.69.46",
-                "axios": "1.13.5"
+                "@nangohq/types": "0.70.1",
+                "axios": "1.15.0"
             },
             "engines": {
                 "node": ">=20.0"
             }
         },
         "node_modules/nango/node_modules/@nangohq/providers": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.69.46.tgz",
-            "integrity": "sha512-Fa/rp4A9hr3zRualscPWYBDEHCffuoegrcJ7KPs7TI6L+cVaGXZibWZfC5VK8vwQMXet/9GXzsfBO1iJYSgKPw==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/providers/-/providers-0.70.1.tgz",
+            "integrity": "sha512-kDOM8WyfExgheJIyBMT/E5uF+vjICWuInw1ZA1i3liAxrEdu6OMA1jL3jNYVBUpXO8G4eWTqWFKvXCBRFGwJQQ==",
             "dev": true,
             "dependencies": {
                 "js-yaml": "4.1.1"
             }
         },
         "node_modules/nango/node_modules/@nangohq/types": {
-            "version": "0.69.46",
-            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.69.46.tgz",
-            "integrity": "sha512-lN6EimkBqBO3zNftkCjwKSNT2F6WtS/ncOEq497y7n1+rxfse5Z77HHgDoK8sPO2sboYbwPgnDoT50ETub/eWg==",
+            "version": "0.70.1",
+            "resolved": "https://registry.npmjs.org/@nangohq/types/-/types-0.70.1.tgz",
+            "integrity": "sha512-hcmlDwKK5rI2+KSroh4lz6BIH93mLiv9cRle8T3msrgILp14efB8FZVHHGS6UAUziKDtA6d1aS/SU8bUtgEo6Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "axios": "1.13.5",
+                "axios": "1.15.0",
                 "json-schema": "0.4.0",
                 "type-fest": "4.41.0"
             }
         },
         "node_modules/nango/node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/nango/node_modules/chokidar": {
@@ -14008,6 +13967,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/nango/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/nango/node_modules/run-async": {
@@ -14634,13 +14603,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
             "version": "2.1.0",
@@ -15607,16 +15569,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/safe-stable-stringify": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -16480,117 +16432,6 @@
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/ts-json-schema-generator": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.4.0.tgz",
-            "integrity": "sha512-HbmNsgs58CfdJq0gpteRTxPXG26zumezOs+SB9tgky6MpqiFgQwieCn2MW70+sxpHouZ/w9LW0V6L4ZQO4y1Ug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.15",
-                "commander": "^13.1.0",
-                "glob": "^11.0.1",
-                "json5": "^2.2.3",
-                "normalize-path": "^3.0.0",
-                "safe-stable-stringify": "^2.5.0",
-                "tslib": "^2.8.1",
-                "typescript": "^5.8.2"
-            },
-            "bin": {
-                "ts-json-schema-generator": "bin/ts-json-schema-generator.js"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/ts-json-schema-generator/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/ts-json-schema-generator/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/ts-json-schema-generator/node_modules/commander": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/ts-json-schema-generator/node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/ts-json-schema-generator/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/ts-json-schema-generator/node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
         },
         "node_modules/ts-node": {
             "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "js-yaml": "4.1.0",
         "lint-staged": "15.2.9",
         "lodash-es": "^4.17.21",
-        "nango": "0.69.46",
+        "nango": "0.70.1",
         "onchange": "7.1.0",
         "parse-link-header": "^2.0.0",
         "soap": "1.1.2",


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `nango` to 0.70.1 across the repo and refreshed SDK version refs in internal flows. Aligns integrations with the latest Nango SDK and trims some transitive deps.

- **Dependencies**
  - Updated `nango` to 0.70.1 in root and `integrations`
  - Synced `@nangohq/*` packages to 0.70.1; `axios` to 1.15.0; `lodash-es` to 4.18.1; `proxy-from-env` to 2.1.0
  - Removed unused deps like `ts-json-schema-generator` and related types/glob utilities

<sup>Written for commit 40fedef293bb77816b89e2a0b941ad41e7fbd9ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

