### PR TITLE
feat(1password-scim): Minor Update SCIM user, group and consistency improvements

### DIFF
--- a/integrations/.nango/schema.json
+++ b/integrations/.nango/schema.json
@@ -1,6 +1,1649 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "ScimGroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "description": "! ** DEPRECATION NOTICE ** ! This file will stop being generated in future versions of nango. ! For access to function types, please export types directly from your code. ! You can leverage `zod.infer` to generate types from your zod schemas. ! See the official zod documentation: https://zod.dev/basics?id=inferring-types"
+    },
+    "ScimUser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            },
+            "givenName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "emails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "resourceType": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "userName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_createscimgroup": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the SCIM group. Example: \"Engineering\""
+        },
+        "externalId": {
+          "type": "string",
+          "description": "The external identifier for the group. Example: \"group-123\""
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string",
+                "description": "The display name of the member. Example: \"John Doe\""
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          },
+          "description": "Array of group members to assign on creation"
+        }
+      },
+      "required": [
+        "displayName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_createscimgroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "displayName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_createscimuser": {
+      "type": "object",
+      "properties": {
+        "userName": {
+          "type": "string",
+          "description": "SCIM userName. Example: \"user@example.com\""
+        },
+        "externalId": {
+          "type": "string",
+          "description": "External identifier for the user."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name for the user."
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            },
+            "givenName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "emails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "active": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "userName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_createscimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            },
+            "givenName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "emails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "userName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_deletescimgroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "SCIM Group ID. Example: \"group-123\""
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_deletescimgroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "deleted": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "deleted"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_deletescimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "SCIM user ID to delete. Example: \"123\""
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_deletescimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "deleted": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "deleted"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_getscimgroup": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "SCIM Group ID. Example: \"e9e30dba-f08f-4109-8486-d5c6a331660a\""
+        }
+      },
+      "required": [
+        "groupId"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_getscimgroup": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "$ref": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "schemas",
+        "id",
+        "displayName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_getscimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The SCIM user ID. Example: \"123\""
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_getscimuser": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "userName": {
+          "type": "string"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            },
+            "givenName": {
+              "type": "string"
+            },
+            "middleName": {
+              "type": "string"
+            },
+            "honorificPrefix": {
+              "type": "string"
+            },
+            "honorificSuffix": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "nickName": {
+          "type": "string"
+        },
+        "profileUrl": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "userType": {
+          "type": "string"
+        },
+        "preferredLanguage": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "emails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "$ref": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "entitlements": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "schemas",
+        "id",
+        "userName"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_getserviceproviderconfig": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_getserviceproviderconfig": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "documentationUri": {
+          "type": "string"
+        },
+        "patch": {
+          "type": "object",
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "bulk": {
+          "type": "object",
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            },
+            "maxOperations": {
+              "type": "number"
+            },
+            "maxPayloadSize": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "filter": {
+          "type": "object",
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            },
+            "maxResults": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "changePassword": {
+          "type": "object",
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "sort": {
+          "type": "object",
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "etag": {
+          "type": "object",
+          "properties": {
+            "supported": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "authenticationSchemes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "specUri": {
+                "type": "string"
+              },
+              "documentationUri": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_listresourcetypes": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_listresourcetypes": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "totalResults": {
+          "type": "number"
+        },
+        "itemsPerPage": {
+          "type": "number"
+        },
+        "startIndex": {
+          "type": "number"
+        },
+        "Resources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "endpoint": {
+                "type": "string"
+              },
+              "schema": {
+                "type": "string"
+              },
+              "schemaExtensions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "schema": {
+                      "type": "string"
+                    },
+                    "required": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "meta": {
+                "type": "object",
+                "properties": {
+                  "resourceType": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_listschemas": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_listschemas": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "totalResults": {
+          "type": "number"
+        },
+        "Resources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "attributes": {
+                "type": "array",
+                "items": {}
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_listscimgroups": {
+      "type": "object",
+      "properties": {
+        "cursor": {
+          "type": "string",
+          "description": "Pagination cursor from the previous response. Omit for the first page."
+        },
+        "filter": {
+          "type": "string",
+          "description": "SCIM filter expression. Example: 'displayName eq \"Engineering\"'"
+        },
+        "count": {
+          "type": "number",
+          "description": "Number of results per page (1-250). Defaults to 100."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_listscimgroups": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "members": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    },
+                    "display": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "meta": {
+                "type": "object",
+                "properties": {
+                  "resourceType": {
+                    "type": "string"
+                  },
+                  "created": {
+                    "type": "string"
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "externalId": {
+                "type": "string"
+              },
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "displayName"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "next_cursor": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_listscimusers": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "type": "string",
+          "description": "SCIM filter query. Example: userName eq \"john.doe@example.com\""
+        },
+        "start_index": {
+          "type": "number",
+          "description": "1-based index of the first result to return."
+        },
+        "count": {
+          "type": "number",
+          "description": "Number of results to return per page."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_listscimusers": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "userName": {
+                "type": "string"
+              },
+              "name": {
+                "type": "object",
+                "properties": {
+                  "familyName": {
+                    "type": "string"
+                  },
+                  "givenName": {
+                    "type": "string"
+                  },
+                  "formatted": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "emails": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "primary": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "active": {
+                "type": "boolean"
+              },
+              "externalId": {
+                "type": "string"
+              },
+              "meta": {
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "type": "string"
+                  },
+                  "lastModified": {
+                    "type": "string"
+                  },
+                  "resourceType": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "userName"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "total_results": {
+          "type": "number"
+        },
+        "start_index": {
+          "type": "number"
+        },
+        "items_per_page": {
+          "type": "number"
+        },
+        "next_start_index": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "users",
+        "total_results"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_patchscimgroup": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "string",
+          "description": "The SCIM group ID to patch. Example: \"group-123\""
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "remove",
+                  "replace"
+                ]
+              },
+              "path": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "op"
+            ],
+            "additionalProperties": false
+          },
+          "description": "SCIM PatchOp operations to apply."
+        }
+      },
+      "required": [
+        "group_id",
+        "operations"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_patchscimgroup": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "$ref": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "resourceType"
+          ],
+          "additionalProperties": false
+        },
+        "externalId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "schemas",
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_patchscimuser": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The SCIM user ID to patch. Example: \"2819c223-7f76-453a-919d-413861904646\""
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "remove",
+                  "replace"
+                ]
+              },
+              "path": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "op"
+            ],
+            "additionalProperties": false
+          },
+          "description": "SCIM patch operations to apply."
+        }
+      },
+      "required": [
+        "userId",
+        "operations"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_patchscimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            },
+            "givenName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "emails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_updatescimgroup": {
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The unique identifier of the SCIM group to update. Example: \"9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d\""
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The new display name for the group."
+        },
+        "addMembers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of user IDs to add as members to the group."
+        },
+        "removeMembers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of user IDs to remove from the group."
+        }
+      },
+      "required": [
+        "groupId"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_updatescimgroup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "$ref": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "ActionInput_1password_scim_updatescimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "SCIM user ID. Example: \"2819c223-7f76-453a-919d-413861904646\""
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "replace",
+                  "remove"
+                ]
+              },
+              "path": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "op"
+            ],
+            "additionalProperties": false
+          },
+          "description": "Array of SCIM PatchOp operations to apply"
+        }
+      },
+      "required": [
+        "id",
+        "operations"
+      ],
+      "additionalProperties": false
+    },
+    "ActionOutput_1password_scim_updatescimuser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "userName": {
+          "type": "string"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            },
+            "givenName": {
+              "type": "string"
+            },
+            "middleName": {
+              "type": "string"
+            },
+            "honorificPrefix": {
+              "type": "string"
+            },
+            "honorificSuffix": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "nickName": {
+          "type": "string"
+        },
+        "profileUrl": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "userType": {
+          "type": "string"
+        },
+        "preferredLanguage": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "emails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
     "StandardEmployee": {
       "type": "object",
       "properties": {
@@ -248,8 +1891,7 @@
         "createdAt",
         "updatedAt"
       ],
-      "additionalProperties": false,
-      "description": "! ** DEPRECATION NOTICE ** ! This file will stop being generated in future versions of nango. ! For access to function types, please export types directly from your code. ! You can leverage `zod.infer` to generate types from your zod schemas. ! See the official zod documentation: https://zod.dev/basics?id=inferring-types"
+      "additionalProperties": false
     },
     "SyncMetadata_adp_unifiedemployees": {
       "type": "object",

--- a/integrations/.nango/schema.json
+++ b/integrations/.nango/schema.json
@@ -1174,21 +1174,63 @@
           "items": {
             "type": "object",
             "properties": {
-              "op": {
-                "type": "string",
-                "enum": [
-                  "add",
-                  "remove",
-                  "replace"
-                ]
+              "0": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "add"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op"
+                ],
+                "additionalProperties": false
               },
-              "path": {
-                "type": "string"
+              "1": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "replace"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op"
+                ],
+                "additionalProperties": false
               },
-              "value": {}
+              "2": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "remove"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op",
+                  "path"
+                ],
+                "additionalProperties": false
+              }
             },
             "required": [
-              "op"
+              "0",
+              "1",
+              "2"
             ],
             "additionalProperties": false
           },
@@ -1286,21 +1328,63 @@
           "items": {
             "type": "object",
             "properties": {
-              "op": {
-                "type": "string",
-                "enum": [
-                  "add",
-                  "remove",
-                  "replace"
-                ]
+              "0": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "add"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op"
+                ],
+                "additionalProperties": false
               },
-              "path": {
-                "type": "string"
+              "1": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "replace"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op"
+                ],
+                "additionalProperties": false
               },
-              "value": {}
+              "2": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "remove"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op",
+                  "path"
+                ],
+                "additionalProperties": false
+              }
             },
             "required": [
-              "op"
+              "0",
+              "1",
+              "2"
             ],
             "additionalProperties": false
           },
@@ -1500,21 +1584,63 @@
           "items": {
             "type": "object",
             "properties": {
-              "op": {
-                "type": "string",
-                "enum": [
-                  "add",
-                  "replace",
-                  "remove"
-                ]
+              "0": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "add"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op"
+                ],
+                "additionalProperties": false
               },
-              "path": {
-                "type": "string"
+              "1": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "replace"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op"
+                ],
+                "additionalProperties": false
               },
-              "value": {}
+              "2": {
+                "type": "object",
+                "properties": {
+                  "op": {
+                    "type": "string",
+                    "const": "remove"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "op",
+                  "path"
+                ],
+                "additionalProperties": false
+              }
             },
             "required": [
-              "op"
+              "0",
+              "1",
+              "2"
             ],
             "additionalProperties": false
           },

--- a/integrations/.nango/schema.json
+++ b/integrations/.nango/schema.json
@@ -1,57 +1,40 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "ScimGroup": {
+    "Group": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
-        "externalId": {
+        "name": {
           "type": "string"
         },
-        "displayName": {
+        "description": {
           "type": "string"
         },
-        "meta": {
-          "type": "object",
-          "properties": {
-            "resourceType": {
-              "type": "string"
-            },
-            "created": {
-              "type": "string"
-            },
-            "lastModified": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+        "isDefault": {
+          "type": "boolean"
         },
-        "members": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "display": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
-          }
+        "isDeleted": {
+          "type": "boolean"
+        },
+        "isPublic": {
+          "type": "boolean"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
         }
       },
       "required": [
-        "id"
+        "id",
+        "name"
       ],
       "additionalProperties": false,
       "description": "! ** DEPRECATION NOTICE ** ! This file will stop being generated in future versions of nango. ! For access to function types, please export types directly from your code. ! You can leverage `zod.infer` to generate types from your zod schemas. ! See the official zod documentation: https://zod.dev/basics?id=inferring-types"
@@ -71,13 +54,13 @@
         "name": {
           "type": "object",
           "properties": {
-            "formatted": {
+            "givenName": {
               "type": "string"
             },
             "familyName": {
               "type": "string"
             },
-            "givenName": {
+            "formatted": {
               "type": "string"
             }
           },
@@ -98,37 +81,21 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "value"
-            ],
             "additionalProperties": false
           }
-        },
-        "externalId": {
-          "type": "string"
         },
         "active": {
           "type": "boolean"
         },
-        "meta": {
-          "type": "object",
-          "properties": {
-            "created": {
-              "type": "string"
-            },
-            "lastModified": {
-              "type": "string"
-            },
-            "resourceType": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+        "externalId": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
         }
       },
       "required": [
-        "id",
-        "userName"
+        "id"
       ],
       "additionalProperties": false
     },
@@ -137,11 +104,11 @@
       "properties": {
         "displayName": {
           "type": "string",
-          "description": "The display name of the SCIM group. Example: \"Engineering\""
+          "description": "Display name of the SCIM group. Example: \"Engineering\""
         },
         "externalId": {
           "type": "string",
-          "description": "The external identifier for the group. Example: \"group-123\""
+          "description": "External identifier for the group."
         },
         "members": {
           "type": "array",
@@ -153,7 +120,7 @@
               },
               "display": {
                 "type": "string",
-                "description": "The display name of the member. Example: \"John Doe\""
+                "description": "Display name of the member."
               }
             },
             "required": [
@@ -161,7 +128,7 @@
             ],
             "additionalProperties": false
           },
-          "description": "Array of group members to assign on creation"
+          "description": "Members to add to the group at creation."
         }
       },
       "required": [
@@ -232,30 +199,29 @@
       "properties": {
         "userName": {
           "type": "string",
-          "description": "SCIM userName. Example: \"user@example.com\""
+          "description": "User login name, typically an email. Example: \"bjensen@example.com\""
         },
         "externalId": {
           "type": "string",
-          "description": "External identifier for the user."
-        },
-        "displayName": {
-          "type": "string",
-          "description": "Display name for the user."
+          "description": "Identifier from the provisioning client. Example: \"bjensen\""
         },
         "name": {
           "type": "object",
           "properties": {
-            "formatted": {
+            "givenName": {
               "type": "string"
             },
             "familyName": {
               "type": "string"
             },
-            "givenName": {
+            "formatted": {
               "type": "string"
             }
           },
           "additionalProperties": false
+        },
+        "displayName": {
+          "type": "string"
         },
         "emails": {
           "type": "array",
@@ -279,7 +245,8 @@
           }
         },
         "active": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the user is active."
         }
       },
       "required": [
@@ -305,13 +272,13 @@
         "name": {
           "type": "object",
           "properties": {
-            "formatted": {
+            "givenName": {
               "type": "string"
             },
             "familyName": {
               "type": "string"
             },
-            "givenName": {
+            "formatted": {
               "type": "string"
             }
           },
@@ -427,13 +394,13 @@
     "ActionInput_1password_scim_getscimgroup": {
       "type": "object",
       "properties": {
-        "groupId": {
+        "id": {
           "type": "string",
-          "description": "SCIM Group ID. Example: \"e9e30dba-f08f-4109-8486-d5c6a331660a\""
+          "description": "The SCIM group ID. Example: \"2819c223-7f76-453a-919d-413861904646\""
         }
       },
       "required": [
-        "groupId"
+        "id"
       ],
       "additionalProperties": false
     },
@@ -451,33 +418,6 @@
         },
         "externalId": {
           "type": "string"
-        },
-        "displayName": {
-          "type": "string"
-        },
-        "members": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "display": {
-                "type": "string"
-              },
-              "$ref": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
-          }
         },
         "meta": {
           "type": "object",
@@ -499,6 +439,30 @@
             }
           },
           "additionalProperties": false
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "$ref": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
         }
       },
       "required": [
@@ -513,7 +477,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "The SCIM user ID. Example: \"123\""
+          "description": "SCIM User ID. Example: \"2819c223-7f76-453a-919d-413861904646\""
         }
       },
       "required": [
@@ -535,27 +499,6 @@
         },
         "externalId": {
           "type": "string"
-        },
-        "meta": {
-          "type": "object",
-          "properties": {
-            "resourceType": {
-              "type": "string"
-            },
-            "created": {
-              "type": "string"
-            },
-            "lastModified": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
         },
         "userName": {
           "type": "string"
@@ -629,9 +572,102 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "value"
-            ],
+            "additionalProperties": false
+          }
+        },
+        "phoneNumbers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "ims": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "photos": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "formatted": {
+                "type": "string"
+              },
+              "streetAddress": {
+                "type": "string"
+              },
+              "locality": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
             "additionalProperties": false
           }
         },
@@ -653,16 +689,6 @@
                 "type": "string"
               }
             },
-            "required": [
-              "value"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "object",
             "additionalProperties": false
           }
         },
@@ -670,14 +696,90 @@
           "type": "array",
           "items": {
             "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
             "additionalProperties": false
           }
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "x509Certificates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "primary": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
         "schemas",
-        "id",
-        "userName"
+        "id"
       ],
       "additionalProperties": false
     },
@@ -694,30 +796,6 @@
             "type": "string"
           }
         },
-        "id": {
-          "type": "string"
-        },
-        "meta": {
-          "type": "object",
-          "properties": {
-            "resourceType": {
-              "type": "string"
-            },
-            "created": {
-              "type": "string"
-            },
-            "lastModified": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
         "documentationUri": {
           "type": "string"
         },
@@ -728,6 +806,9 @@
               "type": "boolean"
             }
           },
+          "required": [
+            "supported"
+          ],
           "additionalProperties": false
         },
         "bulk": {
@@ -743,6 +824,11 @@
               "type": "number"
             }
           },
+          "required": [
+            "supported",
+            "maxOperations",
+            "maxPayloadSize"
+          ],
           "additionalProperties": false
         },
         "filter": {
@@ -755,6 +841,10 @@
               "type": "number"
             }
           },
+          "required": [
+            "supported",
+            "maxResults"
+          ],
           "additionalProperties": false
         },
         "changePassword": {
@@ -764,6 +854,9 @@
               "type": "boolean"
             }
           },
+          "required": [
+            "supported"
+          ],
           "additionalProperties": false
         },
         "sort": {
@@ -773,6 +866,9 @@
               "type": "boolean"
             }
           },
+          "required": [
+            "supported"
+          ],
           "additionalProperties": false
         },
         "etag": {
@@ -782,6 +878,9 @@
               "type": "boolean"
             }
           },
+          "required": [
+            "supported"
+          ],
           "additionalProperties": false
         },
         "authenticationSchemes": {
@@ -808,10 +907,50 @@
                 "type": "boolean"
               }
             },
+            "required": [
+              "name",
+              "description",
+              "type"
+            ],
             "additionalProperties": false
           }
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string"
+            },
+            "resourceType": {
+              "type": "string"
+            },
+            "created": {
+              "type": "string"
+            },
+            "lastModified": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "location",
+            "resourceType"
+          ],
+          "additionalProperties": false
         }
       },
+      "required": [
+        "schemas",
+        "patch",
+        "bulk",
+        "filter",
+        "changePassword",
+        "sort",
+        "etag",
+        "authenticationSchemes"
+      ],
       "additionalProperties": false
     },
     "ActionInput_1password_scim_listresourcetypes": {
@@ -828,12 +967,6 @@
           }
         },
         "totalResults": {
-          "type": "number"
-        },
-        "itemsPerPage": {
-          "type": "number"
-        },
-        "startIndex": {
           "type": "number"
         },
         "Resources": {
@@ -853,10 +986,10 @@
               "name": {
                 "type": "string"
               },
-              "description": {
+              "endpoint": {
                 "type": "string"
               },
-              "endpoint": {
+              "description": {
                 "type": "string"
               },
               "schema": {
@@ -874,6 +1007,10 @@
                       "type": "boolean"
                     }
                   },
+                  "required": [
+                    "schema",
+                    "required"
+                  ],
                   "additionalProperties": false
                 }
               },
@@ -890,10 +1027,26 @@
                 "additionalProperties": false
               }
             },
+            "required": [
+              "id",
+              "name",
+              "endpoint",
+              "schema"
+            ],
             "additionalProperties": false
           }
+        },
+        "startIndex": {
+          "type": "number"
+        },
+        "itemsPerPage": {
+          "type": "number"
         }
       },
+      "required": [
+        "totalResults",
+        "Resources"
+      ],
       "additionalProperties": false
     },
     "ActionInput_1password_scim_listschemas": {
@@ -904,15 +1057,6 @@
       "type": "object",
       "properties": {
         "schemas": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "totalResults": {
-          "type": "number"
-        },
-        "Resources": {
           "type": "array",
           "items": {
             "type": "object",
@@ -928,11 +1072,80 @@
               },
               "attributes": {
                 "type": "array",
-                "items": {}
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "multiValued": {
+                      "type": "boolean"
+                    },
+                    "required": {
+                      "type": "boolean"
+                    },
+                    "mutability": {
+                      "type": "string"
+                    },
+                    "returned": {
+                      "type": "string"
+                    },
+                    "uniqueness": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "subAttributes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "multiValued": {
+                            "type": "boolean"
+                          },
+                          "required": {
+                            "type": "boolean"
+                          },
+                          "mutability": {
+                            "type": "string"
+                          },
+                          "returned": {
+                            "type": "string"
+                          },
+                          "uniqueness": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false
+                }
               }
             },
             "required": [
-              "id"
+              "id",
+              "name"
             ],
             "additionalProperties": false
           }
@@ -947,13 +1160,13 @@
           "type": "string",
           "description": "Pagination cursor from the previous response. Omit for the first page."
         },
-        "filter": {
-          "type": "string",
-          "description": "SCIM filter expression. Example: 'displayName eq \"Engineering\"'"
-        },
         "count": {
           "type": "number",
-          "description": "Number of results per page (1-250). Defaults to 100."
+          "description": "Number of results per page. Defaults to 100."
+        },
+        "filter": {
+          "type": "string",
+          "description": "SCIM filter expression. Example: displayName co \"Engineering\""
         }
       },
       "additionalProperties": false
@@ -961,37 +1174,22 @@
     "ActionOutput_1password_scim_listscimgroups": {
       "type": "object",
       "properties": {
-        "groups": {
+        "items": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "id": {
                 "type": "string"
               },
-              "displayName": {
+              "externalId": {
                 "type": "string"
-              },
-              "members": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "string"
-                    },
-                    "display": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "value"
-                  ],
-                  "additionalProperties": false
-                }
               },
               "meta": {
                 "type": "object",
@@ -1014,42 +1212,58 @@
                 },
                 "additionalProperties": false
               },
-              "externalId": {
+              "displayName": {
                 "type": "string"
               },
-              "schemas": {
+              "members": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    },
+                    "$ref": {
+                      "type": "string"
+                    },
+                    "display": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               }
             },
             "required": [
+              "schemas",
               "id",
               "displayName"
             ],
             "additionalProperties": false
           }
         },
-        "next_cursor": {
+        "nextCursor": {
           "type": "string"
         }
       },
       "required": [
-        "groups"
+        "items"
       ],
       "additionalProperties": false
     },
     "ActionInput_1password_scim_listscimusers": {
       "type": "object",
       "properties": {
+        "cursor": {
+          "type": "string",
+          "description": "Pagination cursor from the previous response. Omit for the first page."
+        },
         "filter": {
           "type": "string",
-          "description": "SCIM filter query. Example: userName eq \"john.doe@example.com\""
-        },
-        "start_index": {
-          "type": "number",
-          "description": "1-based index of the first result to return."
+          "description": "SCIM filter expression. Example: userName eq \"user@example.com\""
         },
         "count": {
           "type": "number",
@@ -1061,7 +1275,7 @@
     "ActionOutput_1password_scim_listscimusers": {
       "type": "object",
       "properties": {
-        "users": {
+        "items": {
           "type": "array",
           "items": {
             "type": "object",
@@ -1075,17 +1289,23 @@
               "name": {
                 "type": "object",
                 "properties": {
+                  "formatted": {
+                    "type": "string"
+                  },
                   "familyName": {
                     "type": "string"
                   },
                   "givenName": {
                     "type": "string"
-                  },
-                  "formatted": {
-                    "type": "string"
                   }
                 },
                 "additionalProperties": false
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean"
               },
               "emails": {
                 "type": "array",
@@ -1095,44 +1315,17 @@
                     "value": {
                       "type": "string"
                     },
-                    "type": {
-                      "type": "string"
-                    },
                     "primary": {
                       "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
                     }
                   },
                   "required": [
                     "value"
                   ],
                   "additionalProperties": false
-                }
-              },
-              "active": {
-                "type": "boolean"
-              },
-              "externalId": {
-                "type": "string"
-              },
-              "meta": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "type": "string"
-                  },
-                  "lastModified": {
-                    "type": "string"
-                  },
-                  "resourceType": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "schemas": {
-                "type": "array",
-                "items": {
-                  "type": "string"
                 }
               }
             },
@@ -1143,102 +1336,92 @@
             "additionalProperties": false
           }
         },
-        "total_results": {
+        "totalResults": {
           "type": "number"
         },
-        "start_index": {
-          "type": "number"
-        },
-        "items_per_page": {
-          "type": "number"
-        },
-        "next_start_index": {
-          "type": "number"
+        "nextCursor": {
+          "type": "string"
         }
       },
       "required": [
-        "users",
-        "total_results"
+        "items"
       ],
       "additionalProperties": false
     },
     "ActionInput_1password_scim_patchscimgroup": {
       "type": "object",
       "properties": {
-        "group_id": {
+        "id": {
           "type": "string",
-          "description": "The SCIM group ID to patch. Example: \"group-123\""
+          "description": "SCIM Group ID. Example: \"9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d\""
         },
         "operations": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "0": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "add"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op"
-                ],
-                "additionalProperties": false
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "remove",
+                  "replace"
+                ]
               },
-              "1": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "replace"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op"
-                ],
-                "additionalProperties": false
+              "path": {
+                "type": "string",
+                "description": "Target attribute path. Example: \"members\" or \"displayName\""
               },
-              "2": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "remove"
-                  },
-                  "path": {
+              "value": {
+                "anyOf": [
+                  {
                     "type": "string"
                   },
-                  "value": {}
-                },
-                "required": [
-                  "op",
-                  "path"
-                ],
-                "additionalProperties": false
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "string"
+                        },
+                        "display": {
+                          "type": "string"
+                        },
+                        "$ref": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": {
+                      "anyOf": [
+                        {},
+                        {
+                          "not": {}
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             },
             "required": [
-              "0",
-              "1",
-              "2"
+              "op"
             ],
             "additionalProperties": false
           },
-          "description": "SCIM PatchOp operations to apply."
+          "description": "SCIM patch operations to apply to the group."
         }
       },
       "required": [
-        "group_id",
+        "id",
         "operations"
       ],
       "additionalProperties": false
@@ -1246,12 +1429,6 @@
     "ActionOutput_1password_scim_patchscimgroup": {
       "type": "object",
       "properties": {
-        "schemas": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "id": {
           "type": "string"
         },
@@ -1267,12 +1444,6 @@
                 "type": "string"
               },
               "display": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
-              },
-              "$ref": {
                 "type": "string"
               }
             },
@@ -1301,9 +1472,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "resourceType"
-          ],
           "additionalProperties": false
         },
         "externalId": {
@@ -1311,7 +1479,6 @@
         }
       },
       "required": [
-        "schemas",
         "id"
       ],
       "additionalProperties": false
@@ -1321,74 +1488,32 @@
       "properties": {
         "userId": {
           "type": "string",
-          "description": "The SCIM user ID to patch. Example: \"2819c223-7f76-453a-919d-413861904646\""
+          "description": "SCIM User ID. Example: \"2819c223-7f76-453a-919d-413861904646\""
         },
         "operations": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "0": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "add"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op"
-                ],
-                "additionalProperties": false
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "replace",
+                  "remove"
+                ]
               },
-              "1": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "replace"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op"
-                ],
-                "additionalProperties": false
+              "path": {
+                "type": "string"
               },
-              "2": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "remove"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op",
-                  "path"
-                ],
-                "additionalProperties": false
-              }
+              "value": {}
             },
             "required": [
-              "0",
-              "1",
-              "2"
+              "op"
             ],
             "additionalProperties": false
           },
-          "description": "SCIM patch operations to apply."
+          "description": "SCIM PatchOp operations. Example: [{\"op\":\"replace\",\"path\":\"userName\",\"value\":\"new@example.com\"}]"
         }
       },
       "required": [
@@ -1400,20 +1525,26 @@
     "ActionOutput_1password_scim_patchscimuser": {
       "type": "object",
       "properties": {
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "id": {
           "type": "string"
         },
         "userName": {
           "type": "string"
         },
-        "externalId": {
-          "type": "string"
+        "active": {
+          "type": "boolean"
         },
         "displayName": {
           "type": "string"
         },
-        "active": {
-          "type": "boolean"
+        "preferredLanguage": {
+          "type": "string"
         },
         "name": {
           "type": "object",
@@ -1445,6 +1576,9 @@
                 "type": "boolean"
               }
             },
+            "required": [
+              "value"
+            ],
             "additionalProperties": false
           }
         },
@@ -1471,6 +1605,7 @@
         }
       },
       "required": [
+        "schemas",
         "id"
       ],
       "additionalProperties": false
@@ -1480,25 +1615,38 @@
       "properties": {
         "groupId": {
           "type": "string",
-          "description": "The unique identifier of the SCIM group to update. Example: \"9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d\""
+          "description": "The SCIM group ID. Example: \"27i3xrasou26ukebqazeadyhua\""
         },
         "displayName": {
           "type": "string",
-          "description": "The new display name for the group."
+          "description": "New display name for the group"
         },
-        "addMembers": {
+        "members": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "remove"
+                ]
+              },
+              "userId": {
+                "type": "string"
+              },
+              "display": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "op",
+              "userId"
+            ],
+            "additionalProperties": false
           },
-          "description": "Array of user IDs to add as members to the group."
-        },
-        "removeMembers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Array of user IDs to remove from the group."
+          "description": "Member add or remove operations"
         }
       },
       "required": [
@@ -1512,12 +1660,6 @@
         "id": {
           "type": "string"
         },
-        "schemas": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "displayName": {
           "type": "string"
         },
@@ -1531,12 +1673,6 @@
               },
               "display": {
                 "type": "string"
-              },
-              "$ref": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string"
               }
             },
             "required": [
@@ -1544,27 +1680,6 @@
             ],
             "additionalProperties": false
           }
-        },
-        "meta": {
-          "type": "object",
-          "properties": {
-            "resourceType": {
-              "type": "string"
-            },
-            "created": {
-              "type": "string"
-            },
-            "lastModified": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
         }
       },
       "required": [
@@ -1577,79 +1692,31 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "SCIM user ID. Example: \"2819c223-7f76-453a-919d-413861904646\""
+          "description": "SCIM User ID. Example: \"2819c223-7f76-453a-919d-413861904646\""
         },
-        "operations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "0": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "add"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op"
-                ],
-                "additionalProperties": false
-              },
-              "1": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "replace"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op"
-                ],
-                "additionalProperties": false
-              },
-              "2": {
-                "type": "object",
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "const": "remove"
-                  },
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": {}
-                },
-                "required": [
-                  "op",
-                  "path"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "0",
-              "1",
-              "2"
-            ],
-            "additionalProperties": false
-          },
-          "description": "Array of SCIM PatchOp operations to apply"
+        "userName": {
+          "type": "string",
+          "description": "User email address. Example: \"user@example.com\""
+        },
+        "givenName": {
+          "type": "string",
+          "description": "First name. Example: \"Jane\""
+        },
+        "familyName": {
+          "type": "string",
+          "description": "Last name. Example: \"Doe\""
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name. Example: \"Jane Doe\""
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the user is active."
         }
       },
       "required": [
-        "id",
-        "operations"
+        "id"
       ],
       "additionalProperties": false
     },
@@ -1659,85 +1726,16 @@
         "id": {
           "type": "string"
         },
-        "externalId": {
-          "type": "string"
-        },
-        "meta": {
-          "type": "object",
-          "properties": {
-            "resourceType": {
-              "type": "string"
-            },
-            "created": {
-              "type": "string"
-            },
-            "lastModified": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "schemas": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "userName": {
           "type": "string"
         },
-        "name": {
-          "type": "object",
-          "properties": {
-            "formatted": {
-              "type": "string"
-            },
-            "familyName": {
-              "type": "string"
-            },
-            "givenName": {
-              "type": "string"
-            },
-            "middleName": {
-              "type": "string"
-            },
-            "honorificPrefix": {
-              "type": "string"
-            },
-            "honorificSuffix": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+        "givenName": {
+          "type": "string"
+        },
+        "familyName": {
+          "type": "string"
         },
         "displayName": {
-          "type": "string"
-        },
-        "nickName": {
-          "type": "string"
-        },
-        "profileUrl": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "userType": {
-          "type": "string"
-        },
-        "preferredLanguage": {
-          "type": "string"
-        },
-        "locale": {
-          "type": "string"
-        },
-        "timezone": {
           "type": "string"
         },
         "active": {
@@ -1751,9 +1749,6 @@
               "value": {
                 "type": "string"
               },
-              "display": {
-                "type": "string"
-              },
               "type": {
                 "type": "string"
               },
@@ -1761,6 +1756,9 @@
                 "type": "boolean"
               }
             },
+            "required": [
+              "value"
+            ],
             "additionalProperties": false
           }
         }
@@ -126433,43 +126431,6 @@
     },
     "SyncMetadata_sap_success_factors_employees": {
       "type": "object",
-      "additionalProperties": false
-    },
-    "Group": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "isDefault": {
-          "type": "boolean"
-        },
-        "isDeleted": {
-          "type": "boolean"
-        },
-        "isPublic": {
-          "type": "boolean"
-        },
-        "createdAt": {
-          "type": "string"
-        },
-        "updatedAt": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "name"
-      ],
       "additionalProperties": false
     },
     "SyncMetadata_sap_success_factors_groups": {

--- a/integrations/.nango/schema.ts
+++ b/integrations/.nango/schema.ts
@@ -11,6 +11,471 @@
  * ! See the official zod documentation: https://zod.dev/basics?id=inferring-types
  */
 
+export interface ScimGroup {
+  id: string;
+  externalId?: string | undefined;
+  displayName?: string | undefined;
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;};
+  members?: ({  value: string;
+  display?: string | undefined;})[];
+};
+
+export interface ScimUser {
+  id: string;
+  userName: string;
+  displayName?: string | undefined;
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;};
+  emails?: ({  value: string;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  externalId?: string | undefined;
+  active?: boolean | undefined;
+  meta?: {  created?: string | undefined;
+  lastModified?: string | undefined;
+  resourceType?: string | undefined;};
+};
+
+export interface ActionInput_1password_scim_createscimgroup {
+  /**
+   * The display name of the SCIM group. Example: "Engineering"
+   */
+  displayName: string;
+  /**
+   * The external identifier for the group. Example: "group-123"
+   */
+  externalId?: string | undefined;
+  /**
+   * Array of group members to assign on creation
+   */
+  members?: ({  /**
+   * The identifier of the member. Example: "user-123"
+   */
+  value: string;
+  /**
+   * The display name of the member. Example: "John Doe"
+   */
+  display?: string | undefined;})[];
+};
+
+export interface ActionOutput_1password_scim_createscimgroup {
+  id: string;
+  displayName: string;
+  externalId?: string | undefined;
+  members?: ({  value: string;
+  display?: string | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+};
+
+export interface ActionInput_1password_scim_createscimuser {
+  /**
+   * SCIM userName. Example: "user@example.com"
+   */
+  userName: string;
+  /**
+   * External identifier for the user.
+   */
+  externalId?: string | undefined;
+  /**
+   * Display name for the user.
+   */
+  displayName?: string | undefined;
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;};
+  emails?: ({  value: string;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  active?: boolean | undefined;
+};
+
+export interface ActionOutput_1password_scim_createscimuser {
+  id: string;
+  userName: string;
+  externalId?: string | undefined;
+  displayName?: string | undefined;
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;};
+  emails?: ({  value: string;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  active?: boolean | undefined;
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;};
+};
+
+export interface ActionInput_1password_scim_deletescimgroup {
+  /**
+   * SCIM Group ID. Example: "group-123"
+   */
+  id: string;
+};
+
+export interface ActionOutput_1password_scim_deletescimgroup {
+  id: string;
+  deleted: boolean;
+};
+
+export interface ActionInput_1password_scim_deletescimuser {
+  /**
+   * SCIM user ID to delete. Example: "123"
+   */
+  id: string;
+};
+
+export interface ActionOutput_1password_scim_deletescimuser {
+  id: string;
+  deleted: boolean;
+};
+
+export interface ActionInput_1password_scim_getscimgroup {
+  /**
+   * SCIM Group ID. Example: "e9e30dba-f08f-4109-8486-d5c6a331660a"
+   */
+  groupId: string;
+};
+
+export interface ActionOutput_1password_scim_getscimgroup {
+  schemas: string[];
+  id: string;
+  externalId?: string | undefined;
+  displayName: string;
+  members?: ({  /**
+   * The ID of the SCIM resource
+   */
+  value: string;
+  display?: string | undefined;
+  "$ref"?: string | undefined;
+  type?: string | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+};
+
+export interface ActionInput_1password_scim_getscimuser {
+  /**
+   * The SCIM user ID. Example: "123"
+   */
+  id: string;
+};
+
+export interface ActionOutput_1password_scim_getscimuser {
+  schemas: string[];
+  id: string;
+  externalId?: string | undefined;
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+  userName: string;
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;
+  middleName?: string | undefined;
+  honorificPrefix?: string | undefined;
+  honorificSuffix?: string | undefined;};
+  displayName?: string | undefined;
+  nickName?: string | undefined;
+  profileUrl?: string | undefined;
+  title?: string | undefined;
+  userType?: string | undefined;
+  preferredLanguage?: string | undefined;
+  locale?: string | undefined;
+  timezone?: string | undefined;
+  active?: boolean | undefined;
+  emails?: ({  value: string;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  groups?: ({  value: string;
+  display?: string | undefined;
+  type?: string | undefined;
+  "$ref"?: string | undefined;})[];
+  roles?: ({})[] | undefined;
+  entitlements?: ({})[] | undefined;
+};
+
+export interface ActionInput_1password_scim_getserviceproviderconfig {
+};
+
+export interface ActionOutput_1password_scim_getserviceproviderconfig {
+  schemas?: string[] | undefined;
+  id?: string | undefined;
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+  documentationUri?: string | undefined;
+  patch?: {  supported?: boolean | undefined;};
+  bulk?: {  supported?: boolean | undefined;
+  maxOperations?: number | undefined;
+  maxPayloadSize?: number | undefined;};
+  filter?: {  supported?: boolean | undefined;
+  maxResults?: number | undefined;};
+  changePassword?: {  supported?: boolean | undefined;};
+  sort?: {  supported?: boolean | undefined;};
+  etag?: {  supported?: boolean | undefined;};
+  authenticationSchemes?: ({  name?: string | undefined;
+  description?: string | undefined;
+  specUri?: string | undefined;
+  documentationUri?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+};
+
+export interface ActionInput_1password_scim_listresourcetypes {
+};
+
+export interface ActionOutput_1password_scim_listresourcetypes {
+  schemas?: string[] | undefined;
+  totalResults?: number | undefined;
+  itemsPerPage?: number | undefined;
+  startIndex?: number | undefined;
+  Resources?: ({  schemas?: string[] | undefined;
+  id?: string | undefined;
+  name?: string | undefined;
+  description?: string | undefined;
+  endpoint?: string | undefined;
+  schema?: string | undefined;
+  schemaExtensions?: ({  schema?: string | undefined;
+  required?: boolean | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  location?: string | undefined;};})[];
+};
+
+export interface ActionInput_1password_scim_listschemas {
+};
+
+export interface ActionOutput_1password_scim_listschemas {
+  schemas?: string[] | undefined;
+  totalResults?: number | undefined;
+  Resources?: ({  id: string;
+  name?: string | undefined;
+  description?: string | undefined;
+  attributes?: unknown[] | undefined;})[];
+};
+
+export interface ActionInput_1password_scim_listscimgroups {
+  /**
+   * Pagination cursor from the previous response. Omit for the first page.
+   */
+  cursor?: string | undefined;
+  /**
+   * SCIM filter expression. Example: 'displayName eq "Engineering"'
+   */
+  filter?: string | undefined;
+  /**
+   * Number of results per page (1-250). Defaults to 100.
+   */
+  count?: number | undefined;
+};
+
+export interface ActionOutput_1password_scim_listscimgroups {
+  groups: ({  id: string;
+  displayName: string;
+  members?: ({  value: string;
+  display?: string | undefined;
+  type?: string | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+  externalId?: string | undefined;
+  schemas?: string[] | undefined;})[];
+  next_cursor?: string | undefined;
+};
+
+export interface ActionInput_1password_scim_listscimusers {
+  /**
+   * SCIM filter query. Example: userName eq "john.doe@example.com"
+   */
+  filter?: string | undefined;
+  /**
+   * 1-based index of the first result to return.
+   */
+  start_index?: number | undefined;
+  /**
+   * Number of results to return per page.
+   */
+  count?: number | undefined;
+};
+
+export interface ActionOutput_1password_scim_listscimusers {
+  users: ({  id: string;
+  userName: string;
+  name?: {  familyName?: string | undefined;
+  givenName?: string | undefined;
+  formatted?: string | undefined;};
+  emails?: ({  value: string;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  active?: boolean | undefined;
+  externalId?: string | undefined;
+  meta?: {  created?: string | undefined;
+  lastModified?: string | undefined;
+  resourceType?: string | undefined;};
+  schemas?: string[] | undefined;})[];
+  total_results: number;
+  start_index?: number | undefined;
+  items_per_page?: number | undefined;
+  next_start_index?: number | undefined;
+};
+
+export interface ActionInput_1password_scim_patchscimgroup {
+  /**
+   * The SCIM group ID to patch. Example: "group-123"
+   */
+  group_id: string;
+  /**
+   * SCIM PatchOp operations to apply.
+   */
+  operations: ({  op: 'add' | 'remove' | 'replace';
+  path?: string | undefined;
+  value?: unknown | undefined;})[];
+};
+
+export interface ActionOutput_1password_scim_patchscimgroup {
+  schemas: string[];
+  id: string;
+  displayName?: string | undefined;
+  members?: ({  value: string;
+  display?: string | undefined;
+  type?: string | undefined;
+  "$ref"?: string | undefined;})[];
+  meta?: {  resourceType: string;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+  externalId?: string | undefined;
+};
+
+export interface ActionInput_1password_scim_patchscimuser {
+  /**
+   * The SCIM user ID to patch. Example: "2819c223-7f76-453a-919d-413861904646"
+   */
+  userId: string;
+  /**
+   * SCIM patch operations to apply.
+   */
+  operations: ({  op: 'add' | 'remove' | 'replace';
+  path?: string | undefined;
+  value?: unknown | undefined;})[];
+};
+
+export interface ActionOutput_1password_scim_patchscimuser {
+  id: string;
+  userName?: string | undefined;
+  externalId?: string | undefined;
+  displayName?: string | undefined;
+  active?: boolean | undefined;
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;};
+  emails?: ({  value?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+};
+
+export interface ActionInput_1password_scim_updatescimgroup {
+  /**
+   * The unique identifier of the SCIM group to update. Example: "9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d"
+   */
+  groupId: string;
+  /**
+   * The new display name for the group.
+   */
+  displayName?: string | undefined;
+  /**
+   * Array of user IDs to add as members to the group.
+   */
+  addMembers?: string[] | undefined;
+  /**
+   * Array of user IDs to remove from the group.
+   */
+  removeMembers?: string[] | undefined;
+};
+
+export interface ActionOutput_1password_scim_updatescimgroup {
+  id: string;
+  schemas?: string[] | undefined;
+  displayName?: string | undefined;
+  members?: ({  value: string;
+  display?: string | undefined;
+  "$ref"?: string | undefined;
+  type?: string | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+};
+
+export interface ActionInput_1password_scim_updatescimuser {
+  /**
+   * SCIM user ID. Example: "2819c223-7f76-453a-919d-413861904646"
+   */
+  id: string;
+  /**
+   * Array of SCIM PatchOp operations to apply
+   */
+  operations: ({  op: 'add' | 'replace' | 'remove';
+  path?: string | undefined;
+  value?: unknown | undefined;})[];
+};
+
+export interface ActionOutput_1password_scim_updatescimuser {
+  id: string;
+  externalId?: string | undefined;
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  location?: string | undefined;
+  version?: string | undefined;};
+  schemas?: string[] | undefined;
+  userName?: string | undefined;
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;
+  middleName?: string | undefined;
+  honorificPrefix?: string | undefined;
+  honorificSuffix?: string | undefined;};
+  displayName?: string | undefined;
+  nickName?: string | undefined;
+  profileUrl?: string | undefined;
+  title?: string | undefined;
+  userType?: string | undefined;
+  preferredLanguage?: string | undefined;
+  locale?: string | undefined;
+  timezone?: string | undefined;
+  active?: boolean | undefined;
+  emails?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+};
+
 export interface StandardEmployee {
   id: string;
   firstName: string;

--- a/integrations/.nango/schema.ts
+++ b/integrations/.nango/schema.ts
@@ -345,9 +345,15 @@ export interface ActionInput_1password_scim_patchscimgroup {
   /**
    * SCIM PatchOp operations to apply.
    */
-  operations: ({  op: 'add' | 'remove' | 'replace';
+  operations: ({  0: {  op: 'add';
   path?: string | undefined;
-  value?: unknown | undefined;})[];
+  value?: unknown | undefined;};
+  1: {  op: 'replace';
+  path?: string | undefined;
+  value?: unknown | undefined;};
+  2: {  op: 'remove';
+  path: string;
+  value?: unknown | undefined;};})[];
 };
 
 export interface ActionOutput_1password_scim_patchscimgroup {
@@ -374,9 +380,15 @@ export interface ActionInput_1password_scim_patchscimuser {
   /**
    * SCIM patch operations to apply.
    */
-  operations: ({  op: 'add' | 'remove' | 'replace';
+  operations: ({  0: {  op: 'add';
   path?: string | undefined;
-  value?: unknown | undefined;})[];
+  value?: unknown | undefined;};
+  1: {  op: 'replace';
+  path?: string | undefined;
+  value?: unknown | undefined;};
+  2: {  op: 'remove';
+  path: string;
+  value?: unknown | undefined;};})[];
 };
 
 export interface ActionOutput_1password_scim_patchscimuser {
@@ -440,9 +452,15 @@ export interface ActionInput_1password_scim_updatescimuser {
   /**
    * Array of SCIM PatchOp operations to apply
    */
-  operations: ({  op: 'add' | 'replace' | 'remove';
+  operations: ({  0: {  op: 'add';
   path?: string | undefined;
-  value?: unknown | undefined;})[];
+  value?: unknown | undefined;};
+  1: {  op: 'replace';
+  path?: string | undefined;
+  value?: unknown | undefined;};
+  2: {  op: 'remove';
+  path: string;
+  value?: unknown | undefined;};})[];
 };
 
 export interface ActionOutput_1password_scim_updatescimuser {

--- a/integrations/.nango/schema.ts
+++ b/integrations/.nango/schema.ts
@@ -11,53 +11,51 @@
  * ! See the official zod documentation: https://zod.dev/basics?id=inferring-types
  */
 
-export interface ScimGroup {
+export interface Group {
   id: string;
-  externalId?: string | undefined;
-  displayName?: string | undefined;
-  meta?: {  resourceType?: string | undefined;
-  created?: string | undefined;
-  lastModified?: string | undefined;
-  location?: string | undefined;};
-  members?: ({  value: string;
-  display?: string | undefined;})[];
+  name: string;
+  description?: string | undefined;
+  isDefault?: boolean | undefined;
+  isDeleted?: boolean | undefined;
+  isPublic?: boolean | undefined;
+  createdAt?: string | undefined;
+  updatedAt?: string | undefined;
+  url?: string | undefined;
 };
 
 export interface ScimUser {
   id: string;
-  userName: string;
+  userName?: string | undefined;
   displayName?: string | undefined;
-  name?: {  formatted?: string | undefined;
+  name?: {  givenName?: string | undefined;
   familyName?: string | undefined;
-  givenName?: string | undefined;};
-  emails?: ({  value: string;
+  formatted?: string | undefined;};
+  emails?: ({  value?: string | undefined;
   type?: string | undefined;
   primary?: boolean | undefined;})[];
-  externalId?: string | undefined;
   active?: boolean | undefined;
-  meta?: {  created?: string | undefined;
-  lastModified?: string | undefined;
-  resourceType?: string | undefined;};
+  externalId?: string | undefined;
+  updated_at?: string | undefined;
 };
 
 export interface ActionInput_1password_scim_createscimgroup {
   /**
-   * The display name of the SCIM group. Example: "Engineering"
+   * Display name of the SCIM group. Example: "Engineering"
    */
   displayName: string;
   /**
-   * The external identifier for the group. Example: "group-123"
+   * External identifier for the group.
    */
   externalId?: string | undefined;
   /**
-   * Array of group members to assign on creation
+   * Members to add to the group at creation.
    */
   members?: ({  /**
-   * The identifier of the member. Example: "user-123"
+   * Identifier of the member. Example: "user-id-123"
    */
   value: string;
   /**
-   * The display name of the member. Example: "John Doe"
+   * Display name of the member.
    */
   display?: string | undefined;})[];
 };
@@ -77,23 +75,23 @@ export interface ActionOutput_1password_scim_createscimgroup {
 
 export interface ActionInput_1password_scim_createscimuser {
   /**
-   * SCIM userName. Example: "user@example.com"
+   * User login name, typically an email. Example: "bjensen@example.com"
    */
   userName: string;
   /**
-   * External identifier for the user.
+   * Identifier from the provisioning client. Example: "bjensen"
    */
   externalId?: string | undefined;
-  /**
-   * Display name for the user.
-   */
-  displayName?: string | undefined;
-  name?: {  formatted?: string | undefined;
+  name?: {  givenName?: string | undefined;
   familyName?: string | undefined;
-  givenName?: string | undefined;};
+  formatted?: string | undefined;};
+  displayName?: string | undefined;
   emails?: ({  value: string;
   type?: string | undefined;
   primary?: boolean | undefined;})[];
+  /**
+   * Whether the user is active.
+   */
   active?: boolean | undefined;
 };
 
@@ -102,9 +100,9 @@ export interface ActionOutput_1password_scim_createscimuser {
   userName: string;
   externalId?: string | undefined;
   displayName?: string | undefined;
-  name?: {  formatted?: string | undefined;
+  name?: {  givenName?: string | undefined;
   familyName?: string | undefined;
-  givenName?: string | undefined;};
+  formatted?: string | undefined;};
   emails?: ({  value: string;
   type?: string | undefined;
   primary?: boolean | undefined;})[];
@@ -141,33 +139,29 @@ export interface ActionOutput_1password_scim_deletescimuser {
 
 export interface ActionInput_1password_scim_getscimgroup {
   /**
-   * SCIM Group ID. Example: "e9e30dba-f08f-4109-8486-d5c6a331660a"
+   * The SCIM group ID. Example: "2819c223-7f76-453a-919d-413861904646"
    */
-  groupId: string;
+  id: string;
 };
 
 export interface ActionOutput_1password_scim_getscimgroup {
   schemas: string[];
   id: string;
   externalId?: string | undefined;
-  displayName: string;
-  members?: ({  /**
-   * The ID of the SCIM resource
-   */
-  value: string;
-  display?: string | undefined;
-  "$ref"?: string | undefined;
-  type?: string | undefined;})[];
   meta?: {  resourceType?: string | undefined;
   created?: string | undefined;
   lastModified?: string | undefined;
   location?: string | undefined;
   version?: string | undefined;};
+  displayName: string;
+  members?: ({  value: string;
+  "$ref"?: string | undefined;
+  display?: string | undefined;})[];
 };
 
 export interface ActionInput_1password_scim_getscimuser {
   /**
-   * The SCIM user ID. Example: "123"
+   * SCIM User ID. Example: "2819c223-7f76-453a-919d-413861904646"
    */
   id: string;
 };
@@ -176,12 +170,7 @@ export interface ActionOutput_1password_scim_getscimuser {
   schemas: string[];
   id: string;
   externalId?: string | undefined;
-  meta?: {  resourceType?: string | undefined;
-  created?: string | undefined;
-  lastModified?: string | undefined;
-  location?: string | undefined;
-  version?: string | undefined;};
-  userName: string;
+  userName?: string | undefined;
   name?: {  formatted?: string | undefined;
   familyName?: string | undefined;
   givenName?: string | undefined;
@@ -197,45 +186,79 @@ export interface ActionOutput_1password_scim_getscimuser {
   locale?: string | undefined;
   timezone?: string | undefined;
   active?: boolean | undefined;
-  emails?: ({  value: string;
+  emails?: ({  value?: string | undefined;
   display?: string | undefined;
   type?: string | undefined;
   primary?: boolean | undefined;})[];
-  groups?: ({  value: string;
+  phoneNumbers?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  ims?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  photos?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  addresses?: ({  formatted?: string | undefined;
+  streetAddress?: string | undefined;
+  locality?: string | undefined;
+  region?: string | undefined;
+  postalCode?: string | undefined;
+  country?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  groups?: ({  value?: string | undefined;
   display?: string | undefined;
   type?: string | undefined;
   "$ref"?: string | undefined;})[];
-  roles?: ({})[] | undefined;
-  entitlements?: ({})[] | undefined;
+  entitlements?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  roles?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  x509Certificates?: ({  value?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;
+  primary?: boolean | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  version?: string | undefined;
+  location?: string | undefined;};
 };
 
 export interface ActionInput_1password_scim_getserviceproviderconfig {
 };
 
 export interface ActionOutput_1password_scim_getserviceproviderconfig {
-  schemas?: string[] | undefined;
-  id?: string | undefined;
-  meta?: {  resourceType?: string | undefined;
-  created?: string | undefined;
-  lastModified?: string | undefined;
-  location?: string | undefined;
-  version?: string | undefined;};
+  schemas: string[];
   documentationUri?: string | undefined;
-  patch?: {  supported?: boolean | undefined;};
-  bulk?: {  supported?: boolean | undefined;
-  maxOperations?: number | undefined;
-  maxPayloadSize?: number | undefined;};
-  filter?: {  supported?: boolean | undefined;
-  maxResults?: number | undefined;};
-  changePassword?: {  supported?: boolean | undefined;};
-  sort?: {  supported?: boolean | undefined;};
-  etag?: {  supported?: boolean | undefined;};
-  authenticationSchemes?: ({  name?: string | undefined;
-  description?: string | undefined;
+  patch: {  supported: boolean;};
+  bulk: {  supported: boolean;
+  maxOperations: number;
+  maxPayloadSize: number;};
+  filter: {  supported: boolean;
+  maxResults: number;};
+  changePassword: {  supported: boolean;};
+  sort: {  supported: boolean;};
+  etag: {  supported: boolean;};
+  authenticationSchemes: ({  name: string;
+  description: string;
   specUri?: string | undefined;
   documentationUri?: string | undefined;
-  type?: string | undefined;
+  type: string;
   primary?: boolean | undefined;})[];
+  meta?: {  location: string;
+  resourceType: string;
+  created?: string | undefined;
+  lastModified?: string | undefined;
+  version?: string | undefined;};
 };
 
 export interface ActionInput_1password_scim_listresourcetypes {
@@ -243,31 +266,44 @@ export interface ActionInput_1password_scim_listresourcetypes {
 
 export interface ActionOutput_1password_scim_listresourcetypes {
   schemas?: string[] | undefined;
-  totalResults?: number | undefined;
-  itemsPerPage?: number | undefined;
-  startIndex?: number | undefined;
-  Resources?: ({  schemas?: string[] | undefined;
-  id?: string | undefined;
-  name?: string | undefined;
+  totalResults: number;
+  Resources: ({  schemas?: string[] | undefined;
+  id: string;
+  name: string;
+  endpoint: string;
   description?: string | undefined;
-  endpoint?: string | undefined;
-  schema?: string | undefined;
-  schemaExtensions?: ({  schema?: string | undefined;
-  required?: boolean | undefined;})[];
+  schema: string;
+  schemaExtensions?: ({  schema: string;
+  required: boolean;})[] | undefined;
   meta?: {  resourceType?: string | undefined;
   location?: string | undefined;};})[];
+  startIndex?: number | undefined;
+  itemsPerPage?: number | undefined;
 };
 
 export interface ActionInput_1password_scim_listschemas {
 };
 
 export interface ActionOutput_1password_scim_listschemas {
-  schemas?: string[] | undefined;
-  totalResults?: number | undefined;
-  Resources?: ({  id: string;
-  name?: string | undefined;
+  schemas?: ({  id: string;
+  name: string;
   description?: string | undefined;
-  attributes?: unknown[] | undefined;})[];
+  attributes?: ({  name: string;
+  type?: string | undefined;
+  multiValued?: boolean | undefined;
+  required?: boolean | undefined;
+  mutability?: string | undefined;
+  returned?: string | undefined;
+  uniqueness?: string | undefined;
+  description?: string | undefined;
+  subAttributes?: ({  name: string;
+  type?: string | undefined;
+  multiValued?: boolean | undefined;
+  required?: boolean | undefined;
+  mutability?: string | undefined;
+  returned?: string | undefined;
+  uniqueness?: string | undefined;
+  description?: string | undefined;})[];})[];})[];
 };
 
 export interface ActionInput_1password_scim_listscimgroups {
@@ -276,40 +312,41 @@ export interface ActionInput_1password_scim_listscimgroups {
    */
   cursor?: string | undefined;
   /**
-   * SCIM filter expression. Example: 'displayName eq "Engineering"'
-   */
-  filter?: string | undefined;
-  /**
-   * Number of results per page (1-250). Defaults to 100.
+   * Number of results per page. Defaults to 100.
    */
   count?: number | undefined;
+  /**
+   * SCIM filter expression. Example: displayName co "Engineering"
+   */
+  filter?: string | undefined;
 };
 
 export interface ActionOutput_1password_scim_listscimgroups {
-  groups: ({  id: string;
-  displayName: string;
-  members?: ({  value: string;
-  display?: string | undefined;
-  type?: string | undefined;})[];
+  items: ({  schemas: string[];
+  id: string;
+  externalId?: string | undefined;
   meta?: {  resourceType?: string | undefined;
   created?: string | undefined;
   lastModified?: string | undefined;
   location?: string | undefined;
   version?: string | undefined;};
-  externalId?: string | undefined;
-  schemas?: string[] | undefined;})[];
-  next_cursor?: string | undefined;
+  displayName: string;
+  members?: ({  value?: string | undefined;
+  "$ref"?: string | undefined;
+  display?: string | undefined;
+  type?: string | undefined;})[];})[];
+  nextCursor?: string | undefined;
 };
 
 export interface ActionInput_1password_scim_listscimusers {
   /**
-   * SCIM filter query. Example: userName eq "john.doe@example.com"
+   * Pagination cursor from the previous response. Omit for the first page.
+   */
+  cursor?: string | undefined;
+  /**
+   * SCIM filter expression. Example: userName eq "user@example.com"
    */
   filter?: string | undefined;
-  /**
-   * 1-based index of the first result to return.
-   */
-  start_index?: number | undefined;
   /**
    * Number of results to return per page.
    */
@@ -317,54 +354,47 @@ export interface ActionInput_1password_scim_listscimusers {
 };
 
 export interface ActionOutput_1password_scim_listscimusers {
-  users: ({  id: string;
+  items: ({  id: string;
   userName: string;
-  name?: {  familyName?: string | undefined;
-  givenName?: string | undefined;
-  formatted?: string | undefined;};
-  emails?: ({  value: string;
-  type?: string | undefined;
-  primary?: boolean | undefined;})[];
+  name?: {  formatted?: string | undefined;
+  familyName?: string | undefined;
+  givenName?: string | undefined;};
+  displayName?: string | undefined;
   active?: boolean | undefined;
-  externalId?: string | undefined;
-  meta?: {  created?: string | undefined;
-  lastModified?: string | undefined;
-  resourceType?: string | undefined;};
-  schemas?: string[] | undefined;})[];
-  total_results: number;
-  start_index?: number | undefined;
-  items_per_page?: number | undefined;
-  next_start_index?: number | undefined;
+  emails?: ({  value: string;
+  primary?: boolean | undefined;
+  type?: string | undefined;})[];})[];
+  totalResults?: number | undefined;
+  nextCursor?: string | undefined;
 };
 
 export interface ActionInput_1password_scim_patchscimgroup {
   /**
-   * The SCIM group ID to patch. Example: "group-123"
+   * SCIM Group ID. Example: "9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d"
    */
-  group_id: string;
+  id: string;
   /**
-   * SCIM PatchOp operations to apply.
+   * SCIM patch operations to apply to the group.
    */
-  operations: ({  0: {  op: 'add';
+  operations: ({  op: 'add' | 'remove' | 'replace';
+  /**
+   * Target attribute path. Example: "members" or "displayName"
+   */
   path?: string | undefined;
-  value?: unknown | undefined;};
-  1: {  op: 'replace';
-  path?: string | undefined;
-  value?: unknown | undefined;};
-  2: {  op: 'remove';
-  path: string;
-  value?: unknown | undefined;};})[];
+  value?: string | ({  /**
+   * User ID. Example: "2819c223-7f76-453a-919d-413861904646"
+   */
+  value: string;
+  display?: string | undefined;
+  "$ref"?: string | undefined;})[] | {  [key: string]: unknown | undefined;};})[];
 };
 
 export interface ActionOutput_1password_scim_patchscimgroup {
-  schemas: string[];
   id: string;
   displayName?: string | undefined;
   members?: ({  value: string;
-  display?: string | undefined;
-  type?: string | undefined;
-  "$ref"?: string | undefined;})[];
-  meta?: {  resourceType: string;
+  display?: string | undefined;})[];
+  meta?: {  resourceType?: string | undefined;
   created?: string | undefined;
   lastModified?: string | undefined;
   location?: string | undefined;
@@ -374,33 +404,28 @@ export interface ActionOutput_1password_scim_patchscimgroup {
 
 export interface ActionInput_1password_scim_patchscimuser {
   /**
-   * The SCIM user ID to patch. Example: "2819c223-7f76-453a-919d-413861904646"
+   * SCIM User ID. Example: "2819c223-7f76-453a-919d-413861904646"
    */
   userId: string;
   /**
-   * SCIM patch operations to apply.
+   * SCIM PatchOp operations. Example: [{"op":"replace","path":"userName","value":"new@example.com"}]
    */
-  operations: ({  0: {  op: 'add';
+  operations: ({  op: 'add' | 'replace' | 'remove';
   path?: string | undefined;
-  value?: unknown | undefined;};
-  1: {  op: 'replace';
-  path?: string | undefined;
-  value?: unknown | undefined;};
-  2: {  op: 'remove';
-  path: string;
-  value?: unknown | undefined;};})[];
+  value?: unknown | undefined;})[];
 };
 
 export interface ActionOutput_1password_scim_patchscimuser {
+  schemas: string[];
   id: string;
   userName?: string | undefined;
-  externalId?: string | undefined;
-  displayName?: string | undefined;
   active?: boolean | undefined;
+  displayName?: string | undefined;
+  preferredLanguage?: string | undefined;
   name?: {  formatted?: string | undefined;
   familyName?: string | undefined;
   givenName?: string | undefined;};
-  emails?: ({  value?: string | undefined;
+  emails?: ({  value: string;
   type?: string | undefined;
   primary?: boolean | undefined;})[];
   meta?: {  resourceType?: string | undefined;
@@ -412,84 +437,63 @@ export interface ActionOutput_1password_scim_patchscimuser {
 
 export interface ActionInput_1password_scim_updatescimgroup {
   /**
-   * The unique identifier of the SCIM group to update. Example: "9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d"
+   * The SCIM group ID. Example: "27i3xrasou26ukebqazeadyhua"
    */
   groupId: string;
   /**
-   * The new display name for the group.
+   * New display name for the group
    */
   displayName?: string | undefined;
   /**
-   * Array of user IDs to add as members to the group.
+   * Member add or remove operations
    */
-  addMembers?: string[] | undefined;
-  /**
-   * Array of user IDs to remove from the group.
-   */
-  removeMembers?: string[] | undefined;
+  members?: ({  op: 'add' | 'remove';
+  userId: string;
+  display?: string | undefined;})[];
 };
 
 export interface ActionOutput_1password_scim_updatescimgroup {
   id: string;
-  schemas?: string[] | undefined;
   displayName?: string | undefined;
   members?: ({  value: string;
-  display?: string | undefined;
-  "$ref"?: string | undefined;
-  type?: string | undefined;})[];
-  meta?: {  resourceType?: string | undefined;
-  created?: string | undefined;
-  lastModified?: string | undefined;
-  location?: string | undefined;
-  version?: string | undefined;};
+  display?: string | undefined;})[];
 };
 
 export interface ActionInput_1password_scim_updatescimuser {
   /**
-   * SCIM user ID. Example: "2819c223-7f76-453a-919d-413861904646"
+   * SCIM User ID. Example: "2819c223-7f76-453a-919d-413861904646"
    */
   id: string;
   /**
-   * Array of SCIM PatchOp operations to apply
+   * User email address. Example: "user@example.com"
    */
-  operations: ({  0: {  op: 'add';
-  path?: string | undefined;
-  value?: unknown | undefined;};
-  1: {  op: 'replace';
-  path?: string | undefined;
-  value?: unknown | undefined;};
-  2: {  op: 'remove';
-  path: string;
-  value?: unknown | undefined;};})[];
+  userName?: string | undefined;
+  /**
+   * First name. Example: "Jane"
+   */
+  givenName?: string | undefined;
+  /**
+   * Last name. Example: "Doe"
+   */
+  familyName?: string | undefined;
+  /**
+   * Display name. Example: "Jane Doe"
+   */
+  displayName?: string | undefined;
+  /**
+   * Whether the user is active.
+   */
+  active?: boolean | undefined;
 };
 
 export interface ActionOutput_1password_scim_updatescimuser {
   id: string;
-  externalId?: string | undefined;
-  meta?: {  resourceType?: string | undefined;
-  created?: string | undefined;
-  lastModified?: string | undefined;
-  location?: string | undefined;
-  version?: string | undefined;};
-  schemas?: string[] | undefined;
   userName?: string | undefined;
-  name?: {  formatted?: string | undefined;
-  familyName?: string | undefined;
   givenName?: string | undefined;
-  middleName?: string | undefined;
-  honorificPrefix?: string | undefined;
-  honorificSuffix?: string | undefined;};
+  familyName?: string | undefined;
   displayName?: string | undefined;
-  nickName?: string | undefined;
-  profileUrl?: string | undefined;
-  title?: string | undefined;
-  userType?: string | undefined;
-  preferredLanguage?: string | undefined;
-  locale?: string | undefined;
-  timezone?: string | undefined;
   active?: boolean | undefined;
-  emails?: ({  value?: string | undefined;
-  display?: string | undefined;
+  emails?: ({  value: string;
   type?: string | undefined;
   primary?: boolean | undefined;})[];
 };
@@ -43342,18 +43346,6 @@ export interface ActionOutput_salesforce_upsertsobjectcollection {
 };
 
 export interface SyncMetadata_sap_success_factors_employees {
-};
-
-export interface Group {
-  id: string;
-  name: string;
-  description?: string | undefined;
-  isDefault?: boolean | undefined;
-  isDeleted?: boolean | undefined;
-  isPublic?: boolean | undefined;
-  createdAt?: string | undefined;
-  updatedAt?: string | undefined;
-  url?: string | undefined;
 };
 
 export interface SyncMetadata_sap_success_factors_groups {

--- a/integrations/1password-scim/actions/create-scim-group.ts
+++ b/integrations/1password-scim/actions/create-scim-group.ts
@@ -1,18 +1,15 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
+const MemberInputSchema = z.object({
+    value: z.string().describe('Identifier of the member. Example: "user-id-123"'),
+    display: z.string().optional().describe('Display name of the member.')
+});
+
 const InputSchema = z.object({
-    displayName: z.string().describe('The display name of the SCIM group. Example: "Engineering"'),
-    externalId: z.string().optional().describe('The external identifier for the group. Example: "group-123"'),
-    members: z
-        .array(
-            z.object({
-                value: z.string().describe('The identifier of the member. Example: "user-123"'),
-                display: z.string().optional().describe('The display name of the member. Example: "John Doe"')
-            })
-        )
-        .optional()
-        .describe('Array of group members to assign on creation')
+    displayName: z.string().describe('Display name of the SCIM group. Example: "Engineering"'),
+    externalId: z.string().optional().describe('External identifier for the group.'),
+    members: z.array(MemberInputSchema).optional().describe('Members to add to the group at creation.')
 });
 
 const ProviderMemberSchema = z.object({
@@ -31,7 +28,7 @@ const ProviderMetaSchema = z.object({
 });
 
 const ProviderGroupSchema = z.object({
-    schemas: z.array(z.string()),
+    schemas: z.array(z.string()).optional(),
     id: z.string(),
     displayName: z.string(),
     externalId: z.string().optional(),
@@ -63,8 +60,8 @@ const OutputSchema = z.object({
 });
 
 const action = createAction({
-    description: 'Create a SCIM group in 1Password SCIM',
-    version: '1.0.0',
+    description: 'Create a SCIM group in 1Password SCIM.',
+    version: '1.1.0',
     endpoint: {
         method: 'POST',
         path: '/actions/create-scim-group',
@@ -72,10 +69,10 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['Groups'],
+    scopes: [],
 
-    exec: async (nango, input) => {
-        const requestBody: Record<string, unknown> = {
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const requestBody = {
             schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
             displayName: input.displayName,
             ...(input.externalId !== undefined && { externalId: input.externalId }),
@@ -87,8 +84,8 @@ const action = createAction({
             })
         };
 
-        // https://support.1password.com/scim-endpoints/
         const response = await nango.post({
+            // https://support.1password.com/scim-endpoints/
             endpoint: '/Groups',
             data: requestBody,
             retries: 3
@@ -96,25 +93,27 @@ const action = createAction({
 
         const providerGroup = ProviderGroupSchema.parse(response.data);
 
+        const members = providerGroup.members?.map((member) => ({
+            value: member.value,
+            ...(member.display !== undefined && { display: member.display })
+        }));
+
+        const meta = providerGroup.meta
+            ? {
+                  ...(providerGroup.meta.resourceType !== undefined && { resourceType: providerGroup.meta.resourceType }),
+                  ...(providerGroup.meta.created !== undefined && { created: providerGroup.meta.created }),
+                  ...(providerGroup.meta.lastModified !== undefined && { lastModified: providerGroup.meta.lastModified }),
+                  ...(providerGroup.meta.location !== undefined && { location: providerGroup.meta.location }),
+                  ...(providerGroup.meta.version !== undefined && { version: providerGroup.meta.version })
+              }
+            : undefined;
+
         return {
             id: providerGroup.id,
             displayName: providerGroup.displayName,
             ...(providerGroup.externalId !== undefined && { externalId: providerGroup.externalId }),
-            ...(providerGroup.members !== undefined && {
-                members: providerGroup.members.map((member) => ({
-                    value: member.value,
-                    ...(member.display !== undefined && { display: member.display })
-                }))
-            }),
-            ...(providerGroup.meta !== undefined && {
-                meta: {
-                    ...(providerGroup.meta.resourceType !== undefined && { resourceType: providerGroup.meta.resourceType }),
-                    ...(providerGroup.meta.created !== undefined && { created: providerGroup.meta.created }),
-                    ...(providerGroup.meta.lastModified !== undefined && { lastModified: providerGroup.meta.lastModified }),
-                    ...(providerGroup.meta.location !== undefined && { location: providerGroup.meta.location }),
-                    ...(providerGroup.meta.version !== undefined && { version: providerGroup.meta.version })
-                }
-            })
+            ...(members !== undefined && { members }),
+            ...(meta !== undefined && { meta })
         };
     }
 });

--- a/integrations/1password-scim/actions/create-scim-group.ts
+++ b/integrations/1password-scim/actions/create-scim-group.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    displayName: z.string().describe('The display name of the SCIM group. Example: "Engineering"'),
+    externalId: z.string().optional().describe('The external identifier for the group. Example: "group-123"'),
+    members: z
+        .array(
+            z.object({
+                value: z.string().describe('The identifier of the member. Example: "user-123"'),
+                display: z.string().optional().describe('The display name of the member. Example: "John Doe"')
+            })
+        )
+        .optional()
+        .describe('Array of group members to assign on creation')
+});
+
+const ProviderMemberSchema = z.object({
+    value: z.string(),
+    display: z.string().optional(),
+    $ref: z.string().optional(),
+    type: z.string().optional()
+});
+
+const ProviderMetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ProviderGroupSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    displayName: z.string(),
+    externalId: z.string().optional(),
+    members: z.array(ProviderMemberSchema).optional(),
+    meta: ProviderMetaSchema.optional()
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    displayName: z.string(),
+    externalId: z.string().optional(),
+    members: z
+        .array(
+            z.object({
+                value: z.string(),
+                display: z.string().optional()
+            })
+        )
+        .optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional(),
+            version: z.string().optional()
+        })
+        .optional()
+});
+
+const action = createAction({
+    description: 'Create a SCIM group in 1Password SCIM',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/create-scim-group',
+        group: 'Groups'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: ['Groups'],
+
+    exec: async (nango, input) => {
+        const requestBody: Record<string, unknown> = {
+            schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+            displayName: input.displayName,
+            ...(input.externalId !== undefined && { externalId: input.externalId }),
+            ...(input.members !== undefined && {
+                members: input.members.map((member) => ({
+                    value: member.value,
+                    ...(member.display !== undefined && { display: member.display })
+                }))
+            })
+        };
+
+        // https://support.1password.com/scim-endpoints/
+        const response = await nango.post({
+            endpoint: '/Groups',
+            data: requestBody,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        });
+
+        const providerGroup = ProviderGroupSchema.parse(response.data);
+
+        return {
+            id: providerGroup.id,
+            displayName: providerGroup.displayName,
+            ...(providerGroup.externalId !== undefined && { externalId: providerGroup.externalId }),
+            ...(providerGroup.members !== undefined && {
+                members: providerGroup.members.map((member) => ({
+                    value: member.value,
+                    ...(member.display !== undefined && { display: member.display })
+                }))
+            }),
+            ...(providerGroup.meta !== undefined && {
+                meta: {
+                    ...(providerGroup.meta.resourceType !== undefined && { resourceType: providerGroup.meta.resourceType }),
+                    ...(providerGroup.meta.created !== undefined && { created: providerGroup.meta.created }),
+                    ...(providerGroup.meta.lastModified !== undefined && { lastModified: providerGroup.meta.lastModified }),
+                    ...(providerGroup.meta.location !== undefined && { location: providerGroup.meta.location }),
+                    ...(providerGroup.meta.version !== undefined && { version: providerGroup.meta.version })
+                }
+            })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/create-scim-group.ts
+++ b/integrations/1password-scim/actions/create-scim-group.ts
@@ -91,7 +91,6 @@ const action = createAction({
         const response = await nango.post({
             endpoint: '/Groups',
             data: requestBody,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         });
 

--- a/integrations/1password-scim/actions/create-scim-user.ts
+++ b/integrations/1password-scim/actions/create-scim-user.ts
@@ -77,7 +77,6 @@ const action = createAction({
         const response = await nango.post({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Users',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             data: payload,
             retries: 3
         });

--- a/integrations/1password-scim/actions/create-scim-user.ts
+++ b/integrations/1password-scim/actions/create-scim-user.ts
@@ -1,44 +1,56 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const ScimEmailSchema = z.object({
+const NameSchema = z.object({
+    givenName: z.string().optional(),
+    familyName: z.string().optional(),
+    formatted: z.string().optional()
+});
+
+const EmailSchema = z.object({
     value: z.string(),
     type: z.string().optional(),
     primary: z.boolean().optional()
 });
 
-const ScimNameSchema = z.object({
+const InputSchema = z.object({
+    userName: z.string().describe('User login name, typically an email. Example: "bjensen@example.com"'),
+    externalId: z.string().optional().describe('Identifier from the provisioning client. Example: "bjensen"'),
+    name: NameSchema.optional(),
+    displayName: z.string().optional(),
+    emails: z.array(EmailSchema).optional(),
+    active: z.boolean().optional().describe('Whether the user is active.')
+});
+
+const ProviderNameSchema = z.looseObject({
     formatted: z.string().optional(),
     familyName: z.string().optional(),
     givenName: z.string().optional()
 });
 
-const ScimMetaSchema = z.object({
+const ProviderEmailSchema = z.looseObject({
+    value: z.string(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ProviderMetaSchema = z.looseObject({
     resourceType: z.string().optional(),
     created: z.string().optional(),
     lastModified: z.string().optional(),
     location: z.string().optional()
 });
 
-const InputSchema = z.object({
-    userName: z.string().describe('SCIM userName. Example: "user@example.com"'),
-    externalId: z.string().optional().describe('External identifier for the user.'),
-    displayName: z.string().optional().describe('Display name for the user.'),
-    name: ScimNameSchema.optional(),
-    emails: z.array(ScimEmailSchema).optional(),
-    active: z.boolean().optional()
-});
-
-const ProviderUserSchema = z.object({
+const ProviderUserSchema = z.looseObject({
     schemas: z.array(z.string()),
     id: z.string(),
-    userName: z.string(),
     externalId: z.string().optional(),
+    userName: z.string(),
+    name: ProviderNameSchema.optional(),
     displayName: z.string().optional(),
-    name: ScimNameSchema.optional(),
-    emails: z.array(ScimEmailSchema).optional(),
+    emails: z.array(ProviderEmailSchema).optional(),
     active: z.boolean().optional(),
-    meta: ScimMetaSchema.optional()
+    meta: ProviderMetaSchema.optional()
 });
 
 const OutputSchema = z.object({
@@ -46,15 +58,36 @@ const OutputSchema = z.object({
     userName: z.string(),
     externalId: z.string().optional(),
     displayName: z.string().optional(),
-    name: ScimNameSchema.optional(),
-    emails: z.array(ScimEmailSchema).optional(),
+    name: z
+        .object({
+            givenName: z.string().optional(),
+            familyName: z.string().optional(),
+            formatted: z.string().optional()
+        })
+        .optional(),
+    emails: z
+        .array(
+            z.object({
+                value: z.string(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
     active: z.boolean().optional(),
-    meta: ScimMetaSchema.optional()
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional()
+        })
+        .optional()
 });
 
 const action = createAction({
     description: 'Create a SCIM user in 1Password SCIM.',
-    version: '1.0.0',
+    version: '1.1.0',
     endpoint: {
         method: 'POST',
         path: '/actions/create-scim-user',
@@ -62,31 +95,26 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
+    scopes: [],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const payload: Record<string, unknown> = {
+        const requestBody: Record<string, unknown> = {
             schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
             userName: input.userName,
             ...(input.externalId !== undefined && { externalId: input.externalId }),
-            ...(input.displayName !== undefined && { displayName: input.displayName }),
             ...(input.name !== undefined && { name: input.name }),
+            ...(input.displayName !== undefined && { displayName: input.displayName }),
             ...(input.emails !== undefined && { emails: input.emails }),
             ...(input.active !== undefined && { active: input.active })
         };
 
         const response = await nango.post({
             // https://support.1password.com/scim-endpoints/
+            // https://datatracker.ietf.org/doc/html/rfc7644#section-3.3
             endpoint: '/Users',
-            data: payload,
+            data: requestBody,
             retries: 3
         });
-
-        if (!response.data) {
-            throw new nango.ActionError({
-                type: 'creation_failed',
-                message: 'Failed to create SCIM user: empty response from provider.'
-            });
-        }
 
         const providerUser = ProviderUserSchema.parse(response.data);
 
@@ -95,10 +123,29 @@ const action = createAction({
             userName: providerUser.userName,
             ...(providerUser.externalId !== undefined && { externalId: providerUser.externalId }),
             ...(providerUser.displayName !== undefined && { displayName: providerUser.displayName }),
-            ...(providerUser.name !== undefined && { name: providerUser.name }),
-            ...(providerUser.emails !== undefined && { emails: providerUser.emails }),
+            ...(providerUser.name !== undefined && {
+                name: {
+                    ...(providerUser.name.givenName !== undefined && { givenName: providerUser.name.givenName }),
+                    ...(providerUser.name.familyName !== undefined && { familyName: providerUser.name.familyName }),
+                    ...(providerUser.name.formatted !== undefined && { formatted: providerUser.name.formatted })
+                }
+            }),
+            ...(providerUser.emails !== undefined && {
+                emails: providerUser.emails.map((email) => ({
+                    value: email.value,
+                    ...(email.type !== undefined && { type: email.type }),
+                    ...(email.primary !== undefined && { primary: email.primary })
+                }))
+            }),
             ...(providerUser.active !== undefined && { active: providerUser.active }),
-            ...(providerUser.meta !== undefined && { meta: providerUser.meta })
+            ...(providerUser.meta !== undefined && {
+                meta: {
+                    ...(providerUser.meta.resourceType !== undefined && { resourceType: providerUser.meta.resourceType }),
+                    ...(providerUser.meta.created !== undefined && { created: providerUser.meta.created }),
+                    ...(providerUser.meta.lastModified !== undefined && { lastModified: providerUser.meta.lastModified }),
+                    ...(providerUser.meta.location !== undefined && { location: providerUser.meta.location })
+                }
+            })
         };
     }
 });

--- a/integrations/1password-scim/actions/create-scim-user.ts
+++ b/integrations/1password-scim/actions/create-scim-user.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const ScimEmailSchema = z.object({
+    value: z.string(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ScimNameSchema = z.object({
+    formatted: z.string().optional(),
+    familyName: z.string().optional(),
+    givenName: z.string().optional()
+});
+
+const ScimMetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional()
+});
+
+const InputSchema = z.object({
+    userName: z.string().describe('SCIM userName. Example: "user@example.com"'),
+    externalId: z.string().optional().describe('External identifier for the user.'),
+    displayName: z.string().optional().describe('Display name for the user.'),
+    name: ScimNameSchema.optional(),
+    emails: z.array(ScimEmailSchema).optional(),
+    active: z.boolean().optional()
+});
+
+const ProviderUserSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    userName: z.string(),
+    externalId: z.string().optional(),
+    displayName: z.string().optional(),
+    name: ScimNameSchema.optional(),
+    emails: z.array(ScimEmailSchema).optional(),
+    active: z.boolean().optional(),
+    meta: ScimMetaSchema.optional()
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    userName: z.string(),
+    externalId: z.string().optional(),
+    displayName: z.string().optional(),
+    name: ScimNameSchema.optional(),
+    emails: z.array(ScimEmailSchema).optional(),
+    active: z.boolean().optional(),
+    meta: ScimMetaSchema.optional()
+});
+
+const action = createAction({
+    description: 'Create a SCIM user in 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/create-scim-user',
+        group: 'Users'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const payload: Record<string, unknown> = {
+            schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            userName: input.userName,
+            ...(input.externalId !== undefined && { externalId: input.externalId }),
+            ...(input.displayName !== undefined && { displayName: input.displayName }),
+            ...(input.name !== undefined && { name: input.name }),
+            ...(input.emails !== undefined && { emails: input.emails }),
+            ...(input.active !== undefined && { active: input.active })
+        };
+
+        const response = await nango.post({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/Users',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            data: payload,
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'creation_failed',
+                message: 'Failed to create SCIM user: empty response from provider.'
+            });
+        }
+
+        const providerUser = ProviderUserSchema.parse(response.data);
+
+        return {
+            id: providerUser.id,
+            userName: providerUser.userName,
+            ...(providerUser.externalId !== undefined && { externalId: providerUser.externalId }),
+            ...(providerUser.displayName !== undefined && { displayName: providerUser.displayName }),
+            ...(providerUser.name !== undefined && { name: providerUser.name }),
+            ...(providerUser.emails !== undefined && { emails: providerUser.emails }),
+            ...(providerUser.active !== undefined && { active: providerUser.active }),
+            ...(providerUser.meta !== undefined && { meta: providerUser.meta })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/delete-scim-group.ts
+++ b/integrations/1password-scim/actions/delete-scim-group.ts
@@ -27,7 +27,6 @@ const action = createAction({
         const config: ProxyConfiguration = {
             // https://support.1password.com/scim-endpoints/
             endpoint: `/Groups/${encodeURIComponent(input.id)}`,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         };
 

--- a/integrations/1password-scim/actions/delete-scim-group.ts
+++ b/integrations/1password-scim/actions/delete-scim-group.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+import type { ProxyConfiguration } from 'nango';
+
+const InputSchema = z.object({
+    id: z.string().describe('SCIM Group ID. Example: "group-123"')
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    deleted: z.boolean()
+});
+
+const action = createAction({
+    description: 'Delete or archive a SCIM group in 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/delete-scim-group',
+        group: 'Groups'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: ['scim'],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const config: ProxyConfiguration = {
+            // https://support.1password.com/scim-endpoints/
+            endpoint: `/Groups/${encodeURIComponent(input.id)}`,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        };
+
+        await nango.delete(config);
+
+        return {
+            id: input.id,
+            deleted: true
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/delete-scim-user.ts
+++ b/integrations/1password-scim/actions/delete-scim-user.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    id: z.string().describe('SCIM user ID to delete. Example: "123"')
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    deleted: z.boolean()
+});
+
+const action = createAction({
+    description: 'Delete or archive a SCIM user in 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/delete-scim-user',
+        group: 'Users'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://support.1password.com/scim-endpoints/
+        await nango.delete({
+            endpoint: `/Users/${encodeURIComponent(input.id)}`,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        });
+
+        return {
+            id: input.id,
+            deleted: true
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/delete-scim-user.ts
+++ b/integrations/1password-scim/actions/delete-scim-user.ts
@@ -25,7 +25,6 @@ const action = createAction({
         // https://support.1password.com/scim-endpoints/
         await nango.delete({
             endpoint: `/Users/${encodeURIComponent(input.id)}`,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         });
 

--- a/integrations/1password-scim/actions/get-scim-group.ts
+++ b/integrations/1password-scim/actions/get-scim-group.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    groupId: z.string().describe('SCIM Group ID. Example: "e9e30dba-f08f-4109-8486-d5c6a331660a"')
+});
+
+const MemberSchema = z.object({
+    value: z.string().describe('The ID of the SCIM resource'),
+    display: z.string().optional(),
+    $ref: z.string().optional(),
+    type: z.string().optional()
+});
+
+const MetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ProviderGroupSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    externalId: z.string().optional(),
+    displayName: z.string(),
+    members: z.array(MemberSchema).optional(),
+    meta: MetaSchema.optional()
+});
+
+const OutputSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    externalId: z.string().optional(),
+    displayName: z.string(),
+    members: z.array(MemberSchema).optional(),
+    meta: MetaSchema.optional()
+});
+
+const action = createAction({
+    description: 'Retrieve a single SCIM group from 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'GET',
+        path: '/actions/get-scim-group',
+        group: 'Groups'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: ['scim'],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://support.1password.com/scim-endpoints/
+        const response = await nango.get({
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            endpoint: '/Groups/' + encodeURIComponent(input.groupId),
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'Group not found',
+                groupId: input.groupId
+            });
+        }
+
+        const providerGroup = ProviderGroupSchema.parse(response.data);
+
+        return {
+            schemas: providerGroup.schemas,
+            id: providerGroup.id,
+            displayName: providerGroup.displayName,
+            ...(providerGroup.externalId !== undefined && { externalId: providerGroup.externalId }),
+            ...(providerGroup.members !== undefined && { members: providerGroup.members }),
+            ...(providerGroup.meta !== undefined && { meta: providerGroup.meta })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/get-scim-group.ts
+++ b/integrations/1password-scim/actions/get-scim-group.ts
@@ -2,17 +2,16 @@ import { z } from 'zod';
 import { createAction } from 'nango';
 
 const InputSchema = z.object({
-    groupId: z.string().describe('SCIM Group ID. Example: "e9e30dba-f08f-4109-8486-d5c6a331660a"')
+    id: z.string().describe('The SCIM group ID. Example: "2819c223-7f76-453a-919d-413861904646"')
 });
 
-const MemberSchema = z.object({
-    value: z.string().describe('The ID of the SCIM resource'),
-    display: z.string().optional(),
+const ProviderMemberSchema = z.object({
+    value: z.string(),
     $ref: z.string().optional(),
-    type: z.string().optional()
+    display: z.string().optional()
 });
 
-const MetaSchema = z.object({
+const ProviderMetaSchema = z.object({
     resourceType: z.string().optional(),
     created: z.string().optional(),
     lastModified: z.string().optional(),
@@ -24,23 +23,39 @@ const ProviderGroupSchema = z.object({
     schemas: z.array(z.string()),
     id: z.string(),
     externalId: z.string().optional(),
+    meta: ProviderMetaSchema.optional(),
     displayName: z.string(),
-    members: z.array(MemberSchema).optional(),
-    meta: MetaSchema.optional()
+    members: z.array(ProviderMemberSchema).optional()
 });
 
 const OutputSchema = z.object({
     schemas: z.array(z.string()),
     id: z.string(),
     externalId: z.string().optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional(),
+            version: z.string().optional()
+        })
+        .optional(),
     displayName: z.string(),
-    members: z.array(MemberSchema).optional(),
-    meta: MetaSchema.optional()
+    members: z
+        .array(
+            z.object({
+                value: z.string(),
+                $ref: z.string().optional(),
+                display: z.string().optional()
+            })
+        )
+        .optional()
 });
 
 const action = createAction({
     description: 'Retrieve a single SCIM group from 1Password SCIM.',
-    version: '1.0.0',
+    version: '1.1.0',
     endpoint: {
         method: 'GET',
         path: '/actions/get-scim-group',
@@ -48,12 +63,11 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['scim'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         // https://support.1password.com/scim-endpoints/
         const response = await nango.get({
-            endpoint: '/Groups/' + encodeURIComponent(input.groupId),
+            endpoint: `/Groups/${encodeURIComponent(input.id)}`,
             retries: 3
         });
 
@@ -61,7 +75,7 @@ const action = createAction({
             throw new nango.ActionError({
                 type: 'not_found',
                 message: 'Group not found',
-                groupId: input.groupId
+                id: input.id
             });
         }
 
@@ -72,8 +86,22 @@ const action = createAction({
             id: providerGroup.id,
             displayName: providerGroup.displayName,
             ...(providerGroup.externalId !== undefined && { externalId: providerGroup.externalId }),
-            ...(providerGroup.members !== undefined && { members: providerGroup.members }),
-            ...(providerGroup.meta !== undefined && { meta: providerGroup.meta })
+            ...(providerGroup.meta !== undefined && {
+                meta: {
+                    ...(providerGroup.meta.resourceType !== undefined && { resourceType: providerGroup.meta.resourceType }),
+                    ...(providerGroup.meta.created !== undefined && { created: providerGroup.meta.created }),
+                    ...(providerGroup.meta.lastModified !== undefined && { lastModified: providerGroup.meta.lastModified }),
+                    ...(providerGroup.meta.location !== undefined && { location: providerGroup.meta.location }),
+                    ...(providerGroup.meta.version !== undefined && { version: providerGroup.meta.version })
+                }
+            }),
+            ...(providerGroup.members !== undefined && {
+                members: providerGroup.members.map((member) => ({
+                    value: member.value,
+                    ...(member['$ref'] !== undefined && { $ref: member['$ref'] }),
+                    ...(member.display !== undefined && { display: member.display })
+                }))
+            })
         };
     }
 });

--- a/integrations/1password-scim/actions/get-scim-group.ts
+++ b/integrations/1password-scim/actions/get-scim-group.ts
@@ -53,7 +53,6 @@ const action = createAction({
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         // https://support.1password.com/scim-endpoints/
         const response = await nango.get({
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             endpoint: '/Groups/' + encodeURIComponent(input.groupId),
             retries: 3
         });

--- a/integrations/1password-scim/actions/get-scim-user.ts
+++ b/integrations/1password-scim/actions/get-scim-user.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+import { createAction, type ProxyConfiguration } from 'nango';
+
+const InputSchema = z.object({
+    id: z.string().describe('The SCIM user ID. Example: "123"')
+});
+
+const ScimMetaSchema = z
+    .object({
+        resourceType: z.string().optional(),
+        created: z.string().optional(),
+        lastModified: z.string().optional(),
+        location: z.string().optional(),
+        version: z.string().optional()
+    })
+    .passthrough();
+
+const ScimNameSchema = z
+    .object({
+        formatted: z.string().optional(),
+        familyName: z.string().optional(),
+        givenName: z.string().optional(),
+        middleName: z.string().optional(),
+        honorificPrefix: z.string().optional(),
+        honorificSuffix: z.string().optional()
+    })
+    .passthrough();
+
+const ScimEmailSchema = z
+    .object({
+        value: z.string(),
+        display: z.string().optional(),
+        type: z.string().optional(),
+        primary: z.boolean().optional()
+    })
+    .passthrough();
+
+const ScimGroupSchema = z
+    .object({
+        value: z.string(),
+        display: z.string().optional(),
+        type: z.string().optional(),
+        $ref: z.string().optional()
+    })
+    .passthrough();
+
+const ScimUserSchema = z
+    .object({
+        schemas: z.array(z.string()),
+        id: z.string(),
+        externalId: z.string().optional(),
+        meta: ScimMetaSchema.optional(),
+        userName: z.string(),
+        name: ScimNameSchema.optional(),
+        displayName: z.string().optional(),
+        nickName: z.string().optional(),
+        profileUrl: z.string().optional(),
+        title: z.string().optional(),
+        userType: z.string().optional(),
+        preferredLanguage: z.string().optional(),
+        locale: z.string().optional(),
+        timezone: z.string().optional(),
+        active: z.boolean().optional(),
+        emails: z.array(ScimEmailSchema).optional(),
+        groups: z.array(ScimGroupSchema).optional(),
+        roles: z.array(z.object({}).passthrough()).optional(),
+        entitlements: z.array(z.object({}).passthrough()).optional()
+    })
+    .passthrough();
+
+const OutputSchema = ScimUserSchema;
+
+const action = createAction({
+    description: 'Retrieve a single SCIM user from 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'GET',
+        path: '/actions/get-scim-user',
+        group: 'Users'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const config: ProxyConfiguration = {
+            // https://support.1password.com/scim-endpoints/
+            endpoint: `/Users/${encodeURIComponent(input.id)}`,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        };
+
+        const response = await nango.get(config);
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'User not found',
+                id: input.id
+            });
+        }
+
+        const user = ScimUserSchema.parse(response.data);
+        return user;
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/get-scim-user.ts
+++ b/integrations/1password-scim/actions/get-scim-user.ts
@@ -1,78 +1,136 @@
 import { z } from 'zod';
-import { createAction, type ProxyConfiguration } from 'nango';
+import { createAction } from 'nango';
 
 const InputSchema = z.object({
-    id: z.string().describe('The SCIM user ID. Example: "123"')
+    id: z.string().describe('SCIM User ID. Example: "2819c223-7f76-453a-919d-413861904646"')
 });
 
-const ScimMetaSchema = z
-    .object({
-        resourceType: z.string().optional(),
-        created: z.string().optional(),
-        lastModified: z.string().optional(),
-        location: z.string().optional(),
-        version: z.string().optional()
-    })
-    .passthrough();
+const NameSchema = z.object({
+    formatted: z.string().optional(),
+    familyName: z.string().optional(),
+    givenName: z.string().optional(),
+    middleName: z.string().optional(),
+    honorificPrefix: z.string().optional(),
+    honorificSuffix: z.string().optional()
+});
 
-const ScimNameSchema = z
-    .object({
-        formatted: z.string().optional(),
-        familyName: z.string().optional(),
-        givenName: z.string().optional(),
-        middleName: z.string().optional(),
-        honorificPrefix: z.string().optional(),
-        honorificSuffix: z.string().optional()
-    })
-    .passthrough();
+const EmailSchema = z.object({
+    value: z.string().optional(),
+    display: z.string().optional(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
 
-const ScimEmailSchema = z
-    .object({
-        value: z.string(),
-        display: z.string().optional(),
-        type: z.string().optional(),
-        primary: z.boolean().optional()
-    })
-    .passthrough();
+const PhoneNumberSchema = z.object({
+    value: z.string().optional(),
+    display: z.string().optional(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
 
-const ScimGroupSchema = z
-    .object({
-        value: z.string(),
-        display: z.string().optional(),
-        type: z.string().optional(),
-        $ref: z.string().optional()
-    })
-    .passthrough();
+const AddressSchema = z.object({
+    formatted: z.string().optional(),
+    streetAddress: z.string().optional(),
+    locality: z.string().optional(),
+    region: z.string().optional(),
+    postalCode: z.string().optional(),
+    country: z.string().optional(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
 
-const ScimUserSchema = z
-    .object({
-        schemas: z.array(z.string()),
-        id: z.string(),
-        externalId: z.string().optional(),
-        meta: ScimMetaSchema.optional(),
-        userName: z.string(),
-        name: ScimNameSchema.optional(),
-        displayName: z.string().optional(),
-        nickName: z.string().optional(),
-        profileUrl: z.string().optional(),
-        title: z.string().optional(),
-        userType: z.string().optional(),
-        preferredLanguage: z.string().optional(),
-        locale: z.string().optional(),
-        timezone: z.string().optional(),
-        active: z.boolean().optional(),
-        emails: z.array(ScimEmailSchema).optional(),
-        groups: z.array(ScimGroupSchema).optional(),
-        roles: z.array(z.object({}).passthrough()).optional(),
-        entitlements: z.array(z.object({}).passthrough()).optional()
-    })
-    .passthrough();
+const GroupSchema = z.object({
+    value: z.string().optional(),
+    display: z.string().optional(),
+    type: z.string().optional(),
+    $ref: z.string().optional()
+});
 
-const OutputSchema = ScimUserSchema;
+const MetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    version: z.string().optional(),
+    location: z.string().optional()
+});
+
+const ProviderUserSchema = z.looseObject({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    externalId: z.string().optional(),
+    userName: z.string().optional(),
+    name: NameSchema.optional(),
+    displayName: z.string().optional(),
+    nickName: z.string().optional(),
+    profileUrl: z.string().optional(),
+    title: z.string().optional(),
+    userType: z.string().optional(),
+    preferredLanguage: z.string().optional(),
+    locale: z.string().optional(),
+    timezone: z.string().optional(),
+    active: z.boolean().optional(),
+    emails: z.array(EmailSchema).optional(),
+    phoneNumbers: z.array(PhoneNumberSchema).optional(),
+    ims: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                display: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
+    photos: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                display: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
+    addresses: z.array(AddressSchema).optional(),
+    groups: z.array(GroupSchema).optional(),
+    entitlements: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                display: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
+    roles: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                display: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
+    x509Certificates: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                display: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
+    meta: MetaSchema.optional()
+});
+
+const OutputSchema = ProviderUserSchema;
 
 const action = createAction({
     description: 'Retrieve a single SCIM user from 1Password SCIM.',
-    version: '1.0.0',
+    version: '1.1.0',
     endpoint: {
         method: 'GET',
         path: '/actions/get-scim-user',
@@ -82,14 +140,12 @@ const action = createAction({
     output: OutputSchema,
     scopes: [],
 
-    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const config: ProxyConfiguration = {
+    exec: async (nango, input) => {
+        const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: `/Users/${encodeURIComponent(input.id)}`,
             retries: 3
-        };
-
-        const response = await nango.get(config);
+        });
 
         if (!response.data) {
             throw new nango.ActionError({
@@ -99,8 +155,8 @@ const action = createAction({
             });
         }
 
-        const user = ScimUserSchema.parse(response.data);
-        return user;
+        const providerUser = ProviderUserSchema.parse(response.data);
+        return providerUser;
     }
 });
 

--- a/integrations/1password-scim/actions/get-scim-user.ts
+++ b/integrations/1password-scim/actions/get-scim-user.ts
@@ -86,7 +86,6 @@ const action = createAction({
         const config: ProxyConfiguration = {
             // https://support.1password.com/scim-endpoints/
             endpoint: `/Users/${encodeURIComponent(input.id)}`,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         };
 

--- a/integrations/1password-scim/actions/get-service-provider-config.ts
+++ b/integrations/1password-scim/actions/get-service-provider-config.ts
@@ -3,64 +3,49 @@ import { createAction } from 'nango';
 
 const InputSchema = z.object({});
 
-const SupportedConfigSchema = z.object({
-    supported: z.boolean().optional()
-});
-
-const BulkConfigSchema = z.object({
-    supported: z.boolean().optional(),
-    maxOperations: z.number().optional(),
-    maxPayloadSize: z.number().optional()
-});
-
-const FilterConfigSchema = z.object({
-    supported: z.boolean().optional(),
-    maxResults: z.number().optional()
-});
-
 const AuthenticationSchemeSchema = z.object({
-    name: z.string().optional(),
-    description: z.string().optional(),
+    name: z.string(),
+    description: z.string(),
     specUri: z.string().optional(),
     documentationUri: z.string().optional(),
-    type: z.string().optional(),
+    type: z.string(),
     primary: z.boolean().optional()
 });
 
 const MetaSchema = z.object({
-    resourceType: z.string().optional(),
+    location: z.string(),
+    resourceType: z.string(),
     created: z.string().optional(),
     lastModified: z.string().optional(),
-    location: z.string().optional(),
     version: z.string().optional()
 });
 
-const ProviderServiceProviderConfigSchema = z.object({
-    schemas: z.array(z.string()).optional(),
-    id: z.string().optional(),
-    meta: MetaSchema.optional(),
-    documentationUri: z.string().optional(),
-    patch: SupportedConfigSchema.optional(),
-    bulk: BulkConfigSchema.optional(),
-    filter: FilterConfigSchema.optional(),
-    changePassword: SupportedConfigSchema.optional(),
-    sort: SupportedConfigSchema.optional(),
-    etag: SupportedConfigSchema.optional(),
-    authenticationSchemes: z.array(AuthenticationSchemeSchema).optional()
-});
-
 const OutputSchema = z.object({
-    schemas: z.array(z.string()).optional(),
-    id: z.string().optional(),
-    meta: MetaSchema.optional(),
+    schemas: z.array(z.string()),
     documentationUri: z.string().optional(),
-    patch: SupportedConfigSchema.optional(),
-    bulk: BulkConfigSchema.optional(),
-    filter: FilterConfigSchema.optional(),
-    changePassword: SupportedConfigSchema.optional(),
-    sort: SupportedConfigSchema.optional(),
-    etag: SupportedConfigSchema.optional(),
-    authenticationSchemes: z.array(AuthenticationSchemeSchema).optional()
+    patch: z.object({
+        supported: z.boolean()
+    }),
+    bulk: z.object({
+        supported: z.boolean(),
+        maxOperations: z.number(),
+        maxPayloadSize: z.number()
+    }),
+    filter: z.object({
+        supported: z.boolean(),
+        maxResults: z.number()
+    }),
+    changePassword: z.object({
+        supported: z.boolean()
+    }),
+    sort: z.object({
+        supported: z.boolean()
+    }),
+    etag: z.object({
+        supported: z.boolean()
+    }),
+    authenticationSchemes: z.array(AuthenticationSchemeSchema),
+    meta: MetaSchema.optional()
 });
 
 const action = createAction({
@@ -76,34 +61,15 @@ const action = createAction({
     scopes: [],
 
     exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://support.1password.com/scim-endpoints/
         const response = await nango.get({
-            // https://support.1password.com/scim-endpoints/
             endpoint: '/ServiceProviderConfig',
             retries: 3
         });
 
-        if (!response.data) {
-            throw new nango.ActionError({
-                type: 'not_found',
-                message: 'Service provider config not found'
-            });
-        }
+        const providerConfig = OutputSchema.parse(response.data);
 
-        const config = ProviderServiceProviderConfigSchema.parse(response.data);
-
-        return {
-            ...(config.schemas !== undefined && { schemas: config.schemas }),
-            ...(config.id !== undefined && { id: config.id }),
-            ...(config.meta !== undefined && { meta: config.meta }),
-            ...(config.documentationUri !== undefined && { documentationUri: config.documentationUri }),
-            ...(config.patch !== undefined && { patch: config.patch }),
-            ...(config.bulk !== undefined && { bulk: config.bulk }),
-            ...(config.filter !== undefined && { filter: config.filter }),
-            ...(config.changePassword !== undefined && { changePassword: config.changePassword }),
-            ...(config.sort !== undefined && { sort: config.sort }),
-            ...(config.etag !== undefined && { etag: config.etag }),
-            ...(config.authenticationSchemes !== undefined && { authenticationSchemes: config.authenticationSchemes })
-        };
+        return providerConfig;
     }
 });
 

--- a/integrations/1password-scim/actions/get-service-provider-config.ts
+++ b/integrations/1password-scim/actions/get-service-provider-config.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({});
+
+const SupportedConfigSchema = z.object({
+    supported: z.boolean().optional()
+});
+
+const BulkConfigSchema = z.object({
+    supported: z.boolean().optional(),
+    maxOperations: z.number().optional(),
+    maxPayloadSize: z.number().optional()
+});
+
+const FilterConfigSchema = z.object({
+    supported: z.boolean().optional(),
+    maxResults: z.number().optional()
+});
+
+const AuthenticationSchemeSchema = z.object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    specUri: z.string().optional(),
+    documentationUri: z.string().optional(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const MetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ProviderServiceProviderConfigSchema = z.object({
+    schemas: z.array(z.string()).optional(),
+    id: z.string().optional(),
+    meta: MetaSchema.optional(),
+    documentationUri: z.string().optional(),
+    patch: SupportedConfigSchema.optional(),
+    bulk: BulkConfigSchema.optional(),
+    filter: FilterConfigSchema.optional(),
+    changePassword: SupportedConfigSchema.optional(),
+    sort: SupportedConfigSchema.optional(),
+    etag: SupportedConfigSchema.optional(),
+    authenticationSchemes: z.array(AuthenticationSchemeSchema).optional()
+});
+
+const OutputSchema = z.object({
+    schemas: z.array(z.string()).optional(),
+    id: z.string().optional(),
+    meta: MetaSchema.optional(),
+    documentationUri: z.string().optional(),
+    patch: SupportedConfigSchema.optional(),
+    bulk: BulkConfigSchema.optional(),
+    filter: FilterConfigSchema.optional(),
+    changePassword: SupportedConfigSchema.optional(),
+    sort: SupportedConfigSchema.optional(),
+    etag: SupportedConfigSchema.optional(),
+    authenticationSchemes: z.array(AuthenticationSchemeSchema).optional()
+});
+
+const action = createAction({
+    description: 'Retrieve SCIM service provider capabilities.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'GET',
+        path: '/actions/get-service-provider-config',
+        group: 'SCIM'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/ServiceProviderConfig',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'Service provider config not found'
+            });
+        }
+
+        const config = ProviderServiceProviderConfigSchema.parse(response.data);
+
+        return {
+            ...(config.schemas !== undefined && { schemas: config.schemas }),
+            ...(config.id !== undefined && { id: config.id }),
+            ...(config.meta !== undefined && { meta: config.meta }),
+            ...(config.documentationUri !== undefined && { documentationUri: config.documentationUri }),
+            ...(config.patch !== undefined && { patch: config.patch }),
+            ...(config.bulk !== undefined && { bulk: config.bulk }),
+            ...(config.filter !== undefined && { filter: config.filter }),
+            ...(config.changePassword !== undefined && { changePassword: config.changePassword }),
+            ...(config.sort !== undefined && { sort: config.sort }),
+            ...(config.etag !== undefined && { etag: config.etag }),
+            ...(config.authenticationSchemes !== undefined && { authenticationSchemes: config.authenticationSchemes })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/get-service-provider-config.ts
+++ b/integrations/1password-scim/actions/get-service-provider-config.ts
@@ -79,7 +79,6 @@ const action = createAction({
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/ServiceProviderConfig',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         });
 

--- a/integrations/1password-scim/actions/list-resource-types.ts
+++ b/integrations/1password-scim/actions/list-resource-types.ts
@@ -47,7 +47,6 @@ const action = createAction({
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/ResourceTypes',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         });
 

--- a/integrations/1password-scim/actions/list-resource-types.ts
+++ b/integrations/1password-scim/actions/list-resource-types.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({});
+
+const ResourceTypeMetaSchema = z.object({
+    resourceType: z.string().optional(),
+    location: z.string().optional()
+});
+
+const SchemaExtensionSchema = z.object({
+    schema: z.string().optional(),
+    required: z.boolean().optional()
+});
+
+const ResourceTypeSchema = z.object({
+    schemas: z.array(z.string()).optional(),
+    id: z.string().optional(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    endpoint: z.string().optional(),
+    schema: z.string().optional(),
+    schemaExtensions: z.array(SchemaExtensionSchema).optional(),
+    meta: ResourceTypeMetaSchema.optional()
+});
+
+const OutputSchema = z.object({
+    schemas: z.array(z.string()).optional(),
+    totalResults: z.number().optional(),
+    itemsPerPage: z.number().optional(),
+    startIndex: z.number().optional(),
+    Resources: z.array(ResourceTypeSchema).optional()
+});
+
+const action = createAction({
+    description: 'List SCIM resource types.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'GET',
+        path: '/actions/list-resource-types',
+        group: 'SCIM'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/ResourceTypes',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        });
+
+        const providerData = OutputSchema.parse(response.data);
+
+        return {
+            ...(providerData.schemas !== undefined && { schemas: providerData.schemas }),
+            ...(providerData.totalResults !== undefined && { totalResults: providerData.totalResults }),
+            ...(providerData.itemsPerPage !== undefined && { itemsPerPage: providerData.itemsPerPage }),
+            ...(providerData.startIndex !== undefined && { startIndex: providerData.startIndex }),
+            ...(providerData.Resources !== undefined && { Resources: providerData.Resources })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/list-resource-types.ts
+++ b/integrations/1password-scim/actions/list-resource-types.ts
@@ -3,37 +3,37 @@ import { createAction } from 'nango';
 
 const InputSchema = z.object({});
 
-const ResourceTypeMetaSchema = z.object({
+const SchemaExtensionSchema = z.object({
+    schema: z.string(),
+    required: z.boolean()
+});
+
+const MetaSchema = z.object({
     resourceType: z.string().optional(),
     location: z.string().optional()
 });
 
-const SchemaExtensionSchema = z.object({
-    schema: z.string().optional(),
-    required: z.boolean().optional()
-});
-
 const ResourceTypeSchema = z.object({
     schemas: z.array(z.string()).optional(),
-    id: z.string().optional(),
-    name: z.string().optional(),
+    id: z.string(),
+    name: z.string(),
+    endpoint: z.string(),
     description: z.string().optional(),
-    endpoint: z.string().optional(),
-    schema: z.string().optional(),
+    schema: z.string(),
     schemaExtensions: z.array(SchemaExtensionSchema).optional(),
-    meta: ResourceTypeMetaSchema.optional()
+    meta: MetaSchema.optional()
 });
 
 const OutputSchema = z.object({
     schemas: z.array(z.string()).optional(),
-    totalResults: z.number().optional(),
-    itemsPerPage: z.number().optional(),
+    totalResults: z.number(),
+    Resources: z.array(ResourceTypeSchema),
     startIndex: z.number().optional(),
-    Resources: z.array(ResourceTypeSchema).optional()
+    itemsPerPage: z.number().optional()
 });
 
 const action = createAction({
-    description: 'List SCIM resource types.',
+    description: 'List SCIM resource types',
     version: '1.0.0',
     endpoint: {
         method: 'GET',
@@ -42,6 +42,7 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
+    scopes: ['scim'],
 
     exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.get({
@@ -50,15 +51,9 @@ const action = createAction({
             retries: 3
         });
 
-        const providerData = OutputSchema.parse(response.data);
+        const listResponse = OutputSchema.parse(response.data);
 
-        return {
-            ...(providerData.schemas !== undefined && { schemas: providerData.schemas }),
-            ...(providerData.totalResults !== undefined && { totalResults: providerData.totalResults }),
-            ...(providerData.itemsPerPage !== undefined && { itemsPerPage: providerData.itemsPerPage }),
-            ...(providerData.startIndex !== undefined && { startIndex: providerData.startIndex }),
-            ...(providerData.Resources !== undefined && { Resources: providerData.Resources })
-        };
+        return listResponse;
     }
 });
 

--- a/integrations/1password-scim/actions/list-schemas.ts
+++ b/integrations/1password-scim/actions/list-schemas.ts
@@ -34,7 +34,6 @@ const action = createAction({
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Schemas',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             retries: 3
         });
 

--- a/integrations/1password-scim/actions/list-schemas.ts
+++ b/integrations/1password-scim/actions/list-schemas.ts
@@ -3,19 +3,48 @@ import { createAction } from 'nango';
 
 const InputSchema = z.object({});
 
-const SchemaResourceSchema = z
-    .object({
-        id: z.string(),
-        name: z.string().optional(),
-        description: z.string().optional(),
-        attributes: z.array(z.unknown()).optional()
-    })
-    .passthrough();
+const SchemaAttributeSchema = z.object({
+    name: z.string(),
+    type: z.string().optional(),
+    multiValued: z.boolean().optional(),
+    required: z.boolean().optional(),
+    mutability: z.string().optional(),
+    returned: z.string().optional(),
+    uniqueness: z.string().optional(),
+    description: z.string().optional(),
+    subAttributes: z
+        .array(
+            z.object({
+                name: z.string(),
+                type: z.string().optional(),
+                multiValued: z.boolean().optional(),
+                required: z.boolean().optional(),
+                mutability: z.string().optional(),
+                returned: z.string().optional(),
+                uniqueness: z.string().optional(),
+                description: z.string().optional()
+            })
+        )
+        .optional()
+});
 
-const OutputSchema = z.object({
+const ProviderSchemaSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    attributes: z.array(SchemaAttributeSchema).optional()
+});
+
+const ProviderListResponseSchema = z.object({
     schemas: z.array(z.string()).optional(),
     totalResults: z.number().optional(),
-    Resources: z.array(SchemaResourceSchema).optional()
+    Resources: z.array(ProviderSchemaSchema).optional(),
+    startIndex: z.number().optional(),
+    itemsPerPage: z.number().optional()
+});
+
+const OutputSchema = z.object({
+    schemas: z.array(ProviderSchemaSchema).optional()
 });
 
 const action = createAction({
@@ -28,7 +57,6 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
 
     exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.get({
@@ -37,26 +65,10 @@ const action = createAction({
             retries: 3
         });
 
-        const listResponse = z
-            .object({
-                schemas: z.array(z.string()).optional(),
-                totalResults: z.number().optional(),
-                Resources: z.array(z.unknown()).optional()
-            })
-            .parse(response.data);
-
-        const resources = listResponse.Resources;
-        if (!resources) {
-            return {
-                schemas: listResponse.schemas,
-                totalResults: listResponse.totalResults
-            };
-        }
+        const listResponse = ProviderListResponseSchema.parse(response.data);
 
         return {
-            schemas: listResponse.schemas,
-            totalResults: listResponse.totalResults,
-            Resources: resources.map((resource) => SchemaResourceSchema.parse(resource))
+            schemas: listResponse.Resources
         };
     }
 });

--- a/integrations/1password-scim/actions/list-schemas.ts
+++ b/integrations/1password-scim/actions/list-schemas.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({});
+
+const SchemaResourceSchema = z
+    .object({
+        id: z.string(),
+        name: z.string().optional(),
+        description: z.string().optional(),
+        attributes: z.array(z.unknown()).optional()
+    })
+    .passthrough();
+
+const OutputSchema = z.object({
+    schemas: z.array(z.string()).optional(),
+    totalResults: z.number().optional(),
+    Resources: z.array(SchemaResourceSchema).optional()
+});
+
+const action = createAction({
+    description: 'List SCIM schemas supported by the bridge.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'GET',
+        path: '/actions/list-schemas',
+        group: 'SCIM'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/Schemas',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            retries: 3
+        });
+
+        const listResponse = z
+            .object({
+                schemas: z.array(z.string()).optional(),
+                totalResults: z.number().optional(),
+                Resources: z.array(z.unknown()).optional()
+            })
+            .parse(response.data);
+
+        const resources = listResponse.Resources;
+        if (!resources) {
+            return {
+                schemas: listResponse.schemas,
+                totalResults: listResponse.totalResults
+            };
+        }
+
+        return {
+            schemas: listResponse.schemas,
+            totalResults: listResponse.totalResults,
+            Resources: resources.map((resource) => SchemaResourceSchema.parse(resource))
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/list-scim-groups.ts
+++ b/integrations/1password-scim/actions/list-scim-groups.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
+    filter: z.string().optional().describe('SCIM filter expression. Example: \'displayName eq "Engineering"\''),
+    count: z.number().int().min(1).max(250).optional().describe('Number of results per page (1-250). Defaults to 100.')
+});
+
+const MemberSchema = z.object({
+    value: z.string(),
+    display: z.string().optional(),
+    type: z.string().optional()
+});
+
+const MetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ProviderGroupSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    displayName: z.string(),
+    members: z.array(MemberSchema).optional(),
+    meta: MetaSchema.optional(),
+    externalId: z.string().optional()
+});
+
+const ProviderListResponseSchema = z.object({
+    schemas: z.array(z.string()).optional(),
+    totalResults: z.number().int(),
+    startIndex: z.number().int(),
+    itemsPerPage: z.number().int(),
+    Resources: z.array(ProviderGroupSchema)
+});
+
+const GroupOutputSchema = z.object({
+    id: z.string(),
+    displayName: z.string(),
+    members: z.array(MemberSchema).optional(),
+    meta: MetaSchema.optional(),
+    externalId: z.string().optional(),
+    schemas: z.array(z.string()).optional()
+});
+
+const OutputSchema = z.object({
+    groups: z.array(GroupOutputSchema),
+    next_cursor: z.string().optional()
+});
+
+const action = createAction({
+    description: 'List SCIM groups from 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/list-scim-groups',
+        group: 'Groups'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const startIndex = input.cursor ? parseInt(input.cursor, 10) : 1;
+        if (Number.isNaN(startIndex) || startIndex < 1) {
+            throw new nango.ActionError({
+                type: 'invalid_cursor',
+                message: 'Cursor must be a positive integer representing a SCIM startIndex.'
+            });
+        }
+
+        const count = input.count ?? 100;
+        const params: Record<string, string | number> = {
+            startIndex,
+            count
+        };
+
+        if (input.filter !== undefined && input.filter !== '') {
+            params['filter'] = input.filter;
+        }
+
+        const response = await nango.get({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/Groups',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            params,
+            retries: 3
+        });
+
+        const raw = ProviderListResponseSchema.parse(response.data);
+
+        const groups = raw.Resources.map((group) => ({
+            id: group.id,
+            displayName: group.displayName,
+            ...(group.members !== undefined && { members: group.members }),
+            ...(group.meta !== undefined && { meta: group.meta }),
+            ...(group.externalId !== undefined && { externalId: group.externalId }),
+            ...(group.schemas !== undefined && { schemas: group.schemas })
+        }));
+
+        const lastIndex = raw.startIndex + raw.itemsPerPage - 1;
+        const hasMore = lastIndex < raw.totalResults;
+
+        return {
+            groups,
+            ...(hasMore && { next_cursor: String(raw.startIndex + raw.itemsPerPage) })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/list-scim-groups.ts
+++ b/integrations/1password-scim/actions/list-scim-groups.ts
@@ -86,7 +86,6 @@ const action = createAction({
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Groups',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             params,
             retries: 3
         });

--- a/integrations/1password-scim/actions/list-scim-groups.ts
+++ b/integrations/1password-scim/actions/list-scim-groups.ts
@@ -3,12 +3,13 @@ import { createAction } from 'nango';
 
 const InputSchema = z.object({
     cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
-    filter: z.string().optional().describe('SCIM filter expression. Example: \'displayName eq "Engineering"\''),
-    count: z.number().int().min(1).max(250).optional().describe('Number of results per page (1-250). Defaults to 100.')
+    count: z.number().int().min(1).max(1000).optional().describe('Number of results per page. Defaults to 100.'),
+    filter: z.string().optional().describe('SCIM filter expression. Example: displayName co "Engineering"')
 });
 
 const MemberSchema = z.object({
-    value: z.string(),
+    value: z.string().optional(),
+    $ref: z.string().optional(),
     display: z.string().optional(),
     type: z.string().optional()
 });
@@ -21,92 +22,80 @@ const MetaSchema = z.object({
     version: z.string().optional()
 });
 
-const ProviderGroupSchema = z.object({
+const GroupSchema = z.object({
     schemas: z.array(z.string()),
     id: z.string(),
-    displayName: z.string(),
-    members: z.array(MemberSchema).optional(),
-    meta: MetaSchema.optional(),
-    externalId: z.string().optional()
-});
-
-const ProviderListResponseSchema = z.object({
-    schemas: z.array(z.string()).optional(),
-    totalResults: z.number().int(),
-    startIndex: z.number().int(),
-    itemsPerPage: z.number().int(),
-    Resources: z.array(ProviderGroupSchema)
-});
-
-const GroupOutputSchema = z.object({
-    id: z.string(),
-    displayName: z.string(),
-    members: z.array(MemberSchema).optional(),
-    meta: MetaSchema.optional(),
     externalId: z.string().optional(),
-    schemas: z.array(z.string()).optional()
+    meta: MetaSchema.optional(),
+    displayName: z.string(),
+    members: z.array(MemberSchema).optional()
+});
+
+const ListResponseSchema = z.object({
+    schemas: z.array(z.string()),
+    totalResults: z.number(),
+    Resources: z.array(z.unknown()),
+    startIndex: z.number().optional(),
+    itemsPerPage: z.number().optional()
 });
 
 const OutputSchema = z.object({
-    groups: z.array(GroupOutputSchema),
-    next_cursor: z.string().optional()
+    items: z.array(GroupSchema),
+    nextCursor: z.string().optional()
 });
 
 const action = createAction({
     description: 'List SCIM groups from 1Password SCIM.',
     version: '1.0.0',
     endpoint: {
-        method: 'POST',
+        method: 'GET',
         path: '/actions/list-scim-groups',
         group: 'Groups'
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
+    scopes: ['scim'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const startIndex = input.cursor ? parseInt(input.cursor, 10) : 1;
-        if (Number.isNaN(startIndex) || startIndex < 1) {
-            throw new nango.ActionError({
-                type: 'invalid_cursor',
-                message: 'Cursor must be a positive integer representing a SCIM startIndex.'
-            });
+        let startIndex = 1;
+        if (input.cursor !== undefined) {
+            const parsed = Number(input.cursor);
+            if (!Number.isInteger(parsed) || parsed < 1) {
+                throw new nango.ActionError({
+                    type: 'invalid_cursor',
+                    message: 'cursor must be a positive integer string'
+                });
+            }
+            startIndex = parsed;
         }
 
         const count = input.count ?? 100;
-        const params: Record<string, string | number> = {
-            startIndex,
-            count
-        };
-
-        if (input.filter !== undefined && input.filter !== '') {
-            params['filter'] = input.filter;
-        }
 
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Groups',
-            params,
+            params: {
+                startIndex: String(startIndex),
+                count: String(count),
+                ...(input.filter !== undefined && { filter: input.filter })
+            },
             retries: 3
         });
 
-        const raw = ProviderListResponseSchema.parse(response.data);
+        const listResponse = ListResponseSchema.parse(response.data);
 
-        const groups = raw.Resources.map((group) => ({
-            id: group.id,
-            displayName: group.displayName,
-            ...(group.members !== undefined && { members: group.members }),
-            ...(group.meta !== undefined && { meta: group.meta }),
-            ...(group.externalId !== undefined && { externalId: group.externalId }),
-            ...(group.schemas !== undefined && { schemas: group.schemas })
-        }));
+        const items = listResponse.Resources.map((resource) => {
+            const group = GroupSchema.parse(resource);
+            return group;
+        });
 
-        const lastIndex = raw.startIndex + raw.itemsPerPage - 1;
-        const hasMore = lastIndex < raw.totalResults;
+        const currentStartIndex = listResponse.startIndex ?? startIndex;
+        const currentItemsPerPage = listResponse.itemsPerPage ?? items.length;
+        const hasMore = currentStartIndex + currentItemsPerPage - 1 < listResponse.totalResults;
 
         return {
-            groups,
-            ...(hasMore && { next_cursor: String(raw.startIndex + raw.itemsPerPage) })
+            items,
+            ...(hasMore && { nextCursor: String(currentStartIndex + currentItemsPerPage) })
         };
     }
 });

--- a/integrations/1password-scim/actions/list-scim-users.ts
+++ b/integrations/1password-scim/actions/list-scim-users.ts
@@ -1,55 +1,37 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const InputSchema = z.object({
-    filter: z.string().optional().describe('SCIM filter query. Example: userName eq "john.doe@example.com"'),
-    start_index: z.number().int().optional().describe('1-based index of the first result to return.'),
-    count: z.number().int().optional().describe('Number of results to return per page.')
-});
-
-const ScimEmailSchema = z.object({
+const ScimEmailSchema = z.looseObject({
     value: z.string(),
-    type: z.string().optional(),
-    primary: z.boolean().optional()
+    primary: z.boolean().optional(),
+    type: z.string().optional()
 });
 
-const ScimNameSchema = z.object({
+const ScimNameSchema = z.looseObject({
+    formatted: z.string().optional(),
     familyName: z.string().optional(),
-    givenName: z.string().optional(),
-    formatted: z.string().optional()
+    givenName: z.string().optional()
 });
 
-const ScimMetaSchema = z.object({
-    created: z.string().optional(),
-    lastModified: z.string().optional(),
-    resourceType: z.string().optional()
-});
-
-const ScimUserSchema = z.object({
+const ScimUserSchema = z.looseObject({
     id: z.string(),
     userName: z.string(),
     name: ScimNameSchema.optional(),
-    emails: z.array(ScimEmailSchema).optional(),
+    displayName: z.string().optional(),
     active: z.boolean().optional(),
-    externalId: z.string().optional(),
-    meta: ScimMetaSchema.optional(),
-    schemas: z.array(z.string()).optional()
+    emails: z.array(ScimEmailSchema).optional()
 });
 
-const ScimListResponseSchema = z.object({
-    schemas: z.array(z.string()),
-    totalResults: z.number().int(),
-    startIndex: z.number().int().optional(),
-    itemsPerPage: z.number().int().optional(),
-    Resources: z.array(z.unknown())
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
+    filter: z.string().optional().describe('SCIM filter expression. Example: userName eq "user@example.com"'),
+    count: z.number().int().min(1).max(100).optional().describe('Number of results to return per page.')
 });
 
 const OutputSchema = z.object({
-    users: z.array(ScimUserSchema),
-    total_results: z.number().int(),
-    start_index: z.number().int().optional(),
-    items_per_page: z.number().int().optional(),
-    next_start_index: z.number().int().optional()
+    items: z.array(ScimUserSchema),
+    totalResults: z.number().int().optional(),
+    nextCursor: z.string().optional()
 });
 
 const action = createAction({
@@ -62,36 +44,58 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
+    scopes: [],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const startIndex = input.cursor ? parseInt(input.cursor, 10) : 1;
+        if (Number.isNaN(startIndex) || startIndex < 1) {
+            throw new nango.ActionError({
+                type: 'invalid_input',
+                message: 'cursor must be a positive integer string'
+            });
+        }
+
+        const params: Record<string, string | number> = {
+            startIndex
+        };
+
+        if (input.filter !== undefined) {
+            params['filter'] = input.filter;
+        }
+
+        if (input.count !== undefined) {
+            params['count'] = input.count;
+        }
+
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Users',
-            params: {
-                ...(input.filter !== undefined && { filter: input.filter }),
-                ...(input.start_index !== undefined && { startIndex: String(input.start_index) }),
-                ...(input.count !== undefined && { count: String(input.count) })
-            },
+            params,
             retries: 3
         });
 
-        const listResponse = ScimListResponseSchema.parse(response.data);
+        const ListResponseSchema = z.object({
+            schemas: z.array(z.string()),
+            totalResults: z.number().int(),
+            startIndex: z.number().int().optional(),
+            itemsPerPage: z.number().int().optional(),
+            Resources: z.array(z.unknown())
+        });
 
-        const users = listResponse.Resources.map((resource: unknown) => {
+        const data = ListResponseSchema.parse(response.data);
+
+        const users = data.Resources.map((resource) => {
             return ScimUserSchema.parse(resource);
         });
 
-        const startIndex = listResponse.startIndex ?? 1;
-        const itemsPerPage = listResponse.itemsPerPage ?? users.length;
-        const hasMore = startIndex + itemsPerPage - 1 < listResponse.totalResults;
-        const nextStartIndex = hasMore ? startIndex + itemsPerPage : undefined;
+        const returnedStartIndex = data.startIndex ?? startIndex;
+        const itemsPerPage = data.itemsPerPage ?? users.length;
+        const nextStartIndex = returnedStartIndex + itemsPerPage;
 
         return {
-            users,
-            total_results: listResponse.totalResults,
-            start_index: listResponse.startIndex,
-            items_per_page: listResponse.itemsPerPage,
-            ...(nextStartIndex !== undefined && { next_start_index: nextStartIndex })
+            items: users,
+            totalResults: data.totalResults,
+            ...(nextStartIndex <= data.totalResults && { nextCursor: String(nextStartIndex) })
         };
     }
 });

--- a/integrations/1password-scim/actions/list-scim-users.ts
+++ b/integrations/1password-scim/actions/list-scim-users.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    filter: z.string().optional().describe('SCIM filter query. Example: userName eq "john.doe@example.com"'),
+    start_index: z.number().int().optional().describe('1-based index of the first result to return.'),
+    count: z.number().int().optional().describe('Number of results to return per page.')
+});
+
+const ScimEmailSchema = z.object({
+    value: z.string(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ScimNameSchema = z.object({
+    familyName: z.string().optional(),
+    givenName: z.string().optional(),
+    formatted: z.string().optional()
+});
+
+const ScimMetaSchema = z.object({
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    resourceType: z.string().optional()
+});
+
+const ScimUserSchema = z.object({
+    id: z.string(),
+    userName: z.string(),
+    name: ScimNameSchema.optional(),
+    emails: z.array(ScimEmailSchema).optional(),
+    active: z.boolean().optional(),
+    externalId: z.string().optional(),
+    meta: ScimMetaSchema.optional(),
+    schemas: z.array(z.string()).optional()
+});
+
+const ScimListResponseSchema = z.object({
+    schemas: z.array(z.string()),
+    totalResults: z.number().int(),
+    startIndex: z.number().int().optional(),
+    itemsPerPage: z.number().int().optional(),
+    Resources: z.array(z.unknown())
+});
+
+const OutputSchema = z.object({
+    users: z.array(ScimUserSchema),
+    total_results: z.number().int(),
+    start_index: z.number().int().optional(),
+    items_per_page: z.number().int().optional(),
+    next_start_index: z.number().int().optional()
+});
+
+const action = createAction({
+    description: 'List SCIM users from 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'GET',
+        path: '/actions/list-scim-users',
+        group: 'Users'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/Users',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            params: {
+                ...(input.filter !== undefined && { filter: input.filter }),
+                ...(input.start_index !== undefined && { startIndex: String(input.start_index) }),
+                ...(input.count !== undefined && { count: String(input.count) })
+            },
+            retries: 3
+        });
+
+        const listResponse = ScimListResponseSchema.parse(response.data);
+
+        const users = listResponse.Resources.map((resource: unknown) => {
+            return ScimUserSchema.parse(resource);
+        });
+
+        const startIndex = listResponse.startIndex ?? 1;
+        const itemsPerPage = listResponse.itemsPerPage ?? users.length;
+        const hasMore = startIndex + itemsPerPage - 1 < listResponse.totalResults;
+        const nextStartIndex = hasMore ? startIndex + itemsPerPage : undefined;
+
+        return {
+            users,
+            total_results: listResponse.totalResults,
+            start_index: listResponse.startIndex,
+            items_per_page: listResponse.itemsPerPage,
+            ...(nextStartIndex !== undefined && { next_start_index: nextStartIndex })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/list-scim-users.ts
+++ b/integrations/1password-scim/actions/list-scim-users.ts
@@ -67,7 +67,6 @@ const action = createAction({
         const response = await nango.get({
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Users',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             params: {
                 ...(input.filter !== undefined && { filter: input.filter }),
                 ...(input.start_index !== undefined && { startIndex: String(input.start_index) }),

--- a/integrations/1password-scim/actions/patch-scim-group.ts
+++ b/integrations/1password-scim/actions/patch-scim-group.ts
@@ -56,7 +56,6 @@ const action = createAction({
         const response = await nango.patch({
             // https://support.1password.com/scim-endpoints/
             endpoint: `/Groups/${encodeURIComponent(input.group_id)}`,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             data: {
                 schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
                 Operations: input.operations
@@ -68,7 +67,6 @@ const action = createAction({
         if (!rawData) {
             // SCIM PATCH may return 204 No Content on success; fetch current state
             const getResponse = await nango.get({
-                baseUrlOverride: 'https://provisioning.1password.com/scim',
                 endpoint: `/Groups/${encodeURIComponent(input.group_id)}`,
                 retries: 3
             });

--- a/integrations/1password-scim/actions/patch-scim-group.ts
+++ b/integrations/1password-scim/actions/patch-scim-group.ts
@@ -20,11 +20,11 @@ const InputSchema = z.object({
     group_id: z.string().describe('The SCIM group ID to patch. Example: "group-123"'),
     operations: z
         .array(
-            z.object({
-                op: z.enum(['add', 'remove', 'replace']),
-                path: z.string().optional(),
-                value: z.unknown().optional()
-            })
+            z.discriminatedUnion('op', [
+                z.object({ op: z.literal('add'), path: z.string().optional(), value: z.unknown().optional() }),
+                z.object({ op: z.literal('replace'), path: z.string().optional(), value: z.unknown().optional() }),
+                z.object({ op: z.literal('remove'), path: z.string(), value: z.unknown().optional() })
+            ])
         )
         .describe('SCIM PatchOp operations to apply.')
 });
@@ -64,15 +64,25 @@ const action = createAction({
             retries: 10
         });
 
-        if (!response.data) {
-            throw new nango.ActionError({
-                type: 'not_found',
-                message: 'Group not found or patch failed',
-                group_id: input.group_id
+        let rawData = response.data;
+        if (!rawData) {
+            // SCIM PATCH may return 204 No Content on success; fetch current state
+            const getResponse = await nango.get({
+                baseUrlOverride: 'https://provisioning.1password.com/scim',
+                endpoint: `/Groups/${encodeURIComponent(input.group_id)}`,
+                retries: 3
             });
+            if (!getResponse.data) {
+                throw new nango.ActionError({
+                    type: 'not_found',
+                    message: 'Group not found',
+                    group_id: input.group_id
+                });
+            }
+            rawData = getResponse.data;
         }
 
-        const providerGroup = OutputSchema.parse(response.data);
+        const providerGroup = OutputSchema.parse(rawData);
 
         return providerGroup;
     }

--- a/integrations/1password-scim/actions/patch-scim-group.ts
+++ b/integrations/1password-scim/actions/patch-scim-group.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const MemberSchema = z.object({
+    value: z.string(),
+    display: z.string().optional(),
+    type: z.string().optional(),
+    $ref: z.string().optional()
+});
+
+const MetaSchema = z.object({
+    resourceType: z.string(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const InputSchema = z.object({
+    group_id: z.string().describe('The SCIM group ID to patch. Example: "group-123"'),
+    operations: z
+        .array(
+            z.object({
+                op: z.enum(['add', 'remove', 'replace']),
+                path: z.string().optional(),
+                value: z.unknown().optional()
+            })
+        )
+        .describe('SCIM PatchOp operations to apply.')
+});
+
+const OutputSchema = z
+    .object({
+        schemas: z.array(z.string()),
+        id: z.string(),
+        displayName: z.string().optional(),
+        members: z.array(MemberSchema).optional(),
+        meta: MetaSchema.optional(),
+        externalId: z.string().optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Patch attributes or membership for a 1Password SCIM group.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/patch-scim-group',
+        group: 'Groups'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: `/Groups/${encodeURIComponent(input.group_id)}`,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            data: {
+                schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                Operations: input.operations
+            },
+            retries: 10
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'Group not found or patch failed',
+                group_id: input.group_id
+            });
+        }
+
+        const providerGroup = OutputSchema.parse(response.data);
+
+        return providerGroup;
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/patch-scim-group.ts
+++ b/integrations/1password-scim/actions/patch-scim-group.ts
@@ -1,44 +1,62 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const MemberSchema = z.object({
-    value: z.string(),
+const ScimMemberSchema = z.object({
+    value: z.string().describe('User ID. Example: "2819c223-7f76-453a-919d-413861904646"'),
     display: z.string().optional(),
-    type: z.string().optional(),
     $ref: z.string().optional()
 });
 
-const MetaSchema = z.object({
-    resourceType: z.string(),
-    created: z.string().optional(),
-    lastModified: z.string().optional(),
-    location: z.string().optional(),
-    version: z.string().optional()
+const ScimOperationSchema = z.object({
+    op: z.enum(['add', 'remove', 'replace']),
+    path: z.string().optional().describe('Target attribute path. Example: "members" or "displayName"'),
+    value: z.union([z.string(), z.array(ScimMemberSchema), z.record(z.string(), z.unknown())]).optional()
 });
 
 const InputSchema = z.object({
-    group_id: z.string().describe('The SCIM group ID to patch. Example: "group-123"'),
-    operations: z
-        .array(
-            z.discriminatedUnion('op', [
-                z.object({ op: z.literal('add'), path: z.string().optional(), value: z.unknown().optional() }),
-                z.object({ op: z.literal('replace'), path: z.string().optional(), value: z.unknown().optional() }),
-                z.object({ op: z.literal('remove'), path: z.string(), value: z.unknown().optional() })
-            ])
-        )
-        .describe('SCIM PatchOp operations to apply.')
+    id: z.string().describe('SCIM Group ID. Example: "9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d"'),
+    operations: z.array(ScimOperationSchema).describe('SCIM patch operations to apply to the group.')
 });
 
-const OutputSchema = z
-    .object({
-        schemas: z.array(z.string()),
-        id: z.string(),
-        displayName: z.string().optional(),
-        members: z.array(MemberSchema).optional(),
-        meta: MetaSchema.optional(),
-        externalId: z.string().optional()
-    })
-    .passthrough();
+const ScimGroupSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    displayName: z.string().optional(),
+    members: z.array(ScimMemberSchema).optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional(),
+            version: z.string().optional()
+        })
+        .optional(),
+    externalId: z.string().optional().nullable()
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    displayName: z.string().optional(),
+    members: z
+        .array(
+            z.object({
+                value: z.string(),
+                display: z.string().optional()
+            })
+        )
+        .optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional(),
+            version: z.string().optional()
+        })
+        .optional(),
+    externalId: z.string().optional()
+});
 
 const action = createAction({
     description: 'Patch attributes or membership for a 1Password SCIM group.',
@@ -50,39 +68,51 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const requestBody = {
+            schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            Operations: input.operations
+        };
+
+        // https://support.1password.com/scim-endpoints/
         const response = await nango.patch({
-            // https://support.1password.com/scim-endpoints/
-            endpoint: `/Groups/${encodeURIComponent(input.group_id)}`,
-            data: {
-                schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
-                Operations: input.operations
-            },
-            retries: 10
+            endpoint: `/Groups/${encodeURIComponent(input.id)}`,
+            data: requestBody,
+            retries: 3
         });
 
         let rawData = response.data;
         if (!rawData) {
             // SCIM PATCH may return 204 No Content on success; fetch current state
             const getResponse = await nango.get({
-                endpoint: `/Groups/${encodeURIComponent(input.group_id)}`,
+                endpoint: `/Groups/${encodeURIComponent(input.id)}`,
                 retries: 3
             });
             if (!getResponse.data) {
                 throw new nango.ActionError({
                     type: 'not_found',
                     message: 'Group not found',
-                    group_id: input.group_id
+                    id: input.id
                 });
             }
             rawData = getResponse.data;
         }
 
-        const providerGroup = OutputSchema.parse(rawData);
+        const providerGroup = ScimGroupSchema.parse(rawData);
 
-        return providerGroup;
+        return {
+            id: providerGroup.id,
+            ...(providerGroup.displayName !== undefined && { displayName: providerGroup.displayName }),
+            ...(providerGroup.members !== undefined && {
+                members: providerGroup.members.map((member) => ({
+                    value: member.value,
+                    ...(member.display !== undefined && { display: member.display })
+                }))
+            }),
+            ...(providerGroup.meta !== undefined && { meta: providerGroup.meta }),
+            ...(providerGroup.externalId != null && { externalId: providerGroup.externalId })
+        };
     }
 });
 

--- a/integrations/1password-scim/actions/patch-scim-user.ts
+++ b/integrations/1password-scim/actions/patch-scim-user.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const ScimOperationSchema = z.object({
+    op: z.enum(['add', 'remove', 'replace']),
+    path: z.string().optional(),
+    value: z.unknown().optional()
+});
+
+const InputSchema = z.object({
+    userId: z.string().describe('The SCIM user ID to patch. Example: "2819c223-7f76-453a-919d-413861904646"'),
+    operations: z.array(ScimOperationSchema).describe('SCIM patch operations to apply.')
+});
+
+const ProviderEmailSchema = z.object({
+    value: z.string().optional(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ProviderNameSchema = z.object({
+    formatted: z.string().optional(),
+    familyName: z.string().optional(),
+    givenName: z.string().optional()
+});
+
+const ProviderMetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ProviderUserSchema = z
+    .object({
+        schemas: z.array(z.string()).optional(),
+        id: z.string().optional(),
+        externalId: z.string().optional(),
+        userName: z.string().optional(),
+        name: ProviderNameSchema.optional(),
+        displayName: z.string().optional(),
+        emails: z.array(ProviderEmailSchema).optional(),
+        active: z.boolean().optional(),
+        meta: ProviderMetaSchema.optional()
+    })
+    .passthrough();
+
+const OutputSchema = z.object({
+    id: z.string(),
+    userName: z.string().optional(),
+    externalId: z.string().optional(),
+    displayName: z.string().optional(),
+    active: z.boolean().optional(),
+    name: z
+        .object({
+            formatted: z.string().optional(),
+            familyName: z.string().optional(),
+            givenName: z.string().optional()
+        })
+        .optional(),
+    emails: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional(),
+            version: z.string().optional()
+        })
+        .optional()
+});
+
+const action = createAction({
+    description: 'Patch attributes for a 1Password SCIM user.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/patch-scim-user',
+        group: 'Users'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://support.1password.com/scim-endpoints/
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            endpoint: `/Users/${encodeURIComponent(input.userId)}`,
+            data: {
+                schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                Operations: input.operations
+            },
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'User not found or patch returned no data.',
+                userId: input.userId
+            });
+        }
+
+        const providerUser = ProviderUserSchema.parse(response.data);
+
+        return {
+            id: providerUser.id ?? '',
+            ...(providerUser.userName !== undefined && { userName: providerUser.userName }),
+            ...(providerUser.externalId !== undefined && { externalId: providerUser.externalId }),
+            ...(providerUser.displayName !== undefined && { displayName: providerUser.displayName }),
+            ...(providerUser.active !== undefined && { active: providerUser.active }),
+            ...(providerUser.name !== undefined && {
+                name: {
+                    ...(providerUser.name.formatted !== undefined && { formatted: providerUser.name.formatted }),
+                    ...(providerUser.name.familyName !== undefined && { familyName: providerUser.name.familyName }),
+                    ...(providerUser.name.givenName !== undefined && { givenName: providerUser.name.givenName })
+                }
+            }),
+            ...(providerUser.emails !== undefined && {
+                emails: providerUser.emails.map((email) => ({
+                    ...(email.value !== undefined && { value: email.value }),
+                    ...(email.type !== undefined && { type: email.type }),
+                    ...(email.primary !== undefined && { primary: email.primary })
+                }))
+            }),
+            ...(providerUser.meta !== undefined && {
+                meta: {
+                    ...(providerUser.meta.resourceType !== undefined && { resourceType: providerUser.meta.resourceType }),
+                    ...(providerUser.meta.created !== undefined && { created: providerUser.meta.created }),
+                    ...(providerUser.meta.lastModified !== undefined && { lastModified: providerUser.meta.lastModified }),
+                    ...(providerUser.meta.location !== undefined && { location: providerUser.meta.location }),
+                    ...(providerUser.meta.version !== undefined && { version: providerUser.meta.version })
+                }
+            })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/patch-scim-user.ts
+++ b/integrations/1password-scim/actions/patch-scim-user.ts
@@ -1,30 +1,30 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const ScimOperationSchema = z.discriminatedUnion('op', [
-    z.object({ op: z.literal('add'), path: z.string().optional(), value: z.unknown().optional() }),
-    z.object({ op: z.literal('replace'), path: z.string().optional(), value: z.unknown().optional() }),
-    z.object({ op: z.literal('remove'), path: z.string(), value: z.unknown().optional() })
-]);
+const ScimOperationSchema = z.object({
+    op: z.enum(['add', 'replace', 'remove']),
+    path: z.string().optional(),
+    value: z.unknown().optional()
+});
 
 const InputSchema = z.object({
-    userId: z.string().describe('The SCIM user ID to patch. Example: "2819c223-7f76-453a-919d-413861904646"'),
-    operations: z.array(ScimOperationSchema).describe('SCIM patch operations to apply.')
+    userId: z.string().describe('SCIM User ID. Example: "2819c223-7f76-453a-919d-413861904646"'),
+    operations: z.array(ScimOperationSchema).describe('SCIM PatchOp operations. Example: [{"op":"replace","path":"userName","value":"new@example.com"}]')
 });
 
-const ProviderEmailSchema = z.object({
-    value: z.string().optional(),
-    type: z.string().optional(),
-    primary: z.boolean().optional()
-});
-
-const ProviderNameSchema = z.object({
+const ScimNameSchema = z.object({
     formatted: z.string().optional(),
     familyName: z.string().optional(),
     givenName: z.string().optional()
 });
 
-const ProviderMetaSchema = z.object({
+const ScimEmailSchema = z.object({
+    value: z.string(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ScimMetaSchema = z.object({
     resourceType: z.string().optional(),
     created: z.string().optional(),
     lastModified: z.string().optional(),
@@ -32,51 +32,28 @@ const ProviderMetaSchema = z.object({
     version: z.string().optional()
 });
 
-const ProviderUserSchema = z
-    .object({
-        schemas: z.array(z.string()).optional(),
-        id: z.string().optional(),
-        externalId: z.string().optional(),
-        userName: z.string().optional(),
-        name: ProviderNameSchema.optional(),
-        displayName: z.string().optional(),
-        emails: z.array(ProviderEmailSchema).optional(),
-        active: z.boolean().optional(),
-        meta: ProviderMetaSchema.optional()
-    })
-    .passthrough();
-
-const OutputSchema = z.object({
+const ProviderUserSchema = z.looseObject({
+    schemas: z.array(z.string()),
     id: z.string(),
     userName: z.string().optional(),
-    externalId: z.string().optional(),
-    displayName: z.string().optional(),
     active: z.boolean().optional(),
-    name: z
-        .object({
-            formatted: z.string().optional(),
-            familyName: z.string().optional(),
-            givenName: z.string().optional()
-        })
-        .optional(),
-    emails: z
-        .array(
-            z.object({
-                value: z.string().optional(),
-                type: z.string().optional(),
-                primary: z.boolean().optional()
-            })
-        )
-        .optional(),
-    meta: z
-        .object({
-            resourceType: z.string().optional(),
-            created: z.string().optional(),
-            lastModified: z.string().optional(),
-            location: z.string().optional(),
-            version: z.string().optional()
-        })
-        .optional()
+    displayName: z.string().optional(),
+    preferredLanguage: z.string().optional(),
+    name: ScimNameSchema.optional(),
+    emails: z.array(ScimEmailSchema).optional(),
+    meta: ScimMetaSchema.optional()
+});
+
+const OutputSchema = z.looseObject({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    userName: z.string().optional(),
+    active: z.boolean().optional(),
+    displayName: z.string().optional(),
+    preferredLanguage: z.string().optional(),
+    name: ScimNameSchema.optional(),
+    emails: z.array(ScimEmailSchema).optional(),
+    meta: ScimMetaSchema.optional()
 });
 
 const action = createAction({
@@ -121,36 +98,7 @@ const action = createAction({
 
         const providerUser = ProviderUserSchema.parse(rawData);
 
-        return {
-            id: providerUser.id ?? '',
-            ...(providerUser.userName !== undefined && { userName: providerUser.userName }),
-            ...(providerUser.externalId !== undefined && { externalId: providerUser.externalId }),
-            ...(providerUser.displayName !== undefined && { displayName: providerUser.displayName }),
-            ...(providerUser.active !== undefined && { active: providerUser.active }),
-            ...(providerUser.name !== undefined && {
-                name: {
-                    ...(providerUser.name.formatted !== undefined && { formatted: providerUser.name.formatted }),
-                    ...(providerUser.name.familyName !== undefined && { familyName: providerUser.name.familyName }),
-                    ...(providerUser.name.givenName !== undefined && { givenName: providerUser.name.givenName })
-                }
-            }),
-            ...(providerUser.emails !== undefined && {
-                emails: providerUser.emails.map((email) => ({
-                    ...(email.value !== undefined && { value: email.value }),
-                    ...(email.type !== undefined && { type: email.type }),
-                    ...(email.primary !== undefined && { primary: email.primary })
-                }))
-            }),
-            ...(providerUser.meta !== undefined && {
-                meta: {
-                    ...(providerUser.meta.resourceType !== undefined && { resourceType: providerUser.meta.resourceType }),
-                    ...(providerUser.meta.created !== undefined && { created: providerUser.meta.created }),
-                    ...(providerUser.meta.lastModified !== undefined && { lastModified: providerUser.meta.lastModified }),
-                    ...(providerUser.meta.location !== undefined && { location: providerUser.meta.location }),
-                    ...(providerUser.meta.version !== undefined && { version: providerUser.meta.version })
-                }
-            })
-        };
+        return providerUser;
     }
 });
 

--- a/integrations/1password-scim/actions/patch-scim-user.ts
+++ b/integrations/1password-scim/actions/patch-scim-user.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const ScimOperationSchema = z.object({
-    op: z.enum(['add', 'remove', 'replace']),
-    path: z.string().optional(),
-    value: z.unknown().optional()
-});
+const ScimOperationSchema = z.discriminatedUnion('op', [
+    z.object({ op: z.literal('add'), path: z.string().optional(), value: z.unknown().optional() }),
+    z.object({ op: z.literal('replace'), path: z.string().optional(), value: z.unknown().optional() }),
+    z.object({ op: z.literal('remove'), path: z.string(), value: z.unknown().optional() })
+]);
 
 const InputSchema = z.object({
     userId: z.string().describe('The SCIM user ID to patch. Example: "2819c223-7f76-453a-919d-413861904646"'),
@@ -103,15 +103,25 @@ const action = createAction({
             retries: 3
         });
 
-        if (!response.data) {
-            throw new nango.ActionError({
-                type: 'not_found',
-                message: 'User not found or patch returned no data.',
-                userId: input.userId
+        let rawData = response.data;
+        if (!rawData) {
+            // SCIM PATCH may return 204 No Content on success; fetch current state
+            const getResponse = await nango.get({
+                baseUrlOverride: 'https://provisioning.1password.com/scim',
+                endpoint: `/Users/${encodeURIComponent(input.userId)}`,
+                retries: 3
             });
+            if (!getResponse.data) {
+                throw new nango.ActionError({
+                    type: 'not_found',
+                    message: 'User not found',
+                    userId: input.userId
+                });
+            }
+            rawData = getResponse.data;
         }
 
-        const providerUser = ProviderUserSchema.parse(response.data);
+        const providerUser = ProviderUserSchema.parse(rawData);
 
         return {
             id: providerUser.id ?? '',

--- a/integrations/1password-scim/actions/patch-scim-user.ts
+++ b/integrations/1password-scim/actions/patch-scim-user.ts
@@ -94,7 +94,6 @@ const action = createAction({
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.patch({
             // https://support.1password.com/scim-endpoints/
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             endpoint: `/Users/${encodeURIComponent(input.userId)}`,
             data: {
                 schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
@@ -107,7 +106,6 @@ const action = createAction({
         if (!rawData) {
             // SCIM PATCH may return 204 No Content on success; fetch current state
             const getResponse = await nango.get({
-                baseUrlOverride: 'https://provisioning.1password.com/scim',
                 endpoint: `/Users/${encodeURIComponent(input.userId)}`,
                 retries: 3
             });

--- a/integrations/1password-scim/actions/update-scim-group.ts
+++ b/integrations/1password-scim/actions/update-scim-group.ts
@@ -104,15 +104,25 @@ const action = createAction({
 
         const response = await nango.patch(config);
 
-        if (!response.data) {
-            throw new nango.ActionError({
-                type: 'not_found',
-                message: 'Group not found or update failed.',
-                groupId: input.groupId
+        let rawData = response.data;
+        if (!rawData) {
+            // SCIM PATCH may return 204 No Content on success; fetch current state
+            const getResponse = await nango.get({
+                baseUrlOverride: 'https://provisioning.1password.com/scim',
+                endpoint: `/Groups/${encodeURIComponent(input.groupId)}`,
+                retries: 3
             });
+            if (!getResponse.data) {
+                throw new nango.ActionError({
+                    type: 'not_found',
+                    message: 'Group not found',
+                    groupId: input.groupId
+                });
+            }
+            rawData = getResponse.data;
         }
 
-        const providerGroup = ProviderGroupSchema.parse(response.data);
+        const providerGroup = ProviderGroupSchema.parse(rawData);
 
         return {
             id: providerGroup.id,

--- a/integrations/1password-scim/actions/update-scim-group.ts
+++ b/integrations/1password-scim/actions/update-scim-group.ts
@@ -94,7 +94,6 @@ const action = createAction({
         const config: ProxyConfiguration = {
             // https://support.1password.com/scim-endpoints/
             endpoint: `/Groups/${encodeURIComponent(input.groupId)}`,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             data: {
                 schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
                 Operations: operations
@@ -108,7 +107,6 @@ const action = createAction({
         if (!rawData) {
             // SCIM PATCH may return 204 No Content on success; fetch current state
             const getResponse = await nango.get({
-                baseUrlOverride: 'https://provisioning.1password.com/scim',
                 endpoint: `/Groups/${encodeURIComponent(input.groupId)}`,
                 retries: 3
             });

--- a/integrations/1password-scim/actions/update-scim-group.ts
+++ b/integrations/1password-scim/actions/update-scim-group.ts
@@ -1,52 +1,46 @@
 import { z } from 'zod';
 import { createAction, ProxyConfiguration } from 'nango';
 
+const MemberOperationSchema = z.object({
+    op: z.enum(['add', 'remove']),
+    userId: z.string(),
+    display: z.string().optional()
+});
+
 const InputSchema = z.object({
-    groupId: z.string().describe('The unique identifier of the SCIM group to update. Example: "9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d"'),
-    displayName: z.string().optional().describe('The new display name for the group.'),
-    addMembers: z.array(z.string()).optional().describe('Array of user IDs to add as members to the group.'),
-    removeMembers: z.array(z.string()).optional().describe('Array of user IDs to remove from the group.')
+    groupId: z.string().describe('The SCIM group ID. Example: "27i3xrasou26ukebqazeadyhua"'),
+    displayName: z.string().optional().describe('New display name for the group'),
+    members: z.array(MemberOperationSchema).optional().describe('Member add or remove operations')
 });
 
-const MemberSchema = z.object({
+const GroupMemberSchema = z.object({
     value: z.string(),
-    display: z.string().optional(),
-    $ref: z.string().optional(),
-    type: z.string().optional()
+    display: z.string().optional()
 });
 
-const MetaSchema = z.object({
-    resourceType: z.string().optional(),
-    created: z.string().optional(),
-    lastModified: z.string().optional(),
-    location: z.string().optional(),
-    version: z.string().optional()
-});
-
-const ProviderGroupSchema = z.object({
+const GroupSchema = z.object({
+    schemas: z.array(z.string()),
     id: z.string(),
-    schemas: z.array(z.string()).optional(),
     displayName: z.string().optional(),
-    members: z.array(MemberSchema).optional(),
-    meta: MetaSchema.optional()
+    members: z.array(GroupMemberSchema).optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional()
+        })
+        .optional()
 });
 
 const OutputSchema = z.object({
     id: z.string(),
-    schemas: z.array(z.string()).optional(),
     displayName: z.string().optional(),
-    members: z.array(MemberSchema).optional(),
-    meta: MetaSchema.optional()
+    members: z.array(z.object({ value: z.string(), display: z.string().optional() })).optional()
 });
 
-type PatchOperation = {
-    op: string;
-    path: string;
-    value: unknown;
-};
-
 const action = createAction({
-    description: 'Update a SCIM group in 1Password SCIM.',
+    description: 'Update a SCIM group in 1Password SCIM',
     version: '1.0.0',
     endpoint: {
         method: 'POST',
@@ -55,10 +49,10 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['required.scope'],
+    scopes: ['scim'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const operations: PatchOperation[] = [];
+        const operations: Array<Record<string, unknown>> = [];
 
         if (input.displayName !== undefined) {
             operations.push({
@@ -68,26 +62,25 @@ const action = createAction({
             });
         }
 
-        if (input.addMembers !== undefined && input.addMembers.length > 0) {
-            operations.push({
-                op: 'add',
-                path: 'members',
-                value: input.addMembers.map((userId) => ({ value: userId }))
-            });
-        }
-
-        if (input.removeMembers !== undefined && input.removeMembers.length > 0) {
-            operations.push({
-                op: 'remove',
-                path: 'members',
-                value: input.removeMembers.map((userId) => ({ value: userId }))
-            });
+        if (input.members !== undefined) {
+            for (const member of input.members) {
+                operations.push({
+                    op: member.op,
+                    path: 'members',
+                    value: [
+                        {
+                            value: member.userId,
+                            ...(member.display !== undefined && { display: member.display })
+                        }
+                    ]
+                });
+            }
         }
 
         if (operations.length === 0) {
             throw new nango.ActionError({
                 type: 'invalid_input',
-                message: 'At least one update field (displayName, addMembers, or removeMembers) must be provided.'
+                message: 'At least one of displayName or members must be provided'
             });
         }
 
@@ -98,7 +91,7 @@ const action = createAction({
                 schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
                 Operations: operations
             },
-            retries: 1
+            retries: 3
         };
 
         const response = await nango.patch(config);
@@ -120,14 +113,17 @@ const action = createAction({
             rawData = getResponse.data;
         }
 
-        const providerGroup = ProviderGroupSchema.parse(rawData);
+        const group = GroupSchema.parse(rawData);
 
         return {
-            id: providerGroup.id,
-            ...(providerGroup.schemas !== undefined && { schemas: providerGroup.schemas }),
-            ...(providerGroup.displayName !== undefined && { displayName: providerGroup.displayName }),
-            ...(providerGroup.members !== undefined && { members: providerGroup.members }),
-            ...(providerGroup.meta !== undefined && { meta: providerGroup.meta })
+            id: group.id,
+            ...(group.displayName !== undefined && { displayName: group.displayName }),
+            ...(group.members !== undefined && {
+                members: group.members.map((m) => ({
+                    value: m.value,
+                    ...(m.display !== undefined && { display: m.display })
+                }))
+            })
         };
     }
 });

--- a/integrations/1password-scim/actions/update-scim-group.ts
+++ b/integrations/1password-scim/actions/update-scim-group.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import { createAction, ProxyConfiguration } from 'nango';
+
+const InputSchema = z.object({
+    groupId: z.string().describe('The unique identifier of the SCIM group to update. Example: "9067729b3d-f987ac4d-a175-44f0-a528-6d23c5d2ec4d"'),
+    displayName: z.string().optional().describe('The new display name for the group.'),
+    addMembers: z.array(z.string()).optional().describe('Array of user IDs to add as members to the group.'),
+    removeMembers: z.array(z.string()).optional().describe('Array of user IDs to remove from the group.')
+});
+
+const MemberSchema = z.object({
+    value: z.string(),
+    display: z.string().optional(),
+    $ref: z.string().optional(),
+    type: z.string().optional()
+});
+
+const MetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ProviderGroupSchema = z.object({
+    id: z.string(),
+    schemas: z.array(z.string()).optional(),
+    displayName: z.string().optional(),
+    members: z.array(MemberSchema).optional(),
+    meta: MetaSchema.optional()
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    schemas: z.array(z.string()).optional(),
+    displayName: z.string().optional(),
+    members: z.array(MemberSchema).optional(),
+    meta: MetaSchema.optional()
+});
+
+type PatchOperation = {
+    op: string;
+    path: string;
+    value: unknown;
+};
+
+const action = createAction({
+    description: 'Update a SCIM group in 1Password SCIM.',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/update-scim-group',
+        group: 'Groups'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: ['required.scope'],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const operations: PatchOperation[] = [];
+
+        if (input.displayName !== undefined) {
+            operations.push({
+                op: 'replace',
+                path: 'displayName',
+                value: input.displayName
+            });
+        }
+
+        if (input.addMembers !== undefined && input.addMembers.length > 0) {
+            operations.push({
+                op: 'add',
+                path: 'members',
+                value: input.addMembers.map((userId) => ({ value: userId }))
+            });
+        }
+
+        if (input.removeMembers !== undefined && input.removeMembers.length > 0) {
+            operations.push({
+                op: 'remove',
+                path: 'members',
+                value: input.removeMembers.map((userId) => ({ value: userId }))
+            });
+        }
+
+        if (operations.length === 0) {
+            throw new nango.ActionError({
+                type: 'invalid_input',
+                message: 'At least one update field (displayName, addMembers, or removeMembers) must be provided.'
+            });
+        }
+
+        const config: ProxyConfiguration = {
+            // https://support.1password.com/scim-endpoints/
+            endpoint: `/Groups/${encodeURIComponent(input.groupId)}`,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            data: {
+                schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                Operations: operations
+            },
+            retries: 1
+        };
+
+        const response = await nango.patch(config);
+
+        if (!response.data) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'Group not found or update failed.',
+                groupId: input.groupId
+            });
+        }
+
+        const providerGroup = ProviderGroupSchema.parse(response.data);
+
+        return {
+            id: providerGroup.id,
+            ...(providerGroup.schemas !== undefined && { schemas: providerGroup.schemas }),
+            ...(providerGroup.displayName !== undefined && { displayName: providerGroup.displayName }),
+            ...(providerGroup.members !== undefined && { members: providerGroup.members }),
+            ...(providerGroup.meta !== undefined && { meta: providerGroup.meta })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/update-scim-user.ts
+++ b/integrations/1password-scim/actions/update-scim-user.ts
@@ -1,84 +1,60 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const ScimOperationSchema = z.discriminatedUnion('op', [
-    z.object({ op: z.literal('add'), path: z.string().optional(), value: z.unknown().optional() }),
-    z.object({ op: z.literal('replace'), path: z.string().optional(), value: z.unknown().optional() }),
-    z.object({ op: z.literal('remove'), path: z.string(), value: z.unknown().optional() })
-]);
-
 const InputSchema = z.object({
-    id: z.string().describe('SCIM user ID. Example: "2819c223-7f76-453a-919d-413861904646"'),
-    operations: z.array(ScimOperationSchema).min(1).describe('Array of SCIM PatchOp operations to apply')
+    id: z.string().describe('SCIM User ID. Example: "2819c223-7f76-453a-919d-413861904646"'),
+    userName: z.string().optional().describe('User email address. Example: "user@example.com"'),
+    givenName: z.string().optional().describe('First name. Example: "Jane"'),
+    familyName: z.string().optional().describe('Last name. Example: "Doe"'),
+    displayName: z.string().optional().describe('Display name. Example: "Jane Doe"'),
+    active: z.boolean().optional().describe('Whether the user is active.')
 });
 
-const ScimMetaSchema = z.object({
-    resourceType: z.string().optional(),
+const NameSchema = z.object({
+    formatted: z.string().optional(),
+    familyName: z.string().optional(),
+    givenName: z.string().optional()
+});
+
+const EmailSchema = z.object({
+    value: z.string(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const MetaSchema = z.object({
+    resourceType: z.string(),
     created: z.string().optional(),
     lastModified: z.string().optional(),
     location: z.string().optional(),
     version: z.string().optional()
 });
 
-const ScimNameSchema = z.object({
-    formatted: z.string().optional(),
-    familyName: z.string().optional(),
-    givenName: z.string().optional(),
-    middleName: z.string().optional(),
-    honorificPrefix: z.string().optional(),
-    honorificSuffix: z.string().optional()
+const ProviderUserSchema = z.object({
+    schemas: z.array(z.string()),
+    id: z.string(),
+    externalId: z.string().optional(),
+    meta: MetaSchema.optional(),
+    userName: z.string().optional(),
+    name: NameSchema.optional(),
+    displayName: z.string().optional(),
+    active: z.boolean().optional(),
+    emails: z.array(EmailSchema).optional()
 });
-
-const ScimEmailSchema = z.object({
-    value: z.string().optional(),
-    display: z.string().optional(),
-    type: z.string().optional(),
-    primary: z.boolean().optional()
-});
-
-const ScimUserSchema = z
-    .object({
-        id: z.string(),
-        externalId: z.string().optional(),
-        meta: ScimMetaSchema.optional(),
-        schemas: z.array(z.string()).optional(),
-        userName: z.string().optional(),
-        name: ScimNameSchema.optional(),
-        displayName: z.string().optional(),
-        nickName: z.string().optional(),
-        profileUrl: z.string().optional(),
-        title: z.string().optional(),
-        userType: z.string().optional(),
-        preferredLanguage: z.string().optional(),
-        locale: z.string().optional(),
-        timezone: z.string().optional(),
-        active: z.boolean().optional(),
-        emails: z.array(ScimEmailSchema).optional()
-    })
-    .passthrough();
 
 const OutputSchema = z.object({
     id: z.string(),
-    externalId: z.string().optional(),
-    meta: ScimMetaSchema.optional(),
-    schemas: z.array(z.string()).optional(),
     userName: z.string().optional(),
-    name: ScimNameSchema.optional(),
+    givenName: z.string().optional(),
+    familyName: z.string().optional(),
     displayName: z.string().optional(),
-    nickName: z.string().optional(),
-    profileUrl: z.string().optional(),
-    title: z.string().optional(),
-    userType: z.string().optional(),
-    preferredLanguage: z.string().optional(),
-    locale: z.string().optional(),
-    timezone: z.string().optional(),
     active: z.boolean().optional(),
-    emails: z.array(ScimEmailSchema).optional()
+    emails: z.array(z.object({ value: z.string(), type: z.string().optional(), primary: z.boolean().optional() })).optional()
 });
 
 const action = createAction({
-    description: 'Update a SCIM user in 1Password SCIM',
-    version: '1.0.0',
+    description: 'Update a SCIM user in 1Password SCIM.',
+    version: '1.1.0',
     endpoint: {
         method: 'POST',
         path: '/actions/update-scim-user',
@@ -86,18 +62,40 @@ const action = createAction({
     },
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['scim'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const patchBody = {
-            schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
-            Operations: input.operations
-        };
+        const operations: Array<{ op: 'replace'; path?: string; value: unknown }> = [];
 
+        if (input.userName !== undefined) {
+            operations.push({ op: 'replace', path: 'userName', value: input.userName });
+        }
+        if (input.givenName !== undefined) {
+            operations.push({ op: 'replace', path: 'name.givenName', value: input.givenName });
+        }
+        if (input.familyName !== undefined) {
+            operations.push({ op: 'replace', path: 'name.familyName', value: input.familyName });
+        }
+        if (input.displayName !== undefined) {
+            operations.push({ op: 'replace', path: 'displayName', value: input.displayName });
+        }
+        if (input.active !== undefined) {
+            operations.push({ op: 'replace', path: 'active', value: input.active });
+        }
+
+        if (operations.length === 0) {
+            throw new nango.ActionError({
+                type: 'invalid_input',
+                message: 'At least one field to update must be provided.'
+            });
+        }
+
+        // https://support.1password.com/scim-endpoints/
         const response = await nango.patch({
-            // https://support.1password.com/scim-endpoints/
-            endpoint: `/Users/${encodeURIComponent(input.id)}`,
-            data: patchBody,
+            endpoint: `v2/Users/${encodeURIComponent(input.id)}`,
+            data: {
+                schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                Operations: operations
+            },
             retries: 3
         });
 
@@ -118,25 +116,22 @@ const action = createAction({
             rawData = getResponse.data;
         }
 
-        const providerUser = ScimUserSchema.parse(rawData);
+        const providerUser = ProviderUserSchema.parse(rawData);
 
         return {
             id: providerUser.id,
-            ...(providerUser.externalId !== undefined && { externalId: providerUser.externalId }),
-            ...(providerUser.meta !== undefined && { meta: providerUser.meta }),
-            ...(providerUser.schemas !== undefined && { schemas: providerUser.schemas }),
             ...(providerUser.userName !== undefined && { userName: providerUser.userName }),
-            ...(providerUser.name !== undefined && { name: providerUser.name }),
+            ...(providerUser.name?.givenName !== undefined && { givenName: providerUser.name.givenName }),
+            ...(providerUser.name?.familyName !== undefined && { familyName: providerUser.name.familyName }),
             ...(providerUser.displayName !== undefined && { displayName: providerUser.displayName }),
-            ...(providerUser.nickName !== undefined && { nickName: providerUser.nickName }),
-            ...(providerUser.profileUrl !== undefined && { profileUrl: providerUser.profileUrl }),
-            ...(providerUser.title !== undefined && { title: providerUser.title }),
-            ...(providerUser.userType !== undefined && { userType: providerUser.userType }),
-            ...(providerUser.preferredLanguage !== undefined && { preferredLanguage: providerUser.preferredLanguage }),
-            ...(providerUser.locale !== undefined && { locale: providerUser.locale }),
-            ...(providerUser.timezone !== undefined && { timezone: providerUser.timezone }),
             ...(providerUser.active !== undefined && { active: providerUser.active }),
-            ...(providerUser.emails !== undefined && { emails: providerUser.emails })
+            ...(providerUser.emails !== undefined && {
+                emails: providerUser.emails.map((email) => ({
+                    value: email.value,
+                    ...(email.type !== undefined && { type: email.type }),
+                    ...(email.primary !== undefined && { primary: email.primary })
+                }))
+            })
         };
     }
 });

--- a/integrations/1password-scim/actions/update-scim-user.ts
+++ b/integrations/1password-scim/actions/update-scim-user.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const ScimOperationSchema = z.object({
-    op: z.enum(['add', 'replace', 'remove']),
-    path: z.string().optional(),
-    value: z.unknown().optional()
-});
+const ScimOperationSchema = z.discriminatedUnion('op', [
+    z.object({ op: z.literal('add'), path: z.string().optional(), value: z.unknown().optional() }),
+    z.object({ op: z.literal('replace'), path: z.string().optional(), value: z.unknown().optional() }),
+    z.object({ op: z.literal('remove'), path: z.string(), value: z.unknown().optional() })
+]);
 
 const InputSchema = z.object({
     id: z.string().describe('SCIM user ID. Example: "2819c223-7f76-453a-919d-413861904646"'),
@@ -102,7 +102,25 @@ const action = createAction({
             retries: 3
         });
 
-        const providerUser = ScimUserSchema.parse(response.data);
+        let rawData = response.data;
+        if (!rawData) {
+            // SCIM PATCH may return 204 No Content on success; fetch current state
+            const getResponse = await nango.get({
+                baseUrlOverride: 'https://provisioning.1password.com/scim',
+                endpoint: `/Users/${encodeURIComponent(input.id)}`,
+                retries: 3
+            });
+            if (!getResponse.data) {
+                throw new nango.ActionError({
+                    type: 'not_found',
+                    message: 'User not found',
+                    id: input.id
+                });
+            }
+            rawData = getResponse.data;
+        }
+
+        const providerUser = ScimUserSchema.parse(rawData);
 
         return {
             id: providerUser.id,

--- a/integrations/1password-scim/actions/update-scim-user.ts
+++ b/integrations/1password-scim/actions/update-scim-user.ts
@@ -1,0 +1,129 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const ScimOperationSchema = z.object({
+    op: z.enum(['add', 'replace', 'remove']),
+    path: z.string().optional(),
+    value: z.unknown().optional()
+});
+
+const InputSchema = z.object({
+    id: z.string().describe('SCIM user ID. Example: "2819c223-7f76-453a-919d-413861904646"'),
+    operations: z.array(ScimOperationSchema).min(1).describe('Array of SCIM PatchOp operations to apply')
+});
+
+const ScimMetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
+});
+
+const ScimNameSchema = z.object({
+    formatted: z.string().optional(),
+    familyName: z.string().optional(),
+    givenName: z.string().optional(),
+    middleName: z.string().optional(),
+    honorificPrefix: z.string().optional(),
+    honorificSuffix: z.string().optional()
+});
+
+const ScimEmailSchema = z.object({
+    value: z.string().optional(),
+    display: z.string().optional(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ScimUserSchema = z
+    .object({
+        id: z.string(),
+        externalId: z.string().optional(),
+        meta: ScimMetaSchema.optional(),
+        schemas: z.array(z.string()).optional(),
+        userName: z.string().optional(),
+        name: ScimNameSchema.optional(),
+        displayName: z.string().optional(),
+        nickName: z.string().optional(),
+        profileUrl: z.string().optional(),
+        title: z.string().optional(),
+        userType: z.string().optional(),
+        preferredLanguage: z.string().optional(),
+        locale: z.string().optional(),
+        timezone: z.string().optional(),
+        active: z.boolean().optional(),
+        emails: z.array(ScimEmailSchema).optional()
+    })
+    .passthrough();
+
+const OutputSchema = z.object({
+    id: z.string(),
+    externalId: z.string().optional(),
+    meta: ScimMetaSchema.optional(),
+    schemas: z.array(z.string()).optional(),
+    userName: z.string().optional(),
+    name: ScimNameSchema.optional(),
+    displayName: z.string().optional(),
+    nickName: z.string().optional(),
+    profileUrl: z.string().optional(),
+    title: z.string().optional(),
+    userType: z.string().optional(),
+    preferredLanguage: z.string().optional(),
+    locale: z.string().optional(),
+    timezone: z.string().optional(),
+    active: z.boolean().optional(),
+    emails: z.array(ScimEmailSchema).optional()
+});
+
+const action = createAction({
+    description: 'Update a SCIM user in 1Password SCIM',
+    version: '1.0.0',
+    endpoint: {
+        method: 'POST',
+        path: '/actions/update-scim-user',
+        group: 'Users'
+    },
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: ['scim'],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const patchBody = {
+            schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            Operations: input.operations
+        };
+
+        const response = await nango.patch({
+            // https://support.1password.com/scim-endpoints/
+            endpoint: `/Users/${encodeURIComponent(input.id)}`,
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            data: patchBody,
+            retries: 3
+        });
+
+        const providerUser = ScimUserSchema.parse(response.data);
+
+        return {
+            id: providerUser.id,
+            ...(providerUser.externalId !== undefined && { externalId: providerUser.externalId }),
+            ...(providerUser.meta !== undefined && { meta: providerUser.meta }),
+            ...(providerUser.schemas !== undefined && { schemas: providerUser.schemas }),
+            ...(providerUser.userName !== undefined && { userName: providerUser.userName }),
+            ...(providerUser.name !== undefined && { name: providerUser.name }),
+            ...(providerUser.displayName !== undefined && { displayName: providerUser.displayName }),
+            ...(providerUser.nickName !== undefined && { nickName: providerUser.nickName }),
+            ...(providerUser.profileUrl !== undefined && { profileUrl: providerUser.profileUrl }),
+            ...(providerUser.title !== undefined && { title: providerUser.title }),
+            ...(providerUser.userType !== undefined && { userType: providerUser.userType }),
+            ...(providerUser.preferredLanguage !== undefined && { preferredLanguage: providerUser.preferredLanguage }),
+            ...(providerUser.locale !== undefined && { locale: providerUser.locale }),
+            ...(providerUser.timezone !== undefined && { timezone: providerUser.timezone }),
+            ...(providerUser.active !== undefined && { active: providerUser.active }),
+            ...(providerUser.emails !== undefined && { emails: providerUser.emails })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/1password-scim/actions/update-scim-user.ts
+++ b/integrations/1password-scim/actions/update-scim-user.ts
@@ -97,7 +97,6 @@ const action = createAction({
         const response = await nango.patch({
             // https://support.1password.com/scim-endpoints/
             endpoint: `/Users/${encodeURIComponent(input.id)}`,
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             data: patchBody,
             retries: 3
         });
@@ -106,7 +105,6 @@ const action = createAction({
         if (!rawData) {
             // SCIM PATCH may return 204 No Content on success; fetch current state
             const getResponse = await nango.get({
-                baseUrlOverride: 'https://provisioning.1password.com/scim',
                 endpoint: `/Users/${encodeURIComponent(input.id)}`,
                 retries: 3
             });

--- a/integrations/1password-scim/syncs/scim-groups.ts
+++ b/integrations/1password-scim/syncs/scim-groups.ts
@@ -1,85 +1,66 @@
-import { createSync } from 'nango';
-import type { ProxyConfiguration } from '@nangohq/runner-sdk';
+import { createSync, type ProxyConfiguration } from 'nango';
 import { z } from 'zod';
 
-const ScimGroupResourceSchema = z.object({
-    id: z.string(),
-    externalId: z.string().nullish(),
-    displayName: z.string().nullish(),
-    meta: z
-        .object({
-            resourceType: z.string().nullish(),
-            created: z.string().nullish(),
-            lastModified: z.string().nullish(),
-            location: z.string().nullish()
-        })
-        .nullish(),
-    members: z
-        .array(
-            z.object({
-                value: z.string(),
-                display: z.string().nullish()
-            })
-        )
-        .nullish()
+const ScimMemberSchema = z.object({
+    value: z.string(),
+    display: z.string().optional(),
+    $ref: z.string().optional()
+});
+
+const ScimMetaSchema = z.object({
+    resourceType: z.string().optional(),
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    location: z.string().optional(),
+    version: z.string().optional()
 });
 
 const ScimGroupSchema = z.object({
+    schemas: z.array(z.string()).optional(),
     id: z.string(),
+    displayName: z.string(),
     externalId: z.string().optional(),
-    displayName: z.string().optional(),
-    meta: z
-        .object({
-            resourceType: z.string().optional(),
-            created: z.string().optional(),
-            lastModified: z.string().optional(),
-            location: z.string().optional()
-        })
-        .optional(),
-    members: z
-        .array(
-            z.object({
-                value: z.string(),
-                display: z.string().optional()
-            })
-        )
-        .optional()
+    members: z.array(ScimMemberSchema).optional(),
+    meta: ScimMetaSchema.optional()
+});
+
+const GroupSchema = z.object({
+    id: z.string(),
+    displayName: z.string(),
+    externalId: z.string().optional(),
+    members: z.array(ScimMemberSchema).optional(),
+    meta: ScimMetaSchema.optional()
 });
 
 const CheckpointSchema = z.object({
     updated_after: z.string()
 });
 
-const LIMIT = 100;
-
 const sync = createSync({
-    description: 'Sync SCIM groups from 1Password SCIM',
+    description: 'Sync SCIM groups from 1Password SCIM.',
     version: '1.0.0',
-    // https://support.1password.com/scim-endpoints/
-    endpoints: [{ method: 'GET', path: '/syncs/scim-groups' }],
     frequency: 'every hour',
     autoStart: true,
+    endpoints: [
+        // https://support.1password.com/scim-endpoints/
+        { method: 'GET', path: '/syncs/scim-groups' }
+    ],
     checkpoint: CheckpointSchema,
     models: {
-        ScimGroup: ScimGroupSchema
+        Group: GroupSchema
     },
 
     exec: async (nango) => {
         const checkpoint = await nango.getCheckpoint();
-        const validatedCheckpoint = CheckpointSchema.safeParse(checkpoint ?? {});
-        const updatedAfter = validatedCheckpoint.success && validatedCheckpoint.data.updated_after ? validatedCheckpoint.data.updated_after : undefined;
-        let latestUpdatedAfter = updatedAfter;
-        let latestUpdatedAfterMs = updatedAfter ? Date.parse(updatedAfter) : Number.NEGATIVE_INFINITY;
-
-        if (Number.isNaN(latestUpdatedAfterMs)) {
-            latestUpdatedAfterMs = Number.NEGATIVE_INFINITY;
-        }
+        const updatedAfter = checkpoint?.updated_after;
 
         const proxyConfig: ProxyConfiguration = {
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Groups',
             params: {
-                ...(updatedAfter && { filter: `meta.lastModified ge "${updatedAfter}"` })
+                ...(updatedAfter && { filter: `meta.lastModified gt "${updatedAfter}"` }),
+                sortBy: 'meta.lastModified',
+                sortOrder: 'ascending'
             },
             paginate: {
                 type: 'offset',
@@ -87,68 +68,41 @@ const sync = createSync({
                 offset_start_value: 1,
                 offset_calculation_method: 'by-response-size',
                 limit_name_in_request: 'count',
-                limit: LIMIT,
+                limit: 100,
                 response_path: 'Resources'
             },
             retries: 3
         };
 
         for await (const page of nango.paginate(proxyConfig)) {
-            const groups = page
-                .map((item) => {
-                    if (typeof item !== 'object' || item === null) {
-                        throw new Error('Expected SCIM group resource to be an object');
-                    }
-                    const parseResult = ScimGroupResourceSchema.safeParse(item);
-                    if (!parseResult.success) {
-                        throw new Error(`Failed to parse SCIM group resource: ${parseResult.error.message}`);
-                    }
-                    return parseResult.data;
-                })
-                .map((record) => ({
-                    id: record.id,
-                    ...(record.externalId != null && { externalId: record.externalId }),
-                    ...(record.displayName != null && { displayName: record.displayName }),
-                    ...(record.meta != null && {
-                        meta: {
-                            ...(record.meta.resourceType != null && { resourceType: record.meta.resourceType }),
-                            ...(record.meta.created != null && { created: record.meta.created }),
-                            ...(record.meta.lastModified != null && { lastModified: record.meta.lastModified }),
-                            ...(record.meta.location != null && { location: record.meta.location })
-                        }
-                    }),
-                    ...(record.members != null && {
-                        members: record.members.map((m) => ({
-                            value: m.value,
-                            ...(m.display != null && { display: m.display })
-                        }))
-                    })
-                }));
+            const groups = page.map((item: unknown) => {
+                const parsed = ScimGroupSchema.safeParse(item);
+                if (!parsed.success) {
+                    throw new Error(`Failed to parse SCIM group: ${parsed.error.message}`);
+                }
+                return parsed.data;
+            });
 
             if (groups.length === 0) {
                 continue;
             }
 
-            await nango.batchSave(groups, 'ScimGroup');
+            const records = groups.map((group) => ({
+                id: group.id,
+                displayName: group.displayName,
+                ...(group.externalId !== undefined && { externalId: group.externalId }),
+                ...(group.members !== undefined && { members: group.members }),
+                ...(group.meta !== undefined && { meta: group.meta })
+            }));
 
-            for (const group of groups) {
-                const lastModified = group.meta?.lastModified;
-                if (!lastModified) {
-                    continue;
-                }
+            await nango.batchSave(records, 'Group');
 
-                const lastModifiedMs = Date.parse(lastModified);
-                if (Number.isNaN(lastModifiedMs) || lastModifiedMs <= latestUpdatedAfterMs) {
-                    continue;
-                }
-
-                latestUpdatedAfter = lastModified;
-                latestUpdatedAfterMs = lastModifiedMs;
+            const lastUpdatedAt = groups[groups.length - 1]?.meta?.lastModified;
+            if (lastUpdatedAt) {
+                await nango.saveCheckpoint({
+                    updated_after: lastUpdatedAt
+                });
             }
-        }
-
-        if (latestUpdatedAfter && latestUpdatedAfter !== updatedAfter) {
-            await nango.saveCheckpoint({ updated_after: latestUpdatedAfter });
         }
     }
 });

--- a/integrations/1password-scim/syncs/scim-groups.ts
+++ b/integrations/1password-scim/syncs/scim-groups.ts
@@ -78,7 +78,6 @@ const sync = createSync({
         const proxyConfig: ProxyConfiguration = {
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Groups',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             params: {
                 ...(updatedAfter && { filter: `meta.lastModified ge "${updatedAfter}"` })
             },

--- a/integrations/1password-scim/syncs/scim-groups.ts
+++ b/integrations/1password-scim/syncs/scim-groups.ts
@@ -110,8 +110,20 @@ const sync = createSync({
                     id: record.id,
                     ...(record.externalId != null && { externalId: record.externalId }),
                     ...(record.displayName != null && { displayName: record.displayName }),
-                    ...(record.meta != null && { meta: record.meta }),
-                    ...(record.members != null && { members: record.members })
+                    ...(record.meta != null && {
+                        meta: {
+                            ...(record.meta.resourceType != null && { resourceType: record.meta.resourceType }),
+                            ...(record.meta.created != null && { created: record.meta.created }),
+                            ...(record.meta.lastModified != null && { lastModified: record.meta.lastModified }),
+                            ...(record.meta.location != null && { location: record.meta.location })
+                        }
+                    }),
+                    ...(record.members != null && {
+                        members: record.members.map((m) => ({
+                            value: m.value,
+                            ...(m.display != null && { display: m.display })
+                        }))
+                    })
                 }));
 
             if (groups.length === 0) {

--- a/integrations/1password-scim/syncs/scim-groups.ts
+++ b/integrations/1password-scim/syncs/scim-groups.ts
@@ -1,0 +1,146 @@
+import { createSync } from 'nango';
+import type { ProxyConfiguration } from '@nangohq/runner-sdk';
+import { z } from 'zod';
+
+const ScimGroupResourceSchema = z.object({
+    id: z.string(),
+    externalId: z.string().nullish(),
+    displayName: z.string().nullish(),
+    meta: z
+        .object({
+            resourceType: z.string().nullish(),
+            created: z.string().nullish(),
+            lastModified: z.string().nullish(),
+            location: z.string().nullish()
+        })
+        .nullish(),
+    members: z
+        .array(
+            z.object({
+                value: z.string(),
+                display: z.string().nullish()
+            })
+        )
+        .nullish()
+});
+
+const ScimGroupSchema = z.object({
+    id: z.string(),
+    externalId: z.string().optional(),
+    displayName: z.string().optional(),
+    meta: z
+        .object({
+            resourceType: z.string().optional(),
+            created: z.string().optional(),
+            lastModified: z.string().optional(),
+            location: z.string().optional()
+        })
+        .optional(),
+    members: z
+        .array(
+            z.object({
+                value: z.string(),
+                display: z.string().optional()
+            })
+        )
+        .optional()
+});
+
+const CheckpointSchema = z.object({
+    updated_after: z.string()
+});
+
+const LIMIT = 100;
+
+const sync = createSync({
+    description: 'Sync SCIM groups from 1Password SCIM',
+    version: '1.0.0',
+    // https://support.1password.com/scim-endpoints/
+    endpoints: [{ method: 'GET', path: '/syncs/scim-groups' }],
+    frequency: 'every hour',
+    autoStart: true,
+    checkpoint: CheckpointSchema,
+    models: {
+        ScimGroup: ScimGroupSchema
+    },
+
+    exec: async (nango) => {
+        const checkpoint = await nango.getCheckpoint();
+        const validatedCheckpoint = CheckpointSchema.safeParse(checkpoint ?? {});
+        const updatedAfter = validatedCheckpoint.success && validatedCheckpoint.data.updated_after ? validatedCheckpoint.data.updated_after : undefined;
+        let latestUpdatedAfter = updatedAfter;
+        let latestUpdatedAfterMs = updatedAfter ? Date.parse(updatedAfter) : Number.NEGATIVE_INFINITY;
+
+        if (Number.isNaN(latestUpdatedAfterMs)) {
+            latestUpdatedAfterMs = Number.NEGATIVE_INFINITY;
+        }
+
+        const proxyConfig: ProxyConfiguration = {
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/Groups',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            params: {
+                ...(updatedAfter && { filter: `meta.lastModified ge "${updatedAfter}"` })
+            },
+            paginate: {
+                type: 'offset',
+                offset_name_in_request: 'startIndex',
+                offset_start_value: 1,
+                offset_calculation_method: 'by-response-size',
+                limit_name_in_request: 'count',
+                limit: LIMIT,
+                response_path: 'Resources'
+            },
+            retries: 3
+        };
+
+        for await (const page of nango.paginate(proxyConfig)) {
+            const groups = page
+                .map((item) => {
+                    if (typeof item !== 'object' || item === null) {
+                        throw new Error('Expected SCIM group resource to be an object');
+                    }
+                    const parseResult = ScimGroupResourceSchema.safeParse(item);
+                    if (!parseResult.success) {
+                        throw new Error(`Failed to parse SCIM group resource: ${parseResult.error.message}`);
+                    }
+                    return parseResult.data;
+                })
+                .map((record) => ({
+                    id: record.id,
+                    ...(record.externalId != null && { externalId: record.externalId }),
+                    ...(record.displayName != null && { displayName: record.displayName }),
+                    ...(record.meta != null && { meta: record.meta }),
+                    ...(record.members != null && { members: record.members })
+                }));
+
+            if (groups.length === 0) {
+                continue;
+            }
+
+            await nango.batchSave(groups, 'ScimGroup');
+
+            for (const group of groups) {
+                const lastModified = group.meta?.lastModified;
+                if (!lastModified) {
+                    continue;
+                }
+
+                const lastModifiedMs = Date.parse(lastModified);
+                if (Number.isNaN(lastModifiedMs) || lastModifiedMs <= latestUpdatedAfterMs) {
+                    continue;
+                }
+
+                latestUpdatedAfter = lastModified;
+                latestUpdatedAfterMs = lastModifiedMs;
+            }
+        }
+
+        if (latestUpdatedAfter && latestUpdatedAfter !== updatedAfter) {
+            await nango.saveCheckpoint({ updated_after: latestUpdatedAfter });
+        }
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/1password-scim/syncs/scim-users.ts
+++ b/integrations/1password-scim/syncs/scim-users.ts
@@ -1,33 +1,56 @@
 import { createSync, type ProxyConfiguration } from 'nango';
 import { z } from 'zod';
 
-const ScimUserEmailSchema = z.object({
-    value: z.string(),
-    type: z.string().optional(),
-    primary: z.boolean().optional()
+const ScimNameSchema = z.object({
+    givenName: z.string().optional().nullable(),
+    familyName: z.string().optional().nullable(),
+    formatted: z.string().optional().nullable()
 });
 
-const ScimUserNameSchema = z.object({
-    formatted: z.string().optional(),
-    familyName: z.string().optional(),
-    givenName: z.string().optional()
+const ScimEmailSchema = z.object({
+    value: z.string().optional().nullable(),
+    type: z.string().optional().nullable(),
+    primary: z.boolean().optional().nullable()
 });
 
 const ScimUserMetaSchema = z.object({
-    created: z.string().optional(),
-    lastModified: z.string().optional(),
-    resourceType: z.string().optional()
+    lastModified: z.string().optional()
+});
+
+const ScimUserResponseSchema = z.object({
+    id: z.string(),
+    userName: z.string().optional().nullable(),
+    displayName: z.string().optional().nullable(),
+    name: ScimNameSchema.optional().nullable(),
+    emails: z.array(ScimEmailSchema).optional().nullable(),
+    active: z.boolean().optional().nullable(),
+    externalId: z.string().optional().nullable(),
+    meta: ScimUserMetaSchema.optional().nullable()
 });
 
 const ScimUserSchema = z.object({
     id: z.string(),
-    userName: z.string(),
+    userName: z.string().optional(),
     displayName: z.string().optional(),
-    name: ScimUserNameSchema.optional(),
-    emails: z.array(ScimUserEmailSchema).optional(),
-    externalId: z.string().optional(),
+    name: z
+        .object({
+            givenName: z.string().optional(),
+            familyName: z.string().optional(),
+            formatted: z.string().optional()
+        })
+        .optional(),
+    emails: z
+        .array(
+            z.object({
+                value: z.string().optional(),
+                type: z.string().optional(),
+                primary: z.boolean().optional()
+            })
+        )
+        .optional(),
     active: z.boolean().optional(),
-    meta: ScimUserMetaSchema.optional()
+    externalId: z.string().optional(),
+    updated_at: z.string().optional()
 });
 
 const sync = createSync({
@@ -35,10 +58,15 @@ const sync = createSync({
     version: '1.0.0',
     frequency: 'every hour',
     autoStart: true,
-    endpoints: [{ method: 'GET', path: '/syncs/scim-users' }],
     models: {
         ScimUser: ScimUserSchema
     },
+    endpoints: [
+        {
+            method: 'GET',
+            path: '/syncs/scim-users'
+        }
+    ],
 
     exec: async (nango) => {
         await nango.trackDeletesStart('ScimUser');
@@ -59,18 +87,48 @@ const sync = createSync({
         };
 
         for await (const page of nango.paginate(proxyConfig)) {
-            const rawItems = z.array(z.unknown()).parse(page);
-            const users = rawItems.map((item) => {
-                const parsed = ScimUserSchema.safeParse(item);
-                if (!parsed.success) {
-                    throw new Error(`Failed to parse SCIM user: ${parsed.error.message}`);
-                }
-                return parsed.data;
-            });
-
-            if (users.length > 0) {
-                await nango.batchSave(users, 'ScimUser');
+            const parseResult = z.array(ScimUserResponseSchema).safeParse(page);
+            if (!parseResult.success) {
+                throw new Error(`Failed to parse SCIM users response: ${parseResult.error.message}`);
             }
+
+            const records = parseResult.data;
+            const users = [];
+            for (const record of records) {
+                const lastModified = record.meta?.lastModified;
+
+                const user = {
+                    id: record.id,
+                    ...(record.userName != null && { userName: record.userName }),
+                    ...(record.displayName != null && { displayName: record.displayName }),
+                    ...(record.name != null && {
+                        name: {
+                            ...(record.name.givenName != null && { givenName: record.name.givenName }),
+                            ...(record.name.familyName != null && { familyName: record.name.familyName }),
+                            ...(record.name.formatted != null && { formatted: record.name.formatted })
+                        }
+                    }),
+                    ...(record.emails != null && {
+                        emails: record.emails
+                            .filter((email) => email.value != null)
+                            .map((email) => ({
+                                ...(email.value != null && { value: email.value }),
+                                ...(email.type != null && { type: email.type }),
+                                ...(email.primary != null && { primary: email.primary })
+                            }))
+                    }),
+                    ...(record.active != null && { active: record.active }),
+                    ...(record.externalId != null && { externalId: record.externalId }),
+                    ...(lastModified != null && { updated_at: lastModified })
+                };
+                users.push(user);
+            }
+
+            if (users.length === 0) {
+                continue;
+            }
+
+            await nango.batchSave(users, 'ScimUser');
         }
 
         await nango.trackDeletesEnd('ScimUser');

--- a/integrations/1password-scim/syncs/scim-users.ts
+++ b/integrations/1password-scim/syncs/scim-users.ts
@@ -46,7 +46,6 @@ const sync = createSync({
         const proxyConfig: ProxyConfiguration = {
             // https://support.1password.com/scim-endpoints/
             endpoint: '/Users',
-            baseUrlOverride: 'https://provisioning.1password.com/scim',
             paginate: {
                 type: 'offset',
                 offset_name_in_request: 'startIndex',

--- a/integrations/1password-scim/syncs/scim-users.ts
+++ b/integrations/1password-scim/syncs/scim-users.ts
@@ -1,0 +1,82 @@
+import { createSync, type ProxyConfiguration } from 'nango';
+import { z } from 'zod';
+
+const ScimUserEmailSchema = z.object({
+    value: z.string(),
+    type: z.string().optional(),
+    primary: z.boolean().optional()
+});
+
+const ScimUserNameSchema = z.object({
+    formatted: z.string().optional(),
+    familyName: z.string().optional(),
+    givenName: z.string().optional()
+});
+
+const ScimUserMetaSchema = z.object({
+    created: z.string().optional(),
+    lastModified: z.string().optional(),
+    resourceType: z.string().optional()
+});
+
+const ScimUserSchema = z.object({
+    id: z.string(),
+    userName: z.string(),
+    displayName: z.string().optional(),
+    name: ScimUserNameSchema.optional(),
+    emails: z.array(ScimUserEmailSchema).optional(),
+    externalId: z.string().optional(),
+    active: z.boolean().optional(),
+    meta: ScimUserMetaSchema.optional()
+});
+
+const sync = createSync({
+    description: 'Sync SCIM users from 1Password SCIM.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    endpoints: [{ method: 'GET', path: '/syncs/scim-users' }],
+    models: {
+        ScimUser: ScimUserSchema
+    },
+
+    exec: async (nango) => {
+        await nango.trackDeletesStart('ScimUser');
+
+        const proxyConfig: ProxyConfiguration = {
+            // https://support.1password.com/scim-endpoints/
+            endpoint: '/Users',
+            baseUrlOverride: 'https://provisioning.1password.com/scim',
+            paginate: {
+                type: 'offset',
+                offset_name_in_request: 'startIndex',
+                offset_start_value: 1,
+                offset_calculation_method: 'by-response-size',
+                limit_name_in_request: 'count',
+                limit: 100,
+                response_path: 'Resources'
+            },
+            retries: 3
+        };
+
+        for await (const page of nango.paginate(proxyConfig)) {
+            const rawItems = z.array(z.unknown()).parse(page);
+            const users = rawItems.map((item) => {
+                const parsed = ScimUserSchema.safeParse(item);
+                if (!parsed.success) {
+                    throw new Error(`Failed to parse SCIM user: ${parsed.error.message}`);
+                }
+                return parsed.data;
+            });
+
+            if (users.length > 0) {
+                await nango.batchSave(users, 'ScimUser');
+            }
+        }
+
+        await nango.trackDeletesEnd('ScimUser');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/1password-scim/tests/1password-scim-create-scim-group.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-create-scim-group.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/create-scim-group.js';
+
+describe('1password-scim create-scim-group tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-scim-group',
+        Model: 'ActionOutput_1password_scim_createscimgroup'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-create-scim-user.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-create-scim-user.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/create-scim-user.js';
+
+describe('1password-scim create-scim-user tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'create-scim-user',
+        Model: 'ActionOutput_1password_scim_createscimuser'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-delete-scim-group.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-delete-scim-group.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/delete-scim-group.js';
+
+describe('1password-scim delete-scim-group tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'delete-scim-group',
+        Model: 'ActionOutput_1password_scim_deletescimgroup'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-delete-scim-user.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-delete-scim-user.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/delete-scim-user.js';
+
+describe('1password-scim delete-scim-user tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'delete-scim-user',
+        Model: 'ActionOutput_1password_scim_deletescimuser'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-get-scim-group.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-get-scim-group.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/get-scim-group.js';
+
+describe('1password-scim get-scim-group tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'get-scim-group',
+        Model: 'ActionOutput_1password_scim_getscimgroup'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-get-scim-user.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-get-scim-user.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/get-scim-user.js';
+
+describe('1password-scim get-scim-user tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'get-scim-user',
+        Model: 'ActionOutput_1password_scim_getscimuser'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-get-service-provider-config.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-get-service-provider-config.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/get-service-provider-config.js';
+
+describe('1password-scim get-service-provider-config tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'get-service-provider-config',
+        Model: 'ActionOutput_1password_scim_getserviceproviderconfig'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-list-resource-types.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-list-resource-types.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/list-resource-types.js';
+
+describe('1password-scim list-resource-types tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'list-resource-types',
+        Model: 'ActionOutput_1password_scim_listresourcetypes'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-list-schemas.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-list-schemas.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/list-schemas.js';
+
+describe('1password-scim list-schemas tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'list-schemas',
+        Model: 'ActionOutput_1password_scim_listschemas'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-list-scim-groups.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-list-scim-groups.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/list-scim-groups.js';
+
+describe('1password-scim list-scim-groups tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'list-scim-groups',
+        Model: 'ActionOutput_1password_scim_listscimgroups'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-list-scim-users.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-list-scim-users.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/list-scim-users.js';
+
+describe('1password-scim list-scim-users tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'list-scim-users',
+        Model: 'ActionOutput_1password_scim_listscimusers'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-patch-scim-group.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-patch-scim-group.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/patch-scim-group.js';
+
+describe('1password-scim patch-scim-group tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'patch-scim-group',
+        Model: 'ActionOutput_1password_scim_patchscimgroup'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-patch-scim-user.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-patch-scim-user.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/patch-scim-user.js';
+
+describe('1password-scim patch-scim-user tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'patch-scim-user',
+        Model: 'ActionOutput_1password_scim_patchscimuser'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-scim-groups.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-scim-groups.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, vi, expect, it, describe } from 'vitest';
+
+import createSync from '../syncs/scim-groups.js';
+
+describe('1password-scim scim-groups tests', () => {
+    const models = 'ScimGroup'.split(',');
+
+    const createTestContext = () => {
+        const nangoMock = new global.vitest.NangoSyncMock({
+            dirname: __dirname,
+            name: 'scim-groups',
+            Model: 'ScimGroup'
+        });
+
+        return {
+            nangoMock,
+            batchSaveSpy: vi.spyOn(nangoMock, 'batchSave')
+        };
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('should get, map correctly the data and batchSave the result', async () => {
+        const { nangoMock, batchSaveSpy } = createTestContext();
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const expectedBatchSaveData = await nangoMock.getBatchSaveData(model);
+
+            const spiedData = batchSaveSpy.mock.calls.flatMap((call) => {
+                if (call[1] === model) {
+                    return call[0];
+                }
+
+                return [];
+            });
+
+            // Normalize spy-captured args into plain JSON so they compare cleanly
+            // with fixture data loaded from `*.test.json`.
+            // Removes things like prototypes, undefined values and other non-serializable data.
+            const spied = JSON.parse(JSON.stringify(spiedData));
+
+            expect(spied).toStrictEqual(expectedBatchSaveData);
+        }
+    });
+
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        const { nangoMock } = createTestContext();
+        const batchDeleteSpy = vi.spyOn(nangoMock, 'batchDelete');
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                const spiedData = batchDeleteSpy.mock.calls.flatMap((call) => {
+                    if (call[1] === model) {
+                        return call[0];
+                    }
+
+                    return [];
+                });
+
+                // Normalize spy-captured args into plain JSON so they compare cleanly
+                // with fixture data loaded from `*.test.json`.
+                // Removes things like prototypes, undefined values and other non-serializable data.
+                const spied = JSON.parse(JSON.stringify(spiedData));
+
+                expect(spied).toStrictEqual(batchDeleteData);
+            }
+        }
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-scim-groups.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-scim-groups.test.ts
@@ -3,13 +3,13 @@ import { afterEach, vi, expect, it, describe } from 'vitest';
 import createSync from '../syncs/scim-groups.js';
 
 describe('1password-scim scim-groups tests', () => {
-    const models = 'ScimGroup'.split(',');
+    const models = 'Group'.split(',');
 
     const createTestContext = () => {
         const nangoMock = new global.vitest.NangoSyncMock({
             dirname: __dirname,
             name: 'scim-groups',
-            Model: 'ScimGroup'
+            Model: 'Group'
         });
 
         return {

--- a/integrations/1password-scim/tests/1password-scim-scim-users.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-scim-users.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, vi, expect, it, describe } from 'vitest';
+
+import createSync from '../syncs/scim-users.js';
+
+describe('1password-scim scim-users tests', () => {
+    const models = 'ScimUser'.split(',');
+
+    const createTestContext = () => {
+        const nangoMock = new global.vitest.NangoSyncMock({
+            dirname: __dirname,
+            name: 'scim-users',
+            Model: 'ScimUser'
+        });
+
+        return {
+            nangoMock,
+            batchSaveSpy: vi.spyOn(nangoMock, 'batchSave')
+        };
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('should get, map correctly the data and batchSave the result', async () => {
+        const { nangoMock, batchSaveSpy } = createTestContext();
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const expectedBatchSaveData = await nangoMock.getBatchSaveData(model);
+
+            const spiedData = batchSaveSpy.mock.calls.flatMap((call) => {
+                if (call[1] === model) {
+                    return call[0];
+                }
+
+                return [];
+            });
+
+            // Normalize spy-captured args into plain JSON so they compare cleanly
+            // with fixture data loaded from `*.test.json`.
+            // Removes things like prototypes, undefined values and other non-serializable data.
+            const spied = JSON.parse(JSON.stringify(spiedData));
+
+            expect(spied).toStrictEqual(expectedBatchSaveData);
+        }
+    });
+
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        const { nangoMock } = createTestContext();
+        const batchDeleteSpy = vi.spyOn(nangoMock, 'batchDelete');
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                const spiedData = batchDeleteSpy.mock.calls.flatMap((call) => {
+                    if (call[1] === model) {
+                        return call[0];
+                    }
+
+                    return [];
+                });
+
+                // Normalize spy-captured args into plain JSON so they compare cleanly
+                // with fixture data loaded from `*.test.json`.
+                // Removes things like prototypes, undefined values and other non-serializable data.
+                const spied = JSON.parse(JSON.stringify(spiedData));
+
+                expect(spied).toStrictEqual(batchDeleteData);
+            }
+        }
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-update-scim-group.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-update-scim-group.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/update-scim-group.js';
+
+describe('1password-scim update-scim-group tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'update-scim-group',
+        Model: 'ActionOutput_1password_scim_updatescimgroup'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/1password-scim-update-scim-user.test.ts
+++ b/integrations/1password-scim/tests/1password-scim-update-scim-user.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/update-scim-user.js';
+
+describe('1password-scim update-scim-user tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'update-scim-user',
+        Model: 'ActionOutput_1password_scim_updatescimuser'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/1password-scim/tests/create-scim-group.test.json
+++ b/integrations/1password-scim/tests/create-scim-group.test.json
@@ -1,0 +1,62 @@
+{
+  "input": {
+    "displayName": "Test Group"
+  },
+  "output": {
+    "id": "sitza7mfvjmrgdr6krnetp7g2q",
+    "displayName": "Test Group",
+    "meta": {
+      "resourceType": "Group",
+      "created": "2026-05-21T14:15:21Z",
+      "lastModified": "2026-05-21T14:15:20Z"
+    }
+  },
+  "nango": {},
+  "api": {
+    "post": {
+      "/Groups": {
+        "response": {
+          "displayName": "Test Group",
+          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "meta": {
+            "created": "2026-05-21T14:15:21Z",
+            "lastModified": "2026-05-21T14:15:20Z",
+            "resourceType": "Group"
+          },
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:Group"
+          ]
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:18:50 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "224",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4994",
+          "x-ratelimit-reset": "1779373169",
+          "etag": "W/\"e0-iXMghRoHewirhPtyKTD/0RdEWvQ\""
+        },
+        "hash": "4eac1e6bb745f7b4727dfcfa3ac31bde51265d6b",
+        "request": {
+          "data": {
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:Group"
+            ],
+            "displayName": "Test Group"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/create-scim-group.test.json
+++ b/integrations/1password-scim/tests/create-scim-group.test.json
@@ -1,14 +1,14 @@
 {
   "input": {
-    "displayName": "Test Group"
+    "displayName": "Nango Test Group 2026-05-22-001"
   },
   "output": {
-    "id": "sitza7mfvjmrgdr6krnetp7g2q",
-    "displayName": "Test Group",
+    "id": "va2pjrrhr7ykpdxkscbql6ipue",
+    "displayName": "Nango Test Group 2026-05-22-001",
     "meta": {
       "resourceType": "Group",
-      "created": "2026-05-21T14:15:21Z",
-      "lastModified": "2026-05-21T14:15:20Z"
+      "created": "2026-05-22T17:57:33Z",
+      "lastModified": "2026-05-22T17:57:33Z"
     }
   },
   "nango": {},
@@ -16,11 +16,11 @@
     "post": {
       "/Groups": {
         "response": {
-          "displayName": "Test Group",
-          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "displayName": "Nango Test Group 2026-05-22-001",
+          "id": "va2pjrrhr7ykpdxkscbql6ipue",
           "meta": {
-            "created": "2026-05-21T14:15:21Z",
-            "lastModified": "2026-05-21T14:15:20Z",
+            "created": "2026-05-22T17:57:33Z",
+            "lastModified": "2026-05-22T17:57:33Z",
             "resourceType": "Group"
           },
           "schemas": [
@@ -29,9 +29,9 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:18:50 GMT",
+          "date": "Fri, 22 May 2026 17:57:41 GMT",
           "content-type": "application/scim+json",
-          "content-length": "224",
+          "content-length": "245",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -43,17 +43,17 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4994",
-          "x-ratelimit-reset": "1779373169",
-          "etag": "W/\"e0-iXMghRoHewirhPtyKTD/0RdEWvQ\""
+          "x-ratelimit-remaining": "4968",
+          "x-ratelimit-reset": "1779472699",
+          "etag": "W/\"f5-/TFsayHfXyAuu2IE4x1oxrIGgIY\""
         },
-        "hash": "4eac1e6bb745f7b4727dfcfa3ac31bde51265d6b",
+        "hash": "90c28bc5d9994c83df72f5c7ff53c3d229da3c04",
         "request": {
           "data": {
             "schemas": [
               "urn:ietf:params:scim:schemas:core:2.0:Group"
             ],
-            "displayName": "Test Group"
+            "displayName": "Nango Test Group 2026-05-22-001"
           }
         }
       }

--- a/integrations/1password-scim/tests/create-scim-user.test.json
+++ b/integrations/1password-scim/tests/create-scim-user.test.json
@@ -1,24 +1,31 @@
 {
   "input": {
-    "userName": "scim-test-action@nango.dev",
+    "userName": "create-scim-user-test-20260522@nango.dev",
     "name": {
-      "givenName": "SCIM",
+      "givenName": "Create",
       "familyName": "Test"
-    },
-    "active": true
-  },
-  "output": {
-    "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
-    "userName": "scim-test-action@nango.dev",
-    "displayName": "SCIM Test",
-    "name": {
-      "formatted": "SCIM Test",
-      "familyName": "Test",
-      "givenName": "SCIM"
     },
     "emails": [
       {
-        "value": "scim-test-action@nango.dev",
+        "value": "create-scim-user-test-20260522@nango.dev",
+        "type": "work",
+        "primary": true
+      }
+    ],
+    "active": true
+  },
+  "output": {
+    "id": "TUUWOM3BINHPRMYTZOI3H224DM",
+    "userName": "create-scim-user-test-20260522@nango.dev",
+    "displayName": "Create Test",
+    "name": {
+      "givenName": "Create",
+      "familyName": "Test",
+      "formatted": "Create Test"
+    },
+    "emails": [
+      {
+        "value": "create-scim-user-test-20260522@nango.dev",
         "primary": true
       }
     ],
@@ -33,33 +40,33 @@
       "/Users": {
         "response": {
           "active": true,
-          "displayName": "SCIM Test",
+          "displayName": "Create Test",
           "emails": [
             {
               "primary": true,
-              "value": "scim-test-action@nango.dev"
+              "value": "create-scim-user-test-20260522@nango.dev"
             }
           ],
-          "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+          "id": "TUUWOM3BINHPRMYTZOI3H224DM",
           "meta": {
             "resourceType": "User"
           },
           "name": {
             "familyName": "Test",
-            "formatted": "SCIM Test",
-            "givenName": "SCIM"
+            "formatted": "Create Test",
+            "givenName": "Create"
           },
           "preferredLanguage": "en",
           "schemas": [
             "urn:ietf:params:scim:schemas:core:2.0:User"
           ],
-          "userName": "scim-test-action@nango.dev"
+          "userName": "create-scim-user-test-20260522@nango.dev"
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:22:58 GMT",
+          "date": "Fri, 22 May 2026 18:02:03 GMT",
           "content-type": "application/scim+json",
-          "content-length": "366",
+          "content-length": "400",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -71,21 +78,28 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4979",
-          "x-ratelimit-reset": "1779373384",
-          "etag": "W/\"16e-W7fwXQ5DPZwbvH3tTax0GGwNVFs\""
+          "x-ratelimit-remaining": "4991",
+          "x-ratelimit-reset": "1779472954",
+          "etag": "W/\"190-CxkD9uvZ4Y2N0nc0z9Bu/uIYQWE\""
         },
-        "hash": "83dd0b0644f91314b863a968996454e7450942ed",
+        "hash": "268849268cb59c0a4033d39bfc23b7764da05a2e",
         "request": {
           "data": {
             "schemas": [
               "urn:ietf:params:scim:schemas:core:2.0:User"
             ],
-            "userName": "scim-test-action@nango.dev",
+            "userName": "create-scim-user-test-20260522@nango.dev",
             "name": {
-              "givenName": "SCIM",
+              "givenName": "Create",
               "familyName": "Test"
             },
+            "emails": [
+              {
+                "value": "create-scim-user-test-20260522@nango.dev",
+                "type": "work",
+                "primary": true
+              }
+            ],
             "active": true
           }
         }

--- a/integrations/1password-scim/tests/create-scim-user.test.json
+++ b/integrations/1password-scim/tests/create-scim-user.test.json
@@ -1,0 +1,95 @@
+{
+  "input": {
+    "userName": "scim-test-action@nango.dev",
+    "name": {
+      "givenName": "SCIM",
+      "familyName": "Test"
+    },
+    "active": true
+  },
+  "output": {
+    "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+    "userName": "scim-test-action@nango.dev",
+    "displayName": "SCIM Test",
+    "name": {
+      "formatted": "SCIM Test",
+      "familyName": "Test",
+      "givenName": "SCIM"
+    },
+    "emails": [
+      {
+        "value": "scim-test-action@nango.dev",
+        "primary": true
+      }
+    ],
+    "active": true,
+    "meta": {
+      "resourceType": "User"
+    }
+  },
+  "nango": {},
+  "api": {
+    "post": {
+      "/Users": {
+        "response": {
+          "active": true,
+          "displayName": "SCIM Test",
+          "emails": [
+            {
+              "primary": true,
+              "value": "scim-test-action@nango.dev"
+            }
+          ],
+          "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+          "meta": {
+            "resourceType": "User"
+          },
+          "name": {
+            "familyName": "Test",
+            "formatted": "SCIM Test",
+            "givenName": "SCIM"
+          },
+          "preferredLanguage": "en",
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:User"
+          ],
+          "userName": "scim-test-action@nango.dev"
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:22:58 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "366",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4979",
+          "x-ratelimit-reset": "1779373384",
+          "etag": "W/\"16e-W7fwXQ5DPZwbvH3tTax0GGwNVFs\""
+        },
+        "hash": "83dd0b0644f91314b863a968996454e7450942ed",
+        "request": {
+          "data": {
+            "schemas": [
+              "urn:ietf:params:scim:schemas:core:2.0:User"
+            ],
+            "userName": "scim-test-action@nango.dev",
+            "name": {
+              "givenName": "SCIM",
+              "familyName": "Test"
+            },
+            "active": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/delete-scim-group.test.json
+++ b/integrations/1password-scim/tests/delete-scim-group.test.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "id": "clikvut2l5pogxy2aqmuetgsoy"
+  },
+  "output": {
+    "id": "clikvut2l5pogxy2aqmuetgsoy",
+    "deleted": true
+  },
+  "nango": {},
+  "api": {
+    "delete": {
+      "/Groups/clikvut2l5pogxy2aqmuetgsoy": {
+        "response": "",
+        "status": 204,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:16:49 GMT",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4984",
+          "x-ratelimit-reset": "1779373033"
+        },
+        "hash": "8732f36690669611c96f5ba07493b9fcd8c620a9",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/delete-scim-user.test.json
+++ b/integrations/1password-scim/tests/delete-scim-user.test.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "id": "TDJZWGRBQRAWTG2APQFSIY5RBY"
+  },
+  "output": {
+    "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+    "deleted": true
+  },
+  "nango": {},
+  "api": {
+    "delete": {
+      "/Users/TDJZWGRBQRAWTG2APQFSIY5RBY": {
+        "response": "",
+        "status": 204,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:25:44 GMT",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4991",
+          "x-ratelimit-reset": "1779373594"
+        },
+        "hash": "62b64ccdc6c6e474644b1c1dd480dd1c2884a4d2",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/get-scim-group.test.json
+++ b/integrations/1password-scim/tests/get-scim-group.test.json
@@ -1,0 +1,58 @@
+{
+  "input": {
+    "groupId": "sitza7mfvjmrgdr6krnetp7g2q"
+  },
+  "output": {
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:Group"
+    ],
+    "id": "sitza7mfvjmrgdr6krnetp7g2q",
+    "displayName": "Test Group Patched",
+    "meta": {
+      "resourceType": "Group",
+      "created": "2026-05-21T14:15:21Z",
+      "lastModified": "2026-05-21T14:23:16Z"
+    }
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/Groups/sitza7mfvjmrgdr6krnetp7g2q": {
+        "response": {
+          "displayName": "Test Group Patched",
+          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "meta": {
+            "created": "2026-05-21T14:15:21Z",
+            "lastModified": "2026-05-21T14:23:16Z",
+            "resourceType": "Group"
+          },
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:Group"
+          ]
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:23:45 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "232",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4980",
+          "x-ratelimit-reset": "1779373452",
+          "etag": "W/\"e8-sCbpq8DnsEXAzU3UgYfcv3yqCoU\""
+        },
+        "hash": "4796620fd8d68c125fef0c70ea499194bf8278f8",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/get-scim-group.test.json
+++ b/integrations/1password-scim/tests/get-scim-group.test.json
@@ -1,29 +1,29 @@
 {
   "input": {
-    "groupId": "sitza7mfvjmrgdr6krnetp7g2q"
+    "id": "27i3xrasou26ukebqazeadyhua"
   },
   "output": {
     "schemas": [
       "urn:ietf:params:scim:schemas:core:2.0:Group"
     ],
-    "id": "sitza7mfvjmrgdr6krnetp7g2q",
-    "displayName": "Test Group Patched",
+    "id": "27i3xrasou26ukebqazeadyhua",
+    "displayName": "Updated Test Group Again",
     "meta": {
       "resourceType": "Group",
-      "created": "2026-05-21T14:15:21Z",
-      "lastModified": "2026-05-21T14:23:16Z"
+      "created": "2026-05-21T14:15:27Z",
+      "lastModified": "2026-05-22T17:55:44Z"
     }
   },
   "nango": {},
   "api": {
     "get": {
-      "/Groups/sitza7mfvjmrgdr6krnetp7g2q": {
+      "/Groups/27i3xrasou26ukebqazeadyhua": {
         "response": {
-          "displayName": "Test Group Patched",
-          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "displayName": "Updated Test Group Again",
+          "id": "27i3xrasou26ukebqazeadyhua",
           "meta": {
-            "created": "2026-05-21T14:15:21Z",
-            "lastModified": "2026-05-21T14:23:16Z",
+            "created": "2026-05-21T14:15:27Z",
+            "lastModified": "2026-05-22T17:55:44Z",
             "resourceType": "Group"
           },
           "schemas": [
@@ -32,9 +32,9 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:23:45 GMT",
+          "date": "Fri, 22 May 2026 17:56:58 GMT",
           "content-type": "application/scim+json",
-          "content-length": "232",
+          "content-length": "238",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -46,11 +46,11 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4980",
-          "x-ratelimit-reset": "1779373452",
-          "etag": "W/\"e8-sCbpq8DnsEXAzU3UgYfcv3yqCoU\""
+          "x-ratelimit-remaining": "4961",
+          "x-ratelimit-reset": "1779472638",
+          "etag": "W/\"ee-phkDgtVuw8Efku0KCW01M9tWLaY\""
         },
-        "hash": "4796620fd8d68c125fef0c70ea499194bf8278f8",
+        "hash": "cff520e4a0550722c4841501ba9b8b5ccffc498e",
         "request": {}
       }
     }

--- a/integrations/1password-scim/tests/get-scim-user.test.json
+++ b/integrations/1password-scim/tests/get-scim-user.test.json
@@ -1,0 +1,82 @@
+{
+  "input": {
+    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A"
+  },
+  "output": {
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+    "meta": {
+      "resourceType": "User"
+    },
+    "userName": "api@nango.dev",
+    "name": {
+      "formatted": "Nango Developer",
+      "familyName": "Developer",
+      "givenName": "Nango"
+    },
+    "displayName": "Nango Developer",
+    "preferredLanguage": "en",
+    "active": true,
+    "emails": [
+      {
+        "value": "api@nango.dev",
+        "primary": true
+      }
+    ]
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/Users/WHIVOG5WFFDGJODAWIGRVZZU5A": {
+        "response": {
+          "active": true,
+          "displayName": "Nango Developer",
+          "emails": [
+            {
+              "primary": true,
+              "value": "api@nango.dev"
+            }
+          ],
+          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "meta": {
+            "resourceType": "User"
+          },
+          "name": {
+            "familyName": "Developer",
+            "formatted": "Nango Developer",
+            "givenName": "Nango"
+          },
+          "preferredLanguage": "en",
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:User"
+          ],
+          "userName": "api@nango.dev"
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:20:17 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "358",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4987",
+          "x-ratelimit-reset": "1779373244",
+          "etag": "W/\"166-t8Fv+wR05PU6dOCa+oZ7zfqzKVQ\""
+        },
+        "hash": "98706753641767c95aea179f3c799518c775206b",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/get-scim-user.test.json
+++ b/integrations/1password-scim/tests/get-scim-user.test.json
@@ -1,64 +1,64 @@
 {
   "input": {
-    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A"
+    "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM"
   },
   "output": {
     "schemas": [
       "urn:ietf:params:scim:schemas:core:2.0:User"
     ],
-    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
-    "meta": {
-      "resourceType": "User"
-    },
-    "userName": "api@nango.dev",
+    "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
+    "userName": "victor@nango.dev",
     "name": {
-      "formatted": "Nango Developer",
-      "familyName": "Developer",
-      "givenName": "Nango"
+      "formatted": "Victor Nango",
+      "familyName": "Nango",
+      "givenName": "Victor"
     },
-    "displayName": "Nango Developer",
+    "displayName": "Victor Nango",
     "preferredLanguage": "en",
     "active": true,
     "emails": [
       {
-        "value": "api@nango.dev",
+        "value": "victor@nango.dev",
         "primary": true
       }
-    ]
+    ],
+    "meta": {
+      "resourceType": "User"
+    }
   },
   "nango": {},
   "api": {
     "get": {
-      "/Users/WHIVOG5WFFDGJODAWIGRVZZU5A": {
+      "/Users/FHNN6ANJUZF3FFXYHEE6EWPHSM": {
         "response": {
           "active": true,
-          "displayName": "Nango Developer",
+          "displayName": "Victor Nango",
           "emails": [
             {
               "primary": true,
-              "value": "api@nango.dev"
+              "value": "victor@nango.dev"
             }
           ],
-          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
           "meta": {
             "resourceType": "User"
           },
           "name": {
-            "familyName": "Developer",
-            "formatted": "Nango Developer",
-            "givenName": "Nango"
+            "familyName": "Nango",
+            "formatted": "Victor Nango",
+            "givenName": "Victor"
           },
           "preferredLanguage": "en",
           "schemas": [
             "urn:ietf:params:scim:schemas:core:2.0:User"
           ],
-          "userName": "api@nango.dev"
+          "userName": "victor@nango.dev"
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:20:17 GMT",
+          "date": "Fri, 22 May 2026 18:03:54 GMT",
           "content-type": "application/scim+json",
-          "content-length": "358",
+          "content-length": "355",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -70,11 +70,11 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4987",
-          "x-ratelimit-reset": "1779373244",
-          "etag": "W/\"166-t8Fv+wR05PU6dOCa+oZ7zfqzKVQ\""
+          "x-ratelimit-remaining": "4992",
+          "x-ratelimit-reset": "1779473081",
+          "etag": "W/\"163-IIDdehP5Zemb1uqZGkkmRgMeEbk\""
         },
-        "hash": "98706753641767c95aea179f3c799518c775206b",
+        "hash": "35953810abf9712711678043713a705f7b1d080c",
         "request": {}
       }
     }

--- a/integrations/1password-scim/tests/get-service-provider-config.test.json
+++ b/integrations/1password-scim/tests/get-service-provider-config.test.json
@@ -1,0 +1,110 @@
+{
+  "input": {},
+  "output": {
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+    ],
+    "meta": {
+      "resourceType": "ServiceProviderConfig",
+      "location": "/scim/v2/ServiceProviderConfig"
+    },
+    "patch": {
+      "supported": true
+    },
+    "bulk": {
+      "supported": false,
+      "maxOperations": 0,
+      "maxPayloadSize": 0
+    },
+    "filter": {
+      "supported": true,
+      "maxResults": 10000
+    },
+    "changePassword": {
+      "supported": false
+    },
+    "sort": {
+      "supported": false
+    },
+    "etag": {
+      "supported": false
+    },
+    "authenticationSchemes": [
+      {
+        "name": "OAuth Bearer Token",
+        "description": "Authentication using the OAuth Bearer Token standard",
+        "specUri": "https://tools.ietf.org/html/rfc6750",
+        "documentationUri": "",
+        "type": "oauthbearertoken"
+      }
+    ]
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/ServiceProviderConfig": {
+        "response": {
+          "authenticationSchemes": [
+            {
+              "description": "Authentication using the OAuth Bearer Token standard",
+              "documentationUri": "",
+              "name": "OAuth Bearer Token",
+              "specUri": "https://tools.ietf.org/html/rfc6750",
+              "type": "oauthbearertoken"
+            }
+          ],
+          "bulk": {
+            "maxOperations": 0,
+            "maxPayloadSize": 0,
+            "supported": false
+          },
+          "changePassword": {
+            "supported": false
+          },
+          "etag": {
+            "supported": false
+          },
+          "filter": {
+            "maxResults": 10000,
+            "supported": true
+          },
+          "meta": {
+            "location": "/scim/v2/ServiceProviderConfig",
+            "resourceType": "ServiceProviderConfig"
+          },
+          "patch": {
+            "supported": true
+          },
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+          ],
+          "sort": {
+            "supported": false
+          }
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:12:24 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "618",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4988",
+          "x-ratelimit-reset": "1779372787",
+          "etag": "W/\"26a-w0+4oAS0AeoXKyujVcfXuuWu7cs\""
+        },
+        "hash": "d767f2df4600c78829583fd233635afb1465cc7b",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/get-service-provider-config.test.json
+++ b/integrations/1password-scim/tests/get-service-provider-config.test.json
@@ -4,10 +4,6 @@
     "schemas": [
       "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
     ],
-    "meta": {
-      "resourceType": "ServiceProviderConfig",
-      "location": "/scim/v2/ServiceProviderConfig"
-    },
     "patch": {
       "supported": true
     },
@@ -37,7 +33,11 @@
         "documentationUri": "",
         "type": "oauthbearertoken"
       }
-    ]
+    ],
+    "meta": {
+      "location": "/scim/v2/ServiceProviderConfig",
+      "resourceType": "ServiceProviderConfig"
+    }
   },
   "nango": {},
   "api": {
@@ -84,7 +84,7 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:12:24 GMT",
+          "date": "Fri, 22 May 2026 17:56:13 GMT",
           "content-type": "application/scim+json",
           "content-length": "618",
           "connection": "keep-alive",
@@ -98,8 +98,8 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4988",
-          "x-ratelimit-reset": "1779372787",
+          "x-ratelimit-remaining": "4964",
+          "x-ratelimit-reset": "1779472577",
           "etag": "W/\"26a-w0+4oAS0AeoXKyujVcfXuuWu7cs\""
         },
         "hash": "d767f2df4600c78829583fd233635afb1465cc7b",

--- a/integrations/1password-scim/tests/list-resource-types.test.json
+++ b/integrations/1password-scim/tests/list-resource-types.test.json
@@ -1,0 +1,108 @@
+{
+  "input": {},
+  "output": {
+    "schemas": [
+      "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+    ],
+    "totalResults": 2,
+    "itemsPerPage": 2,
+    "startIndex": 0,
+    "Resources": [
+      {
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+        ],
+        "id": "User",
+        "name": "User",
+        "description": "User Account",
+        "endpoint": "/scim/v2/User",
+        "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+        "meta": {
+          "resourceType": "ResourceType",
+          "location": "/scim/v2/ResourceTypes/User"
+        }
+      },
+      {
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+        ],
+        "id": "Group",
+        "name": "Group",
+        "description": "Group",
+        "endpoint": "/scim/v2/Groups",
+        "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
+        "meta": {
+          "resourceType": "ResourceType",
+          "location": "/scim/v2/ResourceTypes/Group"
+        }
+      }
+    ]
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/ResourceTypes": {
+        "response": {
+          "Resources": [
+            {
+              "description": "User Account",
+              "endpoint": "/scim/v2/User",
+              "id": "User",
+              "meta": {
+                "location": "/scim/v2/ResourceTypes/User",
+                "resourceType": "ResourceType"
+              },
+              "name": "User",
+              "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+              ]
+            },
+            {
+              "description": "Group",
+              "endpoint": "/scim/v2/Groups",
+              "id": "Group",
+              "meta": {
+                "location": "/scim/v2/ResourceTypes/Group",
+                "resourceType": "ResourceType"
+              },
+              "name": "Group",
+              "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+              ]
+            }
+          ],
+          "itemsPerPage": 2,
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+          ],
+          "startIndex": 0,
+          "totalResults": 2
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:15:39 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "695",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4973",
+          "x-ratelimit-reset": "1779372973",
+          "etag": "W/\"2b7-YzXP206MYfilWmP/lfbCtcU/wKo\""
+        },
+        "hash": "8a3ae5c0014a65e9a1349d4d31b428e726adf132",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/list-resource-types.test.json
+++ b/integrations/1password-scim/tests/list-resource-types.test.json
@@ -5,8 +5,6 @@
       "urn:ietf:params:scim:api:messages:2.0:ListResponse"
     ],
     "totalResults": 2,
-    "itemsPerPage": 2,
-    "startIndex": 0,
     "Resources": [
       {
         "schemas": [
@@ -14,8 +12,8 @@
         ],
         "id": "User",
         "name": "User",
-        "description": "User Account",
         "endpoint": "/scim/v2/User",
+        "description": "User Account",
         "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
         "meta": {
           "resourceType": "ResourceType",
@@ -28,15 +26,17 @@
         ],
         "id": "Group",
         "name": "Group",
-        "description": "Group",
         "endpoint": "/scim/v2/Groups",
+        "description": "Group",
         "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
         "meta": {
           "resourceType": "ResourceType",
           "location": "/scim/v2/ResourceTypes/Group"
         }
       }
-    ]
+    ],
+    "startIndex": 0,
+    "itemsPerPage": 2
   },
   "nango": {},
   "api": {
@@ -82,7 +82,7 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:15:39 GMT",
+          "date": "Fri, 22 May 2026 17:58:26 GMT",
           "content-type": "application/scim+json",
           "content-length": "695",
           "connection": "keep-alive",
@@ -96,8 +96,8 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4973",
-          "x-ratelimit-reset": "1779372973",
+          "x-ratelimit-remaining": "4996",
+          "x-ratelimit-reset": "1779472763",
           "etag": "W/\"2b7-YzXP206MYfilWmP/lfbCtcU/wKo\""
         },
         "hash": "8a3ae5c0014a65e9a1349d4d31b428e726adf132",

--- a/integrations/1password-scim/tests/list-schemas.test.json
+++ b/integrations/1password-scim/tests/list-schemas.test.json
@@ -2,189 +2,168 @@
   "input": {},
   "output": {
     "schemas": [
-      "urn:ietf:params:scim:api:messages:2.0:ListResponse"
-    ],
-    "totalResults": 2,
-    "Resources": [
       {
         "id": "urn:ietf:params:scim:schemas:core:2.0:User",
         "name": "User",
         "description": "User account information",
         "attributes": [
           {
-            "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider.  Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider's entire set of Users.  REQUIRED.",
-            "multiValued": false,
-            "mutability": "readWrite",
             "name": "userName",
-            "required": true,
-            "returned": "always",
             "type": "string",
-            "uniqueness": "server"
+            "multiValued": false,
+            "required": true,
+            "mutability": "readWrite",
+            "returned": "always",
+            "uniqueness": "server",
+            "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider.  Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider's entire set of Users.  REQUIRED."
           },
           {
-            "description": "The components of the user's real name.  Providers MAY return just the full name as a single string in the formatted sub-attribute, or they MAY return just the individual component attributes using the other sub-attributes, or they MAY return both.  If both variants are returned, they SHOULD be describing the same name, with the formatted name indicating how the component attributes should be combined.",
-            "multiValued": false,
-            "mutability": "readWrite",
             "name": "name",
+            "type": "complex",
+            "multiValued": false,
             "required": true,
+            "mutability": "readWrite",
             "returned": "always",
+            "uniqueness": "none",
+            "description": "The components of the user's real name.  Providers MAY return just the full name as a single string in the formatted sub-attribute, or they MAY return just the individual component attributes using the other sub-attributes, or they MAY return both.  If both variants are returned, they SHOULD be describing the same name, with the formatted name indicating how the component attributes should be combined.",
             "subAttributes": [
               {
-                "caseExact": true,
-                "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').",
-                "multiValued": false,
-                "mutability": "readWrite",
                 "name": "givenName",
-                "required": true,
-                "returned": "default",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": true,
+                "mutability": "readWrite",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III')."
               },
               {
-                "caseExact": true,
-                "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the full name 'Ms. Barbara J Jensen, III').",
-                "multiValued": false,
-                "mutability": "readWrite",
                 "name": "familyName",
-                "required": true,
-                "returned": "default",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": true,
+                "mutability": "readWrite",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the full name 'Ms. Barbara J Jensen, III')."
               },
               {
-                "caseExact": true,
-                "description": "The full name, including all middle names, titles, and suffixes as appropriate, formatted for display (e.g., 'Ms. Barbara J Jensen, III').",
-                "multiValued": false,
-                "mutability": "readWrite",
                 "name": "formatted",
-                "required": true,
-                "returned": "default",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": true,
+                "mutability": "readWrite",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "The full name, including all middle names, titles, and suffixes as appropriate, formatted for display (e.g., 'Ms. Barbara J Jensen, III')."
               }
-            ],
-            "type": "complex",
-            "uniqueness": "none"
+            ]
           },
           {
-            "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
-            "multiValued": true,
-            "mutability": "readWrite",
             "name": "emails",
-            "required": false,
-            "returned": "always",
-            "subAttributes": [
-              {
-                "caseExact": false,
-                "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
-                "multiValued": false,
-                "mutability": "readWrite",
-                "name": "primary",
-                "required": true,
-                "returned": "default",
-                "type": "boolean",
-                "uniqueness": "none"
-              },
-              {
-                "caseExact": false,
-                "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
-                "multiValued": false,
-                "mutability": "readWrite",
-                "name": "type",
-                "required": false,
-                "returned": "default",
-                "type": "string",
-                "uniqueness": "none"
-              },
-              {
-                "caseExact": false,
-                "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
-                "multiValued": false,
-                "mutability": "readWrite",
-                "name": "value",
-                "required": true,
-                "returned": "default",
-                "type": "string",
-                "uniqueness": "none"
-              }
-            ],
             "type": "complex",
-            "uniqueness": "none"
-          },
-          {
-            "description": "An identifier for a user defined by the provisioning client",
-            "multiValued": false,
-            "mutability": "readWrite",
-            "name": "externalId",
-            "required": false,
-            "returned": "default",
-            "type": "string",
-            "uniqueness": "none"
-          },
-          {
-            "description": "Indicates the User's preferred written or spoken language.  Generally used for selecting a localized user interface; e.g., 'en_US' specifies the language English and country US.",
-            "multiValued": false,
-            "mutability": "readWrite",
-            "name": "preferredLanguage",
-            "required": false,
-            "returned": "default",
-            "type": "string",
-            "uniqueness": "none"
-          },
-          {
-            "description": "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated.",
             "multiValued": true,
-            "mutability": "readOnly",
-            "name": "groups",
             "required": false,
-            "returned": "default",
+            "mutability": "readWrite",
+            "returned": "always",
+            "uniqueness": "none",
+            "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
             "subAttributes": [
               {
-                "caseExact": false,
-                "description": "The URI of the corresponding 'Group' resource to which the user belongs.",
+                "name": "primary",
+                "type": "boolean",
                 "multiValued": false,
-                "mutability": "readOnly",
-                "name": "$ref",
-                "referenceTypes": [
-                  "User",
-                  "Group"
-                ],
-                "required": false,
+                "required": true,
+                "mutability": "readWrite",
                 "returned": "default",
-                "type": "reference",
-                "uniqueness": "none"
+                "uniqueness": "none",
+                "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once."
               },
               {
-                "caseExact": false,
-                "description": "The identifier of the User's group.",
+                "name": "type",
+                "type": "string",
                 "multiValued": false,
-                "mutability": "readOnly",
+                "required": false,
+                "mutability": "readWrite",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "A label indicating the attribute's function, e.g., 'work' or 'home'."
+              },
+              {
                 "name": "value",
-                "required": false,
-                "returned": "default",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": true,
+                "mutability": "readWrite",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'."
+              }
+            ]
+          },
+          {
+            "name": "externalId",
+            "type": "string",
+            "multiValued": false,
+            "required": false,
+            "mutability": "readWrite",
+            "returned": "default",
+            "uniqueness": "none",
+            "description": "An identifier for a user defined by the provisioning client"
+          },
+          {
+            "name": "preferredLanguage",
+            "type": "string",
+            "multiValued": false,
+            "required": false,
+            "mutability": "readWrite",
+            "returned": "default",
+            "uniqueness": "none",
+            "description": "Indicates the User's preferred written or spoken language.  Generally used for selecting a localized user interface; e.g., 'en_US' specifies the language English and country US."
+          },
+          {
+            "name": "groups",
+            "type": "complex",
+            "multiValued": true,
+            "required": false,
+            "mutability": "readOnly",
+            "returned": "default",
+            "uniqueness": "none",
+            "description": "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated.",
+            "subAttributes": [
+              {
+                "name": "$ref",
+                "type": "reference",
+                "multiValued": false,
+                "required": false,
+                "mutability": "readOnly",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "The URI of the corresponding 'Group' resource to which the user belongs."
               },
               {
-                "caseExact": false,
-                "description": "A human-readable name, primarily used for display purposes.",
-                "multiValued": false,
-                "mutability": "readOnly",
-                "name": "display",
-                "required": false,
-                "returned": "default",
+                "name": "value",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": false,
+                "mutability": "readOnly",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "The identifier of the User's group."
+              },
+              {
+                "name": "display",
+                "type": "string",
+                "multiValued": false,
+                "required": false,
+                "mutability": "readOnly",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "A human-readable name, primarily used for display purposes."
               }
-            ],
-            "type": "complex",
-            "uniqueness": "none"
+            ]
           }
-        ],
-        "meta": {
-          "location": "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
-          "resourceType": "Schema"
-        }
+        ]
       },
       {
         "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
@@ -192,83 +171,68 @@
         "description": "Group information",
         "attributes": [
           {
-            "description": "A human-readable name for the Group. REQUIRED.",
-            "multiValued": false,
-            "mutability": "readWrite",
             "name": "displayName",
-            "required": true,
-            "returned": "default",
             "type": "string",
-            "uniqueness": "none"
+            "multiValued": false,
+            "required": true,
+            "mutability": "readWrite",
+            "returned": "default",
+            "uniqueness": "none",
+            "description": "A human-readable name for the Group. REQUIRED."
           },
           {
-            "description": "A list of members of the Group.",
-            "multiValued": true,
-            "mutability": "readWrite",
             "name": "members",
+            "type": "complex",
+            "multiValued": true,
             "required": false,
+            "mutability": "readWrite",
             "returned": "default",
+            "uniqueness": "none",
+            "description": "A list of members of the Group.",
             "subAttributes": [
               {
-                "caseExact": false,
-                "description": "Identifier of the member of this Group.",
-                "multiValued": false,
-                "mutability": "immutable",
                 "name": "value",
-                "required": false,
-                "returned": "default",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": false,
+                "mutability": "immutable",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "Identifier of the member of this Group."
               },
               {
-                "caseExact": false,
-                "description": "The URI corresponding to a SCIM resource that is a member of this Group.",
-                "multiValued": false,
-                "mutability": "immutable",
                 "name": "$ref",
-                "referenceTypes": [
-                  "User",
-                  "Group"
-                ],
-                "required": false,
-                "returned": "default",
                 "type": "reference",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": false,
+                "mutability": "immutable",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "The URI corresponding to a SCIM resource that is a member of this Group."
               },
               {
-                "canonicalValues": [
-                  "User",
-                  "Group"
-                ],
-                "caseExact": false,
-                "description": "A label indicating the type of resource, e.g., 'User' or 'Group'.",
-                "multiValued": false,
-                "mutability": "immutable",
                 "name": "type",
-                "required": false,
-                "returned": "default",
                 "type": "string",
-                "uniqueness": "none"
+                "multiValued": false,
+                "required": false,
+                "mutability": "immutable",
+                "returned": "default",
+                "uniqueness": "none",
+                "description": "A label indicating the type of resource, e.g., 'User' or 'Group'."
               }
-            ],
-            "type": "complex",
-            "uniqueness": "none"
+            ]
           },
           {
-            "description": "An identifier for a user defined by the provisioning client",
-            "multiValued": false,
-            "mutability": "readWrite",
             "name": "externalId",
-            "required": false,
-            "returned": "default",
             "type": "string",
-            "uniqueness": "none"
+            "multiValued": false,
+            "required": false,
+            "mutability": "readWrite",
+            "returned": "default",
+            "uniqueness": "none",
+            "description": "An identifier for a user defined by the provisioning client"
           }
-        ],
-        "meta": {
-          "location": "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
-          "resourceType": "Schema"
-        }
+        ]
       }
     ]
   },
@@ -552,7 +516,7 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:14:32 GMT",
+          "date": "Fri, 22 May 2026 17:58:12 GMT",
           "content-type": "application/scim+json",
           "transfer-encoding": "chunked",
           "connection": "keep-alive",
@@ -566,8 +530,8 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "1000",
-          "x-ratelimit-remaining": "996",
-          "x-ratelimit-reset": "1779372920",
+          "x-ratelimit-remaining": "989",
+          "x-ratelimit-reset": "1779472718",
           "content-security-policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; img-src 'self' data: https://w3.org; style-src 'self'; frame-ancestors 'none'; form-action 'none'; manifest-src 'self'",
           "referrer-policy": "no-referrer",
           "x-robots-tag": "none"

--- a/integrations/1password-scim/tests/list-schemas.test.json
+++ b/integrations/1password-scim/tests/list-schemas.test.json
@@ -1,0 +1,580 @@
+{
+  "input": {},
+  "output": {
+    "schemas": [
+      "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+    ],
+    "totalResults": 2,
+    "Resources": [
+      {
+        "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+        "name": "User",
+        "description": "User account information",
+        "attributes": [
+          {
+            "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider.  Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider's entire set of Users.  REQUIRED.",
+            "multiValued": false,
+            "mutability": "readWrite",
+            "name": "userName",
+            "required": true,
+            "returned": "always",
+            "type": "string",
+            "uniqueness": "server"
+          },
+          {
+            "description": "The components of the user's real name.  Providers MAY return just the full name as a single string in the formatted sub-attribute, or they MAY return just the individual component attributes using the other sub-attributes, or they MAY return both.  If both variants are returned, they SHOULD be describing the same name, with the formatted name indicating how the component attributes should be combined.",
+            "multiValued": false,
+            "mutability": "readWrite",
+            "name": "name",
+            "required": true,
+            "returned": "always",
+            "subAttributes": [
+              {
+                "caseExact": true,
+                "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').",
+                "multiValued": false,
+                "mutability": "readWrite",
+                "name": "givenName",
+                "required": true,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": true,
+                "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the full name 'Ms. Barbara J Jensen, III').",
+                "multiValued": false,
+                "mutability": "readWrite",
+                "name": "familyName",
+                "required": true,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": true,
+                "description": "The full name, including all middle names, titles, and suffixes as appropriate, formatted for display (e.g., 'Ms. Barbara J Jensen, III').",
+                "multiValued": false,
+                "mutability": "readWrite",
+                "name": "formatted",
+                "required": true,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              }
+            ],
+            "type": "complex",
+            "uniqueness": "none"
+          },
+          {
+            "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
+            "multiValued": true,
+            "mutability": "readWrite",
+            "name": "emails",
+            "required": false,
+            "returned": "always",
+            "subAttributes": [
+              {
+                "caseExact": false,
+                "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
+                "multiValued": false,
+                "mutability": "readWrite",
+                "name": "primary",
+                "required": true,
+                "returned": "default",
+                "type": "boolean",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": false,
+                "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
+                "multiValued": false,
+                "mutability": "readWrite",
+                "name": "type",
+                "required": false,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": false,
+                "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
+                "multiValued": false,
+                "mutability": "readWrite",
+                "name": "value",
+                "required": true,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              }
+            ],
+            "type": "complex",
+            "uniqueness": "none"
+          },
+          {
+            "description": "An identifier for a user defined by the provisioning client",
+            "multiValued": false,
+            "mutability": "readWrite",
+            "name": "externalId",
+            "required": false,
+            "returned": "default",
+            "type": "string",
+            "uniqueness": "none"
+          },
+          {
+            "description": "Indicates the User's preferred written or spoken language.  Generally used for selecting a localized user interface; e.g., 'en_US' specifies the language English and country US.",
+            "multiValued": false,
+            "mutability": "readWrite",
+            "name": "preferredLanguage",
+            "required": false,
+            "returned": "default",
+            "type": "string",
+            "uniqueness": "none"
+          },
+          {
+            "description": "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated.",
+            "multiValued": true,
+            "mutability": "readOnly",
+            "name": "groups",
+            "required": false,
+            "returned": "default",
+            "subAttributes": [
+              {
+                "caseExact": false,
+                "description": "The URI of the corresponding 'Group' resource to which the user belongs.",
+                "multiValued": false,
+                "mutability": "readOnly",
+                "name": "$ref",
+                "referenceTypes": [
+                  "User",
+                  "Group"
+                ],
+                "required": false,
+                "returned": "default",
+                "type": "reference",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": false,
+                "description": "The identifier of the User's group.",
+                "multiValued": false,
+                "mutability": "readOnly",
+                "name": "value",
+                "required": false,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": false,
+                "description": "A human-readable name, primarily used for display purposes.",
+                "multiValued": false,
+                "mutability": "readOnly",
+                "name": "display",
+                "required": false,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              }
+            ],
+            "type": "complex",
+            "uniqueness": "none"
+          }
+        ],
+        "meta": {
+          "location": "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+          "resourceType": "Schema"
+        }
+      },
+      {
+        "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
+        "name": "Group",
+        "description": "Group information",
+        "attributes": [
+          {
+            "description": "A human-readable name for the Group. REQUIRED.",
+            "multiValued": false,
+            "mutability": "readWrite",
+            "name": "displayName",
+            "required": true,
+            "returned": "default",
+            "type": "string",
+            "uniqueness": "none"
+          },
+          {
+            "description": "A list of members of the Group.",
+            "multiValued": true,
+            "mutability": "readWrite",
+            "name": "members",
+            "required": false,
+            "returned": "default",
+            "subAttributes": [
+              {
+                "caseExact": false,
+                "description": "Identifier of the member of this Group.",
+                "multiValued": false,
+                "mutability": "immutable",
+                "name": "value",
+                "required": false,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              },
+              {
+                "caseExact": false,
+                "description": "The URI corresponding to a SCIM resource that is a member of this Group.",
+                "multiValued": false,
+                "mutability": "immutable",
+                "name": "$ref",
+                "referenceTypes": [
+                  "User",
+                  "Group"
+                ],
+                "required": false,
+                "returned": "default",
+                "type": "reference",
+                "uniqueness": "none"
+              },
+              {
+                "canonicalValues": [
+                  "User",
+                  "Group"
+                ],
+                "caseExact": false,
+                "description": "A label indicating the type of resource, e.g., 'User' or 'Group'.",
+                "multiValued": false,
+                "mutability": "immutable",
+                "name": "type",
+                "required": false,
+                "returned": "default",
+                "type": "string",
+                "uniqueness": "none"
+              }
+            ],
+            "type": "complex",
+            "uniqueness": "none"
+          },
+          {
+            "description": "An identifier for a user defined by the provisioning client",
+            "multiValued": false,
+            "mutability": "readWrite",
+            "name": "externalId",
+            "required": false,
+            "returned": "default",
+            "type": "string",
+            "uniqueness": "none"
+          }
+        ],
+        "meta": {
+          "location": "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+          "resourceType": "Schema"
+        }
+      }
+    ]
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/Schemas": {
+        "response": {
+          "Resources": [
+            {
+              "attributes": [
+                {
+                  "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider.  Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider's entire set of Users.  REQUIRED.",
+                  "multiValued": false,
+                  "mutability": "readWrite",
+                  "name": "userName",
+                  "required": true,
+                  "returned": "always",
+                  "type": "string",
+                  "uniqueness": "server"
+                },
+                {
+                  "description": "The components of the user's real name.  Providers MAY return just the full name as a single string in the formatted sub-attribute, or they MAY return just the individual component attributes using the other sub-attributes, or they MAY return both.  If both variants are returned, they SHOULD be describing the same name, with the formatted name indicating how the component attributes should be combined.",
+                  "multiValued": false,
+                  "mutability": "readWrite",
+                  "name": "name",
+                  "required": true,
+                  "returned": "always",
+                  "subAttributes": [
+                    {
+                      "caseExact": true,
+                      "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').",
+                      "multiValued": false,
+                      "mutability": "readWrite",
+                      "name": "givenName",
+                      "required": true,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": true,
+                      "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the full name 'Ms. Barbara J Jensen, III').",
+                      "multiValued": false,
+                      "mutability": "readWrite",
+                      "name": "familyName",
+                      "required": true,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": true,
+                      "description": "The full name, including all middle names, titles, and suffixes as appropriate, formatted for display (e.g., 'Ms. Barbara J Jensen, III').",
+                      "multiValued": false,
+                      "mutability": "readWrite",
+                      "name": "formatted",
+                      "required": true,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    }
+                  ],
+                  "type": "complex",
+                  "uniqueness": "none"
+                },
+                {
+                  "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
+                  "multiValued": true,
+                  "mutability": "readWrite",
+                  "name": "emails",
+                  "required": false,
+                  "returned": "always",
+                  "subAttributes": [
+                    {
+                      "caseExact": false,
+                      "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
+                      "multiValued": false,
+                      "mutability": "readWrite",
+                      "name": "primary",
+                      "required": true,
+                      "returned": "default",
+                      "type": "boolean",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": false,
+                      "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
+                      "multiValued": false,
+                      "mutability": "readWrite",
+                      "name": "type",
+                      "required": false,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": false,
+                      "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.  Canonical type values of 'work', 'home', and 'other'.",
+                      "multiValued": false,
+                      "mutability": "readWrite",
+                      "name": "value",
+                      "required": true,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    }
+                  ],
+                  "type": "complex",
+                  "uniqueness": "none"
+                },
+                {
+                  "description": "An identifier for a user defined by the provisioning client",
+                  "multiValued": false,
+                  "mutability": "readWrite",
+                  "name": "externalId",
+                  "required": false,
+                  "returned": "default",
+                  "type": "string",
+                  "uniqueness": "none"
+                },
+                {
+                  "description": "Indicates the User's preferred written or spoken language.  Generally used for selecting a localized user interface; e.g., 'en_US' specifies the language English and country US.",
+                  "multiValued": false,
+                  "mutability": "readWrite",
+                  "name": "preferredLanguage",
+                  "required": false,
+                  "returned": "default",
+                  "type": "string",
+                  "uniqueness": "none"
+                },
+                {
+                  "description": "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated.",
+                  "multiValued": true,
+                  "mutability": "readOnly",
+                  "name": "groups",
+                  "required": false,
+                  "returned": "default",
+                  "subAttributes": [
+                    {
+                      "caseExact": false,
+                      "description": "The URI of the corresponding 'Group' resource to which the user belongs.",
+                      "multiValued": false,
+                      "mutability": "readOnly",
+                      "name": "$ref",
+                      "referenceTypes": [
+                        "User",
+                        "Group"
+                      ],
+                      "required": false,
+                      "returned": "default",
+                      "type": "reference",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": false,
+                      "description": "The identifier of the User's group.",
+                      "multiValued": false,
+                      "mutability": "readOnly",
+                      "name": "value",
+                      "required": false,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": false,
+                      "description": "A human-readable name, primarily used for display purposes.",
+                      "multiValued": false,
+                      "mutability": "readOnly",
+                      "name": "display",
+                      "required": false,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    }
+                  ],
+                  "type": "complex",
+                  "uniqueness": "none"
+                }
+              ],
+              "description": "User account information",
+              "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+              "meta": {
+                "location": "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+                "resourceType": "Schema"
+              },
+              "name": "User"
+            },
+            {
+              "attributes": [
+                {
+                  "description": "A human-readable name for the Group. REQUIRED.",
+                  "multiValued": false,
+                  "mutability": "readWrite",
+                  "name": "displayName",
+                  "required": true,
+                  "returned": "default",
+                  "type": "string",
+                  "uniqueness": "none"
+                },
+                {
+                  "description": "A list of members of the Group.",
+                  "multiValued": true,
+                  "mutability": "readWrite",
+                  "name": "members",
+                  "required": false,
+                  "returned": "default",
+                  "subAttributes": [
+                    {
+                      "caseExact": false,
+                      "description": "Identifier of the member of this Group.",
+                      "multiValued": false,
+                      "mutability": "immutable",
+                      "name": "value",
+                      "required": false,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "caseExact": false,
+                      "description": "The URI corresponding to a SCIM resource that is a member of this Group.",
+                      "multiValued": false,
+                      "mutability": "immutable",
+                      "name": "$ref",
+                      "referenceTypes": [
+                        "User",
+                        "Group"
+                      ],
+                      "required": false,
+                      "returned": "default",
+                      "type": "reference",
+                      "uniqueness": "none"
+                    },
+                    {
+                      "canonicalValues": [
+                        "User",
+                        "Group"
+                      ],
+                      "caseExact": false,
+                      "description": "A label indicating the type of resource, e.g., 'User' or 'Group'.",
+                      "multiValued": false,
+                      "mutability": "immutable",
+                      "name": "type",
+                      "required": false,
+                      "returned": "default",
+                      "type": "string",
+                      "uniqueness": "none"
+                    }
+                  ],
+                  "type": "complex",
+                  "uniqueness": "none"
+                },
+                {
+                  "description": "An identifier for a user defined by the provisioning client",
+                  "multiValued": false,
+                  "mutability": "readWrite",
+                  "name": "externalId",
+                  "required": false,
+                  "returned": "default",
+                  "type": "string",
+                  "uniqueness": "none"
+                }
+              ],
+              "description": "Group information",
+              "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
+              "meta": {
+                "location": "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+                "resourceType": "Schema"
+              },
+              "name": "Group"
+            }
+          ],
+          "itemsPerPage": 2,
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+          ],
+          "startIndex": 0,
+          "totalResults": 2
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:14:32 GMT",
+          "content-type": "application/scim+json",
+          "transfer-encoding": "chunked",
+          "connection": "keep-alive",
+          "x-xss-protection": "1; mode=block",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "DENY",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "1000",
+          "x-ratelimit-remaining": "996",
+          "x-ratelimit-reset": "1779372920",
+          "content-security-policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; img-src 'self' data: https://w3.org; style-src 'self'; frame-ancestors 'none'; form-action 'none'; manifest-src 'self'",
+          "referrer-policy": "no-referrer",
+          "x-robots-tag": "none"
+        },
+        "hash": "9420ae12c521f15a267584ea19031a70e3dbbe2a",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/list-scim-groups.test.json
+++ b/integrations/1password-scim/tests/list-scim-groups.test.json
@@ -1,0 +1,49 @@
+{
+  "input": {},
+  "output": {
+    "groups": []
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/Groups": {
+        "response": {
+          "Resources": [],
+          "itemsPerPage": 0,
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+          ],
+          "startIndex": 1,
+          "totalResults": 0
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:14:36 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "131",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4958",
+          "x-ratelimit-reset": "1779372909",
+          "etag": "W/\"83-YD0A9a7pFMa8PajsxmQickyAnqI\""
+        },
+        "hash": "72f429f5c708396297b485e5d184a3746b0a31f4",
+        "request": {
+          "params": {
+            "count": "100",
+            "startIndex": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/list-scim-groups.test.json
+++ b/integrations/1password-scim/tests/list-scim-groups.test.json
@@ -1,26 +1,100 @@
 {
   "input": {},
   "output": {
-    "groups": []
+    "items": [
+      {
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:Group"
+        ],
+        "id": "sitza7mfvjmrgdr6krnetp7g2q",
+        "meta": {
+          "resourceType": "Group",
+          "created": "2026-05-21T14:15:21Z",
+          "lastModified": "2026-05-21T14:23:16Z"
+        },
+        "displayName": "Test Group Patched"
+      },
+      {
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:Group"
+        ],
+        "id": "27i3xrasou26ukebqazeadyhua",
+        "meta": {
+          "resourceType": "Group",
+          "created": "2026-05-21T14:15:27Z",
+          "lastModified": "2026-05-22T17:57:03Z"
+        },
+        "displayName": "Updated Test Group Nango"
+      },
+      {
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:Group"
+        ],
+        "id": "va2pjrrhr7ykpdxkscbql6ipue",
+        "meta": {
+          "resourceType": "Group",
+          "created": "2026-05-22T17:57:33Z",
+          "lastModified": "2026-05-22T17:57:33Z"
+        },
+        "displayName": "Nango Test Group 2026-05-22-001"
+      }
+    ]
   },
   "nango": {},
   "api": {
     "get": {
       "/Groups": {
         "response": {
-          "Resources": [],
-          "itemsPerPage": 0,
+          "Resources": [
+            {
+              "displayName": "Test Group Patched",
+              "id": "sitza7mfvjmrgdr6krnetp7g2q",
+              "meta": {
+                "created": "2026-05-21T14:15:21Z",
+                "lastModified": "2026-05-21T14:23:16Z",
+                "resourceType": "Group"
+              },
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:Group"
+              ]
+            },
+            {
+              "displayName": "Updated Test Group Nango",
+              "id": "27i3xrasou26ukebqazeadyhua",
+              "meta": {
+                "created": "2026-05-21T14:15:27Z",
+                "lastModified": "2026-05-22T17:57:03Z",
+                "resourceType": "Group"
+              },
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:Group"
+              ]
+            },
+            {
+              "displayName": "Nango Test Group 2026-05-22-001",
+              "id": "va2pjrrhr7ykpdxkscbql6ipue",
+              "meta": {
+                "created": "2026-05-22T17:57:33Z",
+                "lastModified": "2026-05-22T17:57:33Z",
+                "resourceType": "Group"
+              },
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:Group"
+              ]
+            }
+          ],
+          "itemsPerPage": 3,
           "schemas": [
             "urn:ietf:params:scim:api:messages:2.0:ListResponse"
           ],
           "startIndex": 1,
-          "totalResults": 0
+          "totalResults": 3
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:14:36 GMT",
+          "date": "Fri, 22 May 2026 17:58:47 GMT",
           "content-type": "application/scim+json",
-          "content-length": "131",
+          "content-length": "845",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -32,9 +106,9 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4958",
-          "x-ratelimit-reset": "1779372909",
-          "etag": "W/\"83-YD0A9a7pFMa8PajsxmQickyAnqI\""
+          "x-ratelimit-remaining": "4983",
+          "x-ratelimit-reset": "1779472763",
+          "etag": "W/\"34d-tl3vTtVJVFbVxXL4ATKKE9j/WY8\""
         },
         "hash": "72f429f5c708396297b485e5d184a3746b0a31f4",
         "request": {

--- a/integrations/1password-scim/tests/list-scim-users.test.json
+++ b/integrations/1password-scim/tests/list-scim-users.test.json
@@ -1,0 +1,187 @@
+{
+  "input": {},
+  "output": {
+    "users": [
+      {
+        "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+        "userName": "api@nango.dev",
+        "name": {
+          "familyName": "Developer",
+          "givenName": "Nango",
+          "formatted": "Nango Developer"
+        },
+        "emails": [
+          {
+            "value": "api@nango.dev",
+            "primary": true
+          }
+        ],
+        "active": true,
+        "meta": {
+          "resourceType": "User"
+        },
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      },
+      {
+        "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
+        "userName": "victor@nango.dev",
+        "name": {
+          "familyName": "Nango",
+          "givenName": "Victor",
+          "formatted": "Victor Nango"
+        },
+        "emails": [
+          {
+            "value": "victor@nango.dev",
+            "primary": true
+          }
+        ],
+        "active": true,
+        "meta": {
+          "resourceType": "User"
+        },
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      },
+      {
+        "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+        "userName": "test@nango.dev",
+        "name": {
+          "familyName": "User",
+          "givenName": "Test",
+          "formatted": "Test User"
+        },
+        "emails": [
+          {
+            "value": "test@nango.dev",
+            "primary": true
+          }
+        ],
+        "active": true,
+        "meta": {
+          "resourceType": "User"
+        },
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      }
+    ],
+    "total_results": 3,
+    "start_index": 1,
+    "items_per_page": 3
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/Users": {
+        "response": {
+          "Resources": [
+            {
+              "active": true,
+              "displayName": "Nango Developer",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "api@nango.dev"
+                }
+              ],
+              "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Developer",
+                "formatted": "Nango Developer",
+                "givenName": "Nango"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "api@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Victor Nango",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "victor@nango.dev"
+                }
+              ],
+              "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Nango",
+                "formatted": "Victor Nango",
+                "givenName": "Victor"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "victor@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Test User",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "test@nango.dev"
+                }
+              ],
+              "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "User",
+                "formatted": "Test User",
+                "givenName": "Test"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "test@nango.dev"
+            }
+          ],
+          "itemsPerPage": 3,
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+          ],
+          "startIndex": 1,
+          "totalResults": 3
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:17:10 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "1185",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4976",
+          "x-ratelimit-reset": "1779373033",
+          "etag": "W/\"4a1-4Jad/XhPgMh4vVQo+WGwGClgtn0\""
+        },
+        "hash": "730c01474338adf0f662fcb41508849916799ae7",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/list-scim-users.test.json
+++ b/integrations/1password-scim/tests/list-scim-users.test.json
@@ -1,25 +1,123 @@
 {
   "input": {},
   "output": {
-    "users": [
+    "items": [
+      {
+        "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+        "userName": "test@nango.dev",
+        "name": {
+          "formatted": "Test User",
+          "familyName": "User",
+          "givenName": "Test"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "emails": [
+          {
+            "value": "test@nango.dev",
+            "primary": true
+          }
+        ],
+        "meta": {
+          "resourceType": "User"
+        },
+        "preferredLanguage": "en",
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      },
+      {
+        "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+        "userName": "scim-test-action@nango.dev",
+        "name": {
+          "formatted": "SCIM Test Updated",
+          "familyName": "Test Updated",
+          "givenName": "SCIM"
+        },
+        "displayName": "SCIM Test Updated",
+        "active": true,
+        "emails": [
+          {
+            "value": "scim-test-action@nango.dev",
+            "primary": true
+          }
+        ],
+        "meta": {
+          "resourceType": "User"
+        },
+        "preferredLanguage": "en",
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      },
+      {
+        "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
+        "userName": "tmp-delete-test@nango.dev",
+        "name": {
+          "formatted": "Tmp Delete Test",
+          "familyName": "Delete Test",
+          "givenName": "Tmp"
+        },
+        "displayName": "Tmp Delete Test",
+        "active": false,
+        "emails": [
+          {
+            "value": "tmp-delete-test@nango.dev",
+            "primary": true
+          }
+        ],
+        "meta": {
+          "resourceType": "User"
+        },
+        "preferredLanguage": "en",
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      },
+      {
+        "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+        "userName": "tmp-delete-test-2@nango.dev",
+        "name": {
+          "formatted": "Tmp Delete Test 2",
+          "familyName": "Test 2",
+          "givenName": "Tmp Delete"
+        },
+        "displayName": "Tmp Delete Test 2",
+        "active": false,
+        "emails": [
+          {
+            "value": "tmp-delete-test-2@nango.dev",
+            "primary": true
+          }
+        ],
+        "meta": {
+          "resourceType": "User"
+        },
+        "preferredLanguage": "en",
+        "schemas": [
+          "urn:ietf:params:scim:schemas:core:2.0:User"
+        ]
+      },
       {
         "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
         "userName": "api@nango.dev",
         "name": {
+          "formatted": "Nango Developer",
           "familyName": "Developer",
-          "givenName": "Nango",
-          "formatted": "Nango Developer"
+          "givenName": "Nango"
         },
+        "displayName": "Nango Developer",
+        "active": true,
         "emails": [
           {
             "value": "api@nango.dev",
             "primary": true
           }
         ],
-        "active": true,
         "meta": {
           "resourceType": "User"
         },
+        "preferredLanguage": "en",
         "schemas": [
           "urn:ietf:params:scim:schemas:core:2.0:User"
         ]
@@ -28,50 +126,28 @@
         "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
         "userName": "victor@nango.dev",
         "name": {
+          "formatted": "Victor Nango",
           "familyName": "Nango",
-          "givenName": "Victor",
-          "formatted": "Victor Nango"
+          "givenName": "Victor"
         },
+        "displayName": "Victor Nango",
+        "active": true,
         "emails": [
           {
             "value": "victor@nango.dev",
             "primary": true
           }
         ],
-        "active": true,
         "meta": {
           "resourceType": "User"
         },
-        "schemas": [
-          "urn:ietf:params:scim:schemas:core:2.0:User"
-        ]
-      },
-      {
-        "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
-        "userName": "test@nango.dev",
-        "name": {
-          "familyName": "User",
-          "givenName": "Test",
-          "formatted": "Test User"
-        },
-        "emails": [
-          {
-            "value": "test@nango.dev",
-            "primary": true
-          }
-        ],
-        "active": true,
-        "meta": {
-          "resourceType": "User"
-        },
+        "preferredLanguage": "en",
         "schemas": [
           "urn:ietf:params:scim:schemas:core:2.0:User"
         ]
       }
     ],
-    "total_results": 3,
-    "start_index": 1,
-    "items_per_page": 3
+    "totalResults": 6
   },
   "nango": {},
   "api": {
@@ -79,6 +155,102 @@
       "/Users": {
         "response": {
           "Resources": [
+            {
+              "active": true,
+              "displayName": "Test User",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "test@nango.dev"
+                }
+              ],
+              "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "User",
+                "formatted": "Test User",
+                "givenName": "Test"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "test@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "SCIM Test Updated",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "scim-test-action@nango.dev"
+                }
+              ],
+              "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test Updated",
+                "formatted": "SCIM Test Updated",
+                "givenName": "SCIM"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "scim-test-action@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Tmp Delete Test",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "tmp-delete-test@nango.dev"
+                }
+              ],
+              "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Delete Test",
+                "formatted": "Tmp Delete Test",
+                "givenName": "Tmp"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "tmp-delete-test@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Tmp Delete Test 2",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "tmp-delete-test-2@nango.dev"
+                }
+              ],
+              "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test 2",
+                "formatted": "Tmp Delete Test 2",
+                "givenName": "Tmp Delete"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "tmp-delete-test-2@nango.dev"
+            },
             {
               "active": true,
               "displayName": "Nango Developer",
@@ -126,61 +298,43 @@
                 "urn:ietf:params:scim:schemas:core:2.0:User"
               ],
               "userName": "victor@nango.dev"
-            },
-            {
-              "active": true,
-              "displayName": "Test User",
-              "emails": [
-                {
-                  "primary": true,
-                  "value": "test@nango.dev"
-                }
-              ],
-              "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
-              "meta": {
-                "resourceType": "User"
-              },
-              "name": {
-                "familyName": "User",
-                "formatted": "Test User",
-                "givenName": "Test"
-              },
-              "preferredLanguage": "en",
-              "schemas": [
-                "urn:ietf:params:scim:schemas:core:2.0:User"
-              ],
-              "userName": "test@nango.dev"
             }
           ],
-          "itemsPerPage": 3,
+          "itemsPerPage": 6,
           "schemas": [
             "urn:ietf:params:scim:api:messages:2.0:ListResponse"
           ],
           "startIndex": 1,
-          "totalResults": 3
+          "totalResults": 6
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:17:10 GMT",
+          "date": "Fri, 22 May 2026 17:57:39 GMT",
           "content-type": "application/scim+json",
-          "content-length": "1185",
+          "transfer-encoding": "chunked",
           "connection": "keep-alive",
-          "x-xss-protection": "0",
+          "x-xss-protection": "1; mode=block",
           "x-content-type-options": "nosniff",
           "x-download-options": "noopen",
-          "x-frame-options": "SAMEORIGIN",
+          "x-frame-options": "DENY",
           "x-dns-prefetch-control": "off",
           "strict-transport-security": "max-age=5184000; includeSubDomains",
           "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
-          "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4976",
-          "x-ratelimit-reset": "1779373033",
-          "etag": "W/\"4a1-4Jad/XhPgMh4vVQo+WGwGClgtn0\""
+          "x-ratelimit-limit": "1000",
+          "x-ratelimit-remaining": "998",
+          "x-ratelimit-reset": "1779472718",
+          "content-security-policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; img-src 'self' data: https://w3.org; style-src 'self'; frame-ancestors 'none'; form-action 'none'; manifest-src 'self'",
+          "referrer-policy": "no-referrer",
+          "x-robots-tag": "none"
         },
-        "hash": "730c01474338adf0f662fcb41508849916799ae7",
-        "request": {}
+        "hash": "076b65d8e1976e7ca542e22406bf03e922ac6d7f",
+        "request": {
+          "params": {
+            "startIndex": "1"
+          }
+        }
       }
     }
   }

--- a/integrations/1password-scim/tests/patch-scim-group.test.json
+++ b/integrations/1password-scim/tests/patch-scim-group.test.json
@@ -1,36 +1,33 @@
 {
   "input": {
-    "group_id": "sitza7mfvjmrgdr6krnetp7g2q",
+    "id": "va2pjrrhr7ykpdxkscbql6ipue",
     "operations": [
       {
         "op": "replace",
         "path": "displayName",
-        "value": "Test Group Patched"
+        "value": "Nango Test Group Updated"
       }
     ]
   },
   "output": {
-    "schemas": [
-      "urn:ietf:params:scim:schemas:core:2.0:Group"
-    ],
-    "id": "sitza7mfvjmrgdr6krnetp7g2q",
-    "displayName": "Test Group Patched",
+    "id": "va2pjrrhr7ykpdxkscbql6ipue",
+    "displayName": "Nango Test Group Updated",
     "meta": {
       "resourceType": "Group",
-      "created": "2026-05-21T14:15:21Z",
-      "lastModified": "2026-05-21T14:23:16Z"
+      "created": "2026-05-22T17:57:33Z",
+      "lastModified": "2026-05-22T18:01:09Z"
     }
   },
   "nango": {},
   "api": {
     "patch": {
-      "/Groups/sitza7mfvjmrgdr6krnetp7g2q": {
+      "/Groups/va2pjrrhr7ykpdxkscbql6ipue": {
         "response": {
-          "displayName": "Test Group Patched",
-          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "displayName": "Nango Test Group Updated",
+          "id": "va2pjrrhr7ykpdxkscbql6ipue",
           "meta": {
-            "created": "2026-05-21T14:15:21Z",
-            "lastModified": "2026-05-21T14:23:16Z",
+            "created": "2026-05-22T17:57:33Z",
+            "lastModified": "2026-05-22T18:01:09Z",
             "resourceType": "Group"
           },
           "schemas": [
@@ -39,9 +36,9 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:23:27 GMT",
+          "date": "Fri, 22 May 2026 18:01:23 GMT",
           "content-type": "application/scim+json",
-          "content-length": "232",
+          "content-length": "238",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -53,11 +50,11 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4984",
-          "x-ratelimit-reset": "1779373452",
-          "etag": "W/\"e8-sCbpq8DnsEXAzU3UgYfcv3yqCoU\""
+          "x-ratelimit-remaining": "4969",
+          "x-ratelimit-reset": "1779472886",
+          "etag": "W/\"ee-lSQW4eUFfLuQgIIZCAMhDHZF7mo\""
         },
-        "hash": "233cc7503db1cb5dfa78f645ff512646a0444b9d",
+        "hash": "7b0196cc92eabd472b0a2d4b0036482f93d560eb",
         "request": {
           "data": {
             "schemas": [
@@ -67,7 +64,7 @@
               {
                 "op": "replace",
                 "path": "displayName",
-                "value": "Test Group Patched"
+                "value": "Nango Test Group Updated"
               }
             ]
           }

--- a/integrations/1password-scim/tests/patch-scim-group.test.json
+++ b/integrations/1password-scim/tests/patch-scim-group.test.json
@@ -1,0 +1,78 @@
+{
+  "input": {
+    "group_id": "sitza7mfvjmrgdr6krnetp7g2q",
+    "operations": [
+      {
+        "op": "replace",
+        "path": "displayName",
+        "value": "Test Group Patched"
+      }
+    ]
+  },
+  "output": {
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:Group"
+    ],
+    "id": "sitza7mfvjmrgdr6krnetp7g2q",
+    "displayName": "Test Group Patched",
+    "meta": {
+      "resourceType": "Group",
+      "created": "2026-05-21T14:15:21Z",
+      "lastModified": "2026-05-21T14:23:16Z"
+    }
+  },
+  "nango": {},
+  "api": {
+    "patch": {
+      "/Groups/sitza7mfvjmrgdr6krnetp7g2q": {
+        "response": {
+          "displayName": "Test Group Patched",
+          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "meta": {
+            "created": "2026-05-21T14:15:21Z",
+            "lastModified": "2026-05-21T14:23:16Z",
+            "resourceType": "Group"
+          },
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:Group"
+          ]
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:23:27 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "232",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4984",
+          "x-ratelimit-reset": "1779373452",
+          "etag": "W/\"e8-sCbpq8DnsEXAzU3UgYfcv3yqCoU\""
+        },
+        "hash": "233cc7503db1cb5dfa78f645ff512646a0444b9d",
+        "request": {
+          "data": {
+            "schemas": [
+              "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+            ],
+            "Operations": [
+              {
+                "op": "replace",
+                "path": "displayName",
+                "value": "Test Group Patched"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/patch-scim-user.test.json
+++ b/integrations/1password-scim/tests/patch-scim-user.test.json
@@ -1,0 +1,98 @@
+{
+  "input": {
+    "userId": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+    "operations": [
+      {
+        "op": "replace",
+        "path": "displayName",
+        "value": "Nango Developer Test"
+      }
+    ]
+  },
+  "output": {
+    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+    "userName": "api@nango.dev",
+    "displayName": "Nango Developer Test",
+    "active": true,
+    "name": {
+      "formatted": "Nango Developer Test",
+      "familyName": "Developer Test",
+      "givenName": "Nango"
+    },
+    "emails": [
+      {
+        "value": "api@nango.dev",
+        "primary": true
+      }
+    ],
+    "meta": {
+      "resourceType": "User"
+    }
+  },
+  "nango": {},
+  "api": {
+    "patch": {
+      "/Users/WHIVOG5WFFDGJODAWIGRVZZU5A": {
+        "response": {
+          "active": true,
+          "displayName": "Nango Developer Test",
+          "emails": [
+            {
+              "primary": true,
+              "value": "api@nango.dev"
+            }
+          ],
+          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "meta": {
+            "resourceType": "User"
+          },
+          "name": {
+            "familyName": "Developer Test",
+            "formatted": "Nango Developer Test",
+            "givenName": "Nango"
+          },
+          "preferredLanguage": "en",
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:User"
+          ],
+          "userName": "api@nango.dev"
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:14:34 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "373",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4963",
+          "x-ratelimit-reset": "1779372909",
+          "etag": "W/\"175-ujiyI6OGOnXrlsZyTtUpGoyTz3A\""
+        },
+        "hash": "f84b3c402b0c2bf6e173e5bb3757ef13979101fe",
+        "request": {
+          "data": {
+            "schemas": [
+              "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+            ],
+            "Operations": [
+              {
+                "op": "replace",
+                "path": "displayName",
+                "value": "Nango Developer Test"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/patch-scim-user.test.json
+++ b/integrations/1password-scim/tests/patch-scim-user.test.json
@@ -1,27 +1,31 @@
 {
   "input": {
-    "userId": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+    "userId": "NFAPLXW3PFA6NJKAV7IAD63BQI",
     "operations": [
       {
         "op": "replace",
         "path": "displayName",
-        "value": "Nango Developer Test"
+        "value": "Patched Delete Test"
       }
     ]
   },
   "output": {
-    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
-    "userName": "api@nango.dev",
-    "displayName": "Nango Developer Test",
-    "active": true,
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "id": "NFAPLXW3PFA6NJKAV7IAD63BQI",
+    "userName": "delete-test-1@nango.dev",
+    "active": false,
+    "displayName": "Patched Delete Test",
+    "preferredLanguage": "en",
     "name": {
-      "formatted": "Nango Developer Test",
-      "familyName": "Developer Test",
-      "givenName": "Nango"
+      "formatted": "Patched Delete Test",
+      "familyName": "Delete Test",
+      "givenName": "Patched"
     },
     "emails": [
       {
-        "value": "api@nango.dev",
+        "value": "delete-test-1@nango.dev",
         "primary": true
       }
     ],
@@ -32,36 +36,36 @@
   "nango": {},
   "api": {
     "patch": {
-      "/Users/WHIVOG5WFFDGJODAWIGRVZZU5A": {
+      "/Users/NFAPLXW3PFA6NJKAV7IAD63BQI": {
         "response": {
-          "active": true,
-          "displayName": "Nango Developer Test",
+          "active": false,
+          "displayName": "Patched Delete Test",
           "emails": [
             {
               "primary": true,
-              "value": "api@nango.dev"
+              "value": "delete-test-1@nango.dev"
             }
           ],
-          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "id": "NFAPLXW3PFA6NJKAV7IAD63BQI",
           "meta": {
             "resourceType": "User"
           },
           "name": {
-            "familyName": "Developer Test",
-            "formatted": "Nango Developer Test",
-            "givenName": "Nango"
+            "familyName": "Delete Test",
+            "formatted": "Patched Delete Test",
+            "givenName": "Patched"
           },
           "preferredLanguage": "en",
           "schemas": [
             "urn:ietf:params:scim:schemas:core:2.0:User"
           ],
-          "userName": "api@nango.dev"
+          "userName": "delete-test-1@nango.dev"
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:14:34 GMT",
+          "date": "Fri, 22 May 2026 18:02:52 GMT",
           "content-type": "application/scim+json",
-          "content-length": "373",
+          "content-length": "391",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -73,11 +77,11 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4963",
-          "x-ratelimit-reset": "1779372909",
-          "etag": "W/\"175-ujiyI6OGOnXrlsZyTtUpGoyTz3A\""
+          "x-ratelimit-remaining": "4988",
+          "x-ratelimit-reset": "1779473020",
+          "etag": "W/\"187-YAatFsEEbwcaB7k5IFXLuJrJQVo\""
         },
-        "hash": "f84b3c402b0c2bf6e173e5bb3757ef13979101fe",
+        "hash": "f7924e74e55c521b2401be45e0ffd06e70ae5228",
         "request": {
           "data": {
             "schemas": [
@@ -87,7 +91,7 @@
               {
                 "op": "replace",
                 "path": "displayName",
-                "value": "Nango Developer Test"
+                "value": "Patched Delete Test"
               }
             ]
           }

--- a/integrations/1password-scim/tests/scim-groups.test.json
+++ b/integrations/1password-scim/tests/scim-groups.test.json
@@ -1,0 +1,96 @@
+{
+  "nango": {
+    "batchSave": {
+      "ScimGroup": [
+        {
+          "id": "sitza7mfvjmrgdr6krnetp7g2q",
+          "displayName": "Test Group Patched",
+          "meta": {
+            "resourceType": "Group",
+            "created": "2026-05-21T14:15:21Z",
+            "lastModified": "2026-05-21T14:23:16Z"
+          }
+        },
+        {
+          "id": "27i3xrasou26ukebqazeadyhua",
+          "displayName": "Updated Test Group",
+          "meta": {
+            "resourceType": "Group",
+            "created": "2026-05-21T14:15:27Z",
+            "lastModified": "2026-05-21T14:15:41Z"
+          }
+        }
+      ]
+    },
+    "batchDelete": {
+      "ScimGroup": []
+    }
+  },
+  "api": {
+    "get": {
+      "/Groups": {
+        "response": {
+          "Resources": [
+            {
+              "displayName": "Test Group Patched",
+              "id": "sitza7mfvjmrgdr6krnetp7g2q",
+              "meta": {
+                "created": "2026-05-21T14:15:21Z",
+                "lastModified": "2026-05-21T14:23:16Z",
+                "resourceType": "Group"
+              },
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:Group"
+              ]
+            },
+            {
+              "displayName": "Updated Test Group",
+              "id": "27i3xrasou26ukebqazeadyhua",
+              "meta": {
+                "created": "2026-05-21T14:15:27Z",
+                "lastModified": "2026-05-21T14:15:41Z",
+                "resourceType": "Group"
+              },
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:Group"
+              ]
+            }
+          ],
+          "itemsPerPage": 2,
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+          ],
+          "startIndex": 1,
+          "totalResults": 2
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 18:17:37 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "594",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4994",
+          "x-ratelimit-reset": "1779387513",
+          "etag": "W/\"252-b50GjUNFH++3MFnFkcN0/8o98DA\""
+        },
+        "hash": "72f429f5c708396297b485e5d184a3746b0a31f4",
+        "request": {
+          "params": {
+            "count": "100",
+            "startIndex": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/scim-groups.test.json
+++ b/integrations/1password-scim/tests/scim-groups.test.json
@@ -1,96 +1,111 @@
 {
-  "nango": {
-    "batchSave": {
-      "ScimGroup": [
-        {
-          "id": "sitza7mfvjmrgdr6krnetp7g2q",
-          "displayName": "Test Group Patched",
-          "meta": {
-            "resourceType": "Group",
-            "created": "2026-05-21T14:15:21Z",
-            "lastModified": "2026-05-21T14:23:16Z"
-          }
+    "nango": {
+        "batchSave": {
+            "Group": [
+                {
+                    "id": "sitza7mfvjmrgdr6krnetp7g2q",
+                    "displayName": "Test Group Patched",
+                    "meta": {
+                        "resourceType": "Group",
+                        "created": "2026-05-21T14:15:21Z",
+                        "lastModified": "2026-05-21T14:23:16Z"
+                    }
+                },
+                {
+                    "id": "27i3xrasou26ukebqazeadyhua",
+                    "displayName": "Updated Test Group Nango",
+                    "meta": {
+                        "resourceType": "Group",
+                        "created": "2026-05-21T14:15:27Z",
+                        "lastModified": "2026-05-22T17:57:03Z"
+                    }
+                },
+                {
+                    "id": "va2pjrrhr7ykpdxkscbql6ipue",
+                    "displayName": "Nango Test Group Updated",
+                    "meta": {
+                        "resourceType": "Group",
+                        "created": "2026-05-22T17:57:33Z",
+                        "lastModified": "2026-05-22T18:01:09Z"
+                    }
+                }
+            ]
         },
-        {
-          "id": "27i3xrasou26ukebqazeadyhua",
-          "displayName": "Updated Test Group",
-          "meta": {
-            "resourceType": "Group",
-            "created": "2026-05-21T14:15:27Z",
-            "lastModified": "2026-05-21T14:15:41Z"
-          }
+        "batchDelete": {
+            "Group": []
         }
-      ]
     },
-    "batchDelete": {
-      "ScimGroup": []
-    }
-  },
-  "api": {
-    "get": {
-      "/Groups": {
-        "response": {
-          "Resources": [
-            {
-              "displayName": "Test Group Patched",
-              "id": "sitza7mfvjmrgdr6krnetp7g2q",
-              "meta": {
-                "created": "2026-05-21T14:15:21Z",
-                "lastModified": "2026-05-21T14:23:16Z",
-                "resourceType": "Group"
-              },
-              "schemas": [
-                "urn:ietf:params:scim:schemas:core:2.0:Group"
-              ]
-            },
-            {
-              "displayName": "Updated Test Group",
-              "id": "27i3xrasou26ukebqazeadyhua",
-              "meta": {
-                "created": "2026-05-21T14:15:27Z",
-                "lastModified": "2026-05-21T14:15:41Z",
-                "resourceType": "Group"
-              },
-              "schemas": [
-                "urn:ietf:params:scim:schemas:core:2.0:Group"
-              ]
+    "api": {
+        "get": {
+            "/Groups": {
+                "response": {
+                    "Resources": [
+                        {
+                            "displayName": "Test Group Patched",
+                            "id": "sitza7mfvjmrgdr6krnetp7g2q",
+                            "meta": {
+                                "created": "2026-05-21T14:15:21Z",
+                                "lastModified": "2026-05-21T14:23:16Z",
+                                "resourceType": "Group"
+                            },
+                            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+                        },
+                        {
+                            "displayName": "Updated Test Group Nango",
+                            "id": "27i3xrasou26ukebqazeadyhua",
+                            "meta": {
+                                "created": "2026-05-21T14:15:27Z",
+                                "lastModified": "2026-05-22T17:57:03Z",
+                                "resourceType": "Group"
+                            },
+                            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+                        },
+                        {
+                            "displayName": "Nango Test Group Updated",
+                            "id": "va2pjrrhr7ykpdxkscbql6ipue",
+                            "meta": {
+                                "created": "2026-05-22T17:57:33Z",
+                                "lastModified": "2026-05-22T18:01:09Z",
+                                "resourceType": "Group"
+                            },
+                            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+                        }
+                    ],
+                    "itemsPerPage": 3,
+                    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+                    "startIndex": 1,
+                    "totalResults": 3
+                },
+                "status": 200,
+                "headers": {
+                    "date": "Fri, 22 May 2026 18:54:28 GMT",
+                    "content-type": "application/scim+json",
+                    "content-length": "838",
+                    "connection": "keep-alive",
+                    "x-xss-protection": "0",
+                    "x-content-type-options": "nosniff",
+                    "x-download-options": "noopen",
+                    "x-frame-options": "SAMEORIGIN",
+                    "x-dns-prefetch-control": "off",
+                    "strict-transport-security": "max-age=5184000; includeSubDomains",
+                    "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4985",
+                    "x-ratelimit-reset": "1779476070",
+                    "etag": "W/\"346-FbKlEZDRojTuv4+zlzjxT1cye/8\""
+                },
+                "hash": "c4a9aab43c0e7199f7fad7b988571970b3824f75",
+                "request": {
+                    "params": {
+                        "count": "100",
+                        "sortBy": "meta.lastModified",
+                        "sortOrder": "ascending",
+                        "startIndex": "1"
+                    }
+                }
             }
-          ],
-          "itemsPerPage": 2,
-          "schemas": [
-            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
-          ],
-          "startIndex": 1,
-          "totalResults": 2
-        },
-        "status": 200,
-        "headers": {
-          "date": "Thu, 21 May 2026 18:17:37 GMT",
-          "content-type": "application/scim+json",
-          "content-length": "594",
-          "connection": "keep-alive",
-          "x-xss-protection": "0",
-          "x-content-type-options": "nosniff",
-          "x-download-options": "noopen",
-          "x-frame-options": "SAMEORIGIN",
-          "x-dns-prefetch-control": "off",
-          "strict-transport-security": "max-age=5184000; includeSubDomains",
-          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
-          "access-control-allow-origin": "*",
-          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
-          "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4994",
-          "x-ratelimit-reset": "1779387513",
-          "etag": "W/\"252-b50GjUNFH++3MFnFkcN0/8o98DA\""
-        },
-        "hash": "72f429f5c708396297b485e5d184a3746b0a31f4",
-        "request": {
-          "params": {
-            "count": "100",
-            "startIndex": "1"
-          }
         }
-      }
     }
-  }
 }

--- a/integrations/1password-scim/tests/scim-users.test.json
+++ b/integrations/1password-scim/tests/scim-users.test.json
@@ -3,53 +3,30 @@
     "batchSave": {
       "ScimUser": [
         {
-          "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
-          "userName": "tmp-delete-test-2@nango.dev",
-          "displayName": "Tmp Delete Test 2",
+          "id": "2ZC2XO6BQ5FETAF7AIQNFC73MM",
+          "userName": "delete-test-3@nango.dev",
+          "displayName": "Delete Test3",
           "name": {
-            "formatted": "Tmp Delete Test 2",
-            "familyName": "Test 2",
-            "givenName": "Tmp Delete"
+            "givenName": "Delete",
+            "familyName": "Test3",
+            "formatted": "Delete Test3"
           },
           "emails": [
             {
-              "value": "tmp-delete-test-2@nango.dev",
+              "value": "delete-test-3@nango.dev",
               "primary": true
             }
           ],
-          "active": false,
-          "meta": {
-            "resourceType": "User"
-          }
-        },
-        {
-          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
-          "userName": "api@nango.dev",
-          "displayName": "Nango Developer",
-          "name": {
-            "formatted": "Nango Developer",
-            "familyName": "Developer",
-            "givenName": "Nango"
-          },
-          "emails": [
-            {
-              "value": "api@nango.dev",
-              "primary": true
-            }
-          ],
-          "active": true,
-          "meta": {
-            "resourceType": "User"
-          }
+          "active": false
         },
         {
           "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
           "userName": "victor@nango.dev",
           "displayName": "Victor Nango",
           "name": {
-            "formatted": "Victor Nango",
+            "givenName": "Victor",
             "familyName": "Nango",
-            "givenName": "Victor"
+            "formatted": "Victor Nango"
           },
           "emails": [
             {
@@ -57,59 +34,16 @@
               "primary": true
             }
           ],
-          "active": true,
-          "meta": {
-            "resourceType": "User"
-          }
-        },
-        {
-          "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
-          "userName": "test@nango.dev",
-          "displayName": "Test User",
-          "name": {
-            "formatted": "Test User",
-            "familyName": "User",
-            "givenName": "Test"
-          },
-          "emails": [
-            {
-              "value": "test@nango.dev",
-              "primary": true
-            }
-          ],
-          "active": true,
-          "meta": {
-            "resourceType": "User"
-          }
-        },
-        {
-          "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
-          "userName": "scim-test-action@nango.dev",
-          "displayName": "SCIM Test",
-          "name": {
-            "formatted": "SCIM Test",
-            "familyName": "Test",
-            "givenName": "SCIM"
-          },
-          "emails": [
-            {
-              "value": "scim-test-action@nango.dev",
-              "primary": true
-            }
-          ],
-          "active": true,
-          "meta": {
-            "resourceType": "User"
-          }
+          "active": true
         },
         {
           "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
           "userName": "tmp-delete-test@nango.dev",
           "displayName": "Tmp Delete Test",
           "name": {
-            "formatted": "Tmp Delete Test",
+            "givenName": "Tmp",
             "familyName": "Delete Test",
-            "givenName": "Tmp"
+            "formatted": "Tmp Delete Test"
           },
           "emails": [
             {
@@ -117,10 +51,143 @@
               "primary": true
             }
           ],
-          "active": false,
-          "meta": {
-            "resourceType": "User"
-          }
+          "active": false
+        },
+        {
+          "id": "6AQDNV7JBNHCJNX6QOS7Z6DYOI",
+          "userName": "delete-test-4@nango.dev",
+          "displayName": "Delete Test4",
+          "name": {
+            "givenName": "Delete",
+            "familyName": "Test4",
+            "formatted": "Delete Test4"
+          },
+          "emails": [
+            {
+              "value": "delete-test-4@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": false
+        },
+        {
+          "id": "TUUWOM3BINHPRMYTZOI3H224DM",
+          "userName": "create-scim-user-test-20260522@nango.dev",
+          "displayName": "Create Test",
+          "name": {
+            "givenName": "Create",
+            "familyName": "Test",
+            "formatted": "Create Test"
+          },
+          "emails": [
+            {
+              "value": "create-scim-user-test-20260522@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true
+        },
+        {
+          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "userName": "api@nango.dev",
+          "displayName": "Nango Developer",
+          "name": {
+            "givenName": "Nango",
+            "familyName": "Developer",
+            "formatted": "Nango Developer"
+          },
+          "emails": [
+            {
+              "value": "api@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true
+        },
+        {
+          "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+          "userName": "test@nango.dev",
+          "displayName": "Test User",
+          "name": {
+            "givenName": "Test",
+            "familyName": "User",
+            "formatted": "Test User"
+          },
+          "emails": [
+            {
+              "value": "test@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true
+        },
+        {
+          "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+          "userName": "scim-test-action@nango.dev",
+          "displayName": "SCIM Test Updated",
+          "name": {
+            "givenName": "SCIM",
+            "familyName": "Test Updated",
+            "formatted": "SCIM Test Updated"
+          },
+          "emails": [
+            {
+              "value": "scim-test-action@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true
+        },
+        {
+          "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+          "userName": "tmp-delete-test-2@nango.dev",
+          "displayName": "Tmp Delete Test 2",
+          "name": {
+            "givenName": "Tmp Delete",
+            "familyName": "Test 2",
+            "formatted": "Tmp Delete Test 2"
+          },
+          "emails": [
+            {
+              "value": "tmp-delete-test-2@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": false
+        },
+        {
+          "id": "NFAPLXW3PFA6NJKAV7IAD63BQI",
+          "userName": "delete-test-1@nango.dev",
+          "displayName": "Patched Delete Test",
+          "name": {
+            "givenName": "Patched",
+            "familyName": "Delete Test",
+            "formatted": "Patched Delete Test"
+          },
+          "emails": [
+            {
+              "value": "delete-test-1@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": false
+        },
+        {
+          "id": "EUFSZIJJQZFV7LWRGYMIJFTR2U",
+          "userName": "delete-test-2@nango.dev",
+          "displayName": "Delete Test2",
+          "name": {
+            "givenName": "Delete",
+            "familyName": "Test2",
+            "formatted": "Delete Test2"
+          },
+          "emails": [
+            {
+              "value": "delete-test-2@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": false
         }
       ]
     },
@@ -135,27 +202,123 @@
           "Resources": [
             {
               "active": false,
-              "displayName": "Tmp Delete Test 2",
+              "displayName": "Delete Test3",
               "emails": [
                 {
                   "primary": true,
-                  "value": "tmp-delete-test-2@nango.dev"
+                  "value": "delete-test-3@nango.dev"
                 }
               ],
-              "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+              "id": "2ZC2XO6BQ5FETAF7AIQNFC73MM",
               "meta": {
                 "resourceType": "User"
               },
               "name": {
-                "familyName": "Test 2",
-                "formatted": "Tmp Delete Test 2",
-                "givenName": "Tmp Delete"
+                "familyName": "Test3",
+                "formatted": "Delete Test3",
+                "givenName": "Delete"
               },
               "preferredLanguage": "en",
               "schemas": [
                 "urn:ietf:params:scim:schemas:core:2.0:User"
               ],
-              "userName": "tmp-delete-test-2@nango.dev"
+              "userName": "delete-test-3@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Victor Nango",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "victor@nango.dev"
+                }
+              ],
+              "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Nango",
+                "formatted": "Victor Nango",
+                "givenName": "Victor"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "victor@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Tmp Delete Test",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "tmp-delete-test@nango.dev"
+                }
+              ],
+              "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Delete Test",
+                "formatted": "Tmp Delete Test",
+                "givenName": "Tmp"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "tmp-delete-test@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Delete Test4",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "delete-test-4@nango.dev"
+                }
+              ],
+              "id": "6AQDNV7JBNHCJNX6QOS7Z6DYOI",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test4",
+                "formatted": "Delete Test4",
+                "givenName": "Delete"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "delete-test-4@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Create Test",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "create-scim-user-test-20260522@nango.dev"
+                }
+              ],
+              "id": "TUUWOM3BINHPRMYTZOI3H224DM",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test",
+                "formatted": "Create Test",
+                "givenName": "Create"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "create-scim-user-test-20260522@nango.dev"
             },
             {
               "active": true,
@@ -183,30 +346,6 @@
             },
             {
               "active": true,
-              "displayName": "Victor Nango",
-              "emails": [
-                {
-                  "primary": true,
-                  "value": "victor@nango.dev"
-                }
-              ],
-              "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
-              "meta": {
-                "resourceType": "User"
-              },
-              "name": {
-                "familyName": "Nango",
-                "formatted": "Victor Nango",
-                "givenName": "Victor"
-              },
-              "preferredLanguage": "en",
-              "schemas": [
-                "urn:ietf:params:scim:schemas:core:2.0:User"
-              ],
-              "userName": "victor@nango.dev"
-            },
-            {
-              "active": true,
               "displayName": "Test User",
               "emails": [
                 {
@@ -231,7 +370,7 @@
             },
             {
               "active": true,
-              "displayName": "SCIM Test",
+              "displayName": "SCIM Test Updated",
               "emails": [
                 {
                   "primary": true,
@@ -243,8 +382,8 @@
                 "resourceType": "User"
               },
               "name": {
-                "familyName": "Test",
-                "formatted": "SCIM Test",
+                "familyName": "Test Updated",
+                "formatted": "SCIM Test Updated",
                 "givenName": "SCIM"
               },
               "preferredLanguage": "en",
@@ -255,39 +394,87 @@
             },
             {
               "active": false,
-              "displayName": "Tmp Delete Test",
+              "displayName": "Tmp Delete Test 2",
               "emails": [
                 {
                   "primary": true,
-                  "value": "tmp-delete-test@nango.dev"
+                  "value": "tmp-delete-test-2@nango.dev"
                 }
               ],
-              "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
+              "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
               "meta": {
                 "resourceType": "User"
               },
               "name": {
-                "familyName": "Delete Test",
-                "formatted": "Tmp Delete Test",
-                "givenName": "Tmp"
+                "familyName": "Test 2",
+                "formatted": "Tmp Delete Test 2",
+                "givenName": "Tmp Delete"
               },
               "preferredLanguage": "en",
               "schemas": [
                 "urn:ietf:params:scim:schemas:core:2.0:User"
               ],
-              "userName": "tmp-delete-test@nango.dev"
+              "userName": "tmp-delete-test-2@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Patched Delete Test",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "delete-test-1@nango.dev"
+                }
+              ],
+              "id": "NFAPLXW3PFA6NJKAV7IAD63BQI",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Delete Test",
+                "formatted": "Patched Delete Test",
+                "givenName": "Patched"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "delete-test-1@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Delete Test2",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "delete-test-2@nango.dev"
+                }
+              ],
+              "id": "EUFSZIJJQZFV7LWRGYMIJFTR2U",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test2",
+                "formatted": "Delete Test2",
+                "givenName": "Delete"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "delete-test-2@nango.dev"
             }
           ],
-          "itemsPerPage": 6,
+          "itemsPerPage": 11,
           "schemas": [
             "urn:ietf:params:scim:api:messages:2.0:ListResponse"
           ],
           "startIndex": 1,
-          "totalResults": 6
+          "totalResults": 11
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:34:16 GMT",
+          "date": "Sun, 24 May 2026 23:02:57 GMT",
           "content-type": "application/scim+json",
           "transfer-encoding": "chunked",
           "connection": "keep-alive",
@@ -302,7 +489,7 @@
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "1000",
           "x-ratelimit-remaining": "998",
-          "x-ratelimit-reset": "1779374107",
+          "x-ratelimit-reset": "1779663835",
           "content-security-policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; img-src 'self' data: https://w3.org; style-src 'self'; frame-ancestors 'none'; form-action 'none'; manifest-src 'self'",
           "referrer-policy": "no-referrer",
           "x-robots-tag": "none"

--- a/integrations/1password-scim/tests/scim-users.test.json
+++ b/integrations/1password-scim/tests/scim-users.test.json
@@ -1,0 +1,320 @@
+{
+  "nango": {
+    "batchSave": {
+      "ScimUser": [
+        {
+          "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+          "userName": "tmp-delete-test-2@nango.dev",
+          "displayName": "Tmp Delete Test 2",
+          "name": {
+            "formatted": "Tmp Delete Test 2",
+            "familyName": "Test 2",
+            "givenName": "Tmp Delete"
+          },
+          "emails": [
+            {
+              "value": "tmp-delete-test-2@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": false,
+          "meta": {
+            "resourceType": "User"
+          }
+        },
+        {
+          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "userName": "api@nango.dev",
+          "displayName": "Nango Developer",
+          "name": {
+            "formatted": "Nango Developer",
+            "familyName": "Developer",
+            "givenName": "Nango"
+          },
+          "emails": [
+            {
+              "value": "api@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true,
+          "meta": {
+            "resourceType": "User"
+          }
+        },
+        {
+          "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
+          "userName": "victor@nango.dev",
+          "displayName": "Victor Nango",
+          "name": {
+            "formatted": "Victor Nango",
+            "familyName": "Nango",
+            "givenName": "Victor"
+          },
+          "emails": [
+            {
+              "value": "victor@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true,
+          "meta": {
+            "resourceType": "User"
+          }
+        },
+        {
+          "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+          "userName": "test@nango.dev",
+          "displayName": "Test User",
+          "name": {
+            "formatted": "Test User",
+            "familyName": "User",
+            "givenName": "Test"
+          },
+          "emails": [
+            {
+              "value": "test@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true,
+          "meta": {
+            "resourceType": "User"
+          }
+        },
+        {
+          "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+          "userName": "scim-test-action@nango.dev",
+          "displayName": "SCIM Test",
+          "name": {
+            "formatted": "SCIM Test",
+            "familyName": "Test",
+            "givenName": "SCIM"
+          },
+          "emails": [
+            {
+              "value": "scim-test-action@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": true,
+          "meta": {
+            "resourceType": "User"
+          }
+        },
+        {
+          "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
+          "userName": "tmp-delete-test@nango.dev",
+          "displayName": "Tmp Delete Test",
+          "name": {
+            "formatted": "Tmp Delete Test",
+            "familyName": "Delete Test",
+            "givenName": "Tmp"
+          },
+          "emails": [
+            {
+              "value": "tmp-delete-test@nango.dev",
+              "primary": true
+            }
+          ],
+          "active": false,
+          "meta": {
+            "resourceType": "User"
+          }
+        }
+      ]
+    },
+    "batchDelete": {
+      "ScimUser": []
+    }
+  },
+  "api": {
+    "get": {
+      "/Users": {
+        "response": {
+          "Resources": [
+            {
+              "active": false,
+              "displayName": "Tmp Delete Test 2",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "tmp-delete-test-2@nango.dev"
+                }
+              ],
+              "id": "TDJZWGRBQRAWTG2APQFSIY5RBY",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test 2",
+                "formatted": "Tmp Delete Test 2",
+                "givenName": "Tmp Delete"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "tmp-delete-test-2@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Nango Developer",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "api@nango.dev"
+                }
+              ],
+              "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Developer",
+                "formatted": "Nango Developer",
+                "givenName": "Nango"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "api@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Victor Nango",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "victor@nango.dev"
+                }
+              ],
+              "id": "FHNN6ANJUZF3FFXYHEE6EWPHSM",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Nango",
+                "formatted": "Victor Nango",
+                "givenName": "Victor"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "victor@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "Test User",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "test@nango.dev"
+                }
+              ],
+              "id": "6NF7ZWCFBBHUXBSGZM5YXY2OSU",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "User",
+                "formatted": "Test User",
+                "givenName": "Test"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "test@nango.dev"
+            },
+            {
+              "active": true,
+              "displayName": "SCIM Test",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "scim-test-action@nango.dev"
+                }
+              ],
+              "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Test",
+                "formatted": "SCIM Test",
+                "givenName": "SCIM"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "scim-test-action@nango.dev"
+            },
+            {
+              "active": false,
+              "displayName": "Tmp Delete Test",
+              "emails": [
+                {
+                  "primary": true,
+                  "value": "tmp-delete-test@nango.dev"
+                }
+              ],
+              "id": "I3CPWGZZEJESNNEPKKLGIPFQTE",
+              "meta": {
+                "resourceType": "User"
+              },
+              "name": {
+                "familyName": "Delete Test",
+                "formatted": "Tmp Delete Test",
+                "givenName": "Tmp"
+              },
+              "preferredLanguage": "en",
+              "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User"
+              ],
+              "userName": "tmp-delete-test@nango.dev"
+            }
+          ],
+          "itemsPerPage": 6,
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+          ],
+          "startIndex": 1,
+          "totalResults": 6
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:34:16 GMT",
+          "content-type": "application/scim+json",
+          "transfer-encoding": "chunked",
+          "connection": "keep-alive",
+          "x-xss-protection": "1; mode=block",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "DENY",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "1000",
+          "x-ratelimit-remaining": "998",
+          "x-ratelimit-reset": "1779374107",
+          "content-security-policy": "default-src 'none'; connect-src 'self' https:; script-src 'self'; img-src 'self' data: https://w3.org; style-src 'self'; frame-ancestors 'none'; form-action 'none'; manifest-src 'self'",
+          "referrer-policy": "no-referrer",
+          "x-robots-tag": "none"
+        },
+        "hash": "687a5f97c6aad99aea3ed30bffd23191904eea99",
+        "request": {
+          "params": {
+            "count": "100",
+            "startIndex": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/update-scim-group.test.json
+++ b/integrations/1password-scim/tests/update-scim-group.test.json
@@ -1,0 +1,72 @@
+{
+  "input": {
+    "groupId": "27i3xrasou26ukebqazeadyhua",
+    "displayName": "Updated Test Group"
+  },
+  "output": {
+    "id": "27i3xrasou26ukebqazeadyhua",
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:Group"
+    ],
+    "displayName": "Updated Test Group",
+    "meta": {
+      "resourceType": "Group",
+      "created": "2026-05-21T14:15:27Z",
+      "lastModified": "2026-05-21T14:15:41Z"
+    }
+  },
+  "nango": {},
+  "api": {
+    "patch": {
+      "/Groups/27i3xrasou26ukebqazeadyhua": {
+        "response": {
+          "displayName": "Updated Test Group",
+          "id": "27i3xrasou26ukebqazeadyhua",
+          "meta": {
+            "created": "2026-05-21T14:15:27Z",
+            "lastModified": "2026-05-21T14:15:41Z",
+            "resourceType": "Group"
+          },
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:Group"
+          ]
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:15:55 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "232",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4962",
+          "x-ratelimit-reset": "1779372973",
+          "etag": "W/\"e8-1F7W9Pim9uUv4qsJcowRPSoiB+o\""
+        },
+        "hash": "e7df24bc8ece31ff16c5ff4728adf0c966461791",
+        "request": {
+          "data": {
+            "schemas": [
+              "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+            ],
+            "Operations": [
+              {
+                "op": "replace",
+                "path": "displayName",
+                "value": "Updated Test Group"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/1password-scim/tests/update-scim-group.test.json
+++ b/integrations/1password-scim/tests/update-scim-group.test.json
@@ -1,30 +1,22 @@
 {
   "input": {
     "groupId": "27i3xrasou26ukebqazeadyhua",
-    "displayName": "Updated Test Group"
+    "displayName": "Updated Test Group Nango"
   },
   "output": {
     "id": "27i3xrasou26ukebqazeadyhua",
-    "schemas": [
-      "urn:ietf:params:scim:schemas:core:2.0:Group"
-    ],
-    "displayName": "Updated Test Group",
-    "meta": {
-      "resourceType": "Group",
-      "created": "2026-05-21T14:15:27Z",
-      "lastModified": "2026-05-21T14:15:41Z"
-    }
+    "displayName": "Updated Test Group Nango"
   },
   "nango": {},
   "api": {
     "patch": {
       "/Groups/27i3xrasou26ukebqazeadyhua": {
         "response": {
-          "displayName": "Updated Test Group",
+          "displayName": "Updated Test Group Nango",
           "id": "27i3xrasou26ukebqazeadyhua",
           "meta": {
             "created": "2026-05-21T14:15:27Z",
-            "lastModified": "2026-05-21T14:15:41Z",
+            "lastModified": "2026-05-22T17:57:03Z",
             "resourceType": "Group"
           },
           "schemas": [
@@ -33,9 +25,9 @@
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:15:55 GMT",
+          "date": "Fri, 22 May 2026 18:00:50 GMT",
           "content-type": "application/scim+json",
-          "content-length": "232",
+          "content-length": "238",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -47,11 +39,11 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4962",
-          "x-ratelimit-reset": "1779372973",
-          "etag": "W/\"e8-1F7W9Pim9uUv4qsJcowRPSoiB+o\""
+          "x-ratelimit-remaining": "4984",
+          "x-ratelimit-reset": "1779472886",
+          "etag": "W/\"ee-6sLsXBjEaUqioNtxsCuTTbf4fxc\""
         },
-        "hash": "e7df24bc8ece31ff16c5ff4728adf0c966461791",
+        "hash": "d08ddaf562321e4915e0e270ae0c9e4c570283ec",
         "request": {
           "data": {
             "schemas": [
@@ -61,7 +53,7 @@
               {
                 "op": "replace",
                 "path": "displayName",
-                "value": "Updated Test Group"
+                "value": "Updated Test Group Nango"
               }
             ]
           }

--- a/integrations/1password-scim/tests/update-scim-user.test.json
+++ b/integrations/1password-scim/tests/update-scim-user.test.json
@@ -1,34 +1,18 @@
 {
   "input": {
-    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
-    "operations": [
-      {
-        "op": "replace",
-        "path": "displayName",
-        "value": "Updated Display Name"
-      }
-    ]
+    "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+    "displayName": "SCIM Test Updated"
   },
   "output": {
-    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
-    "meta": {
-      "resourceType": "User"
-    },
-    "schemas": [
-      "urn:ietf:params:scim:schemas:core:2.0:User"
-    ],
-    "userName": "api@nango.dev",
-    "name": {
-      "formatted": "Updated Display Name",
-      "familyName": "Display Name",
-      "givenName": "Updated"
-    },
-    "displayName": "Updated Display Name",
-    "preferredLanguage": "en",
+    "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
+    "userName": "scim-test-action@nango.dev",
+    "givenName": "SCIM",
+    "familyName": "Test Updated",
+    "displayName": "SCIM Test Updated",
     "active": true,
     "emails": [
       {
-        "value": "api@nango.dev",
+        "value": "scim-test-action@nango.dev",
         "primary": true
       }
     ]
@@ -36,36 +20,36 @@
   "nango": {},
   "api": {
     "patch": {
-      "/Users/WHIVOG5WFFDGJODAWIGRVZZU5A": {
+      "/v2/Users/Z54GW3SPDZBJJPCEBMEOO2HQPE": {
         "response": {
           "active": true,
-          "displayName": "Updated Display Name",
+          "displayName": "SCIM Test Updated",
           "emails": [
             {
               "primary": true,
-              "value": "api@nango.dev"
+              "value": "scim-test-action@nango.dev"
             }
           ],
-          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "id": "Z54GW3SPDZBJJPCEBMEOO2HQPE",
           "meta": {
             "resourceType": "User"
           },
           "name": {
-            "familyName": "Display Name",
-            "formatted": "Updated Display Name",
-            "givenName": "Updated"
+            "familyName": "Test Updated",
+            "formatted": "SCIM Test Updated",
+            "givenName": "SCIM"
           },
           "preferredLanguage": "en",
           "schemas": [
             "urn:ietf:params:scim:schemas:core:2.0:User"
           ],
-          "userName": "api@nango.dev"
+          "userName": "scim-test-action@nango.dev"
         },
         "status": 200,
         "headers": {
-          "date": "Thu, 21 May 2026 14:14:39 GMT",
+          "date": "Fri, 22 May 2026 17:57:31 GMT",
           "content-type": "application/scim+json",
-          "content-length": "373",
+          "content-length": "390",
           "connection": "keep-alive",
           "x-xss-protection": "0",
           "x-content-type-options": "nosniff",
@@ -77,11 +61,11 @@
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
           "x-ratelimit-limit": "5000",
-          "x-ratelimit-remaining": "4955",
-          "x-ratelimit-reset": "1779372909",
-          "etag": "W/\"175-c+qNAEVA23peEm4spNet9b0hWvs\""
+          "x-ratelimit-remaining": "4982",
+          "x-ratelimit-reset": "1779472699",
+          "etag": "W/\"186-NwfE1sQu5jc0I2jT7WogB1Taa8Q\""
         },
-        "hash": "de34886d214cdaaaed3e2e29fcb5dad84b785b25",
+        "hash": "712c4bac3a9f4269a7e6b4aa0f802715ebbb9609",
         "request": {
           "data": {
             "schemas": [
@@ -91,7 +75,7 @@
               {
                 "op": "replace",
                 "path": "displayName",
-                "value": "Updated Display Name"
+                "value": "SCIM Test Updated"
               }
             ]
           }

--- a/integrations/1password-scim/tests/update-scim-user.test.json
+++ b/integrations/1password-scim/tests/update-scim-user.test.json
@@ -1,0 +1,102 @@
+{
+  "input": {
+    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+    "operations": [
+      {
+        "op": "replace",
+        "path": "displayName",
+        "value": "Updated Display Name"
+      }
+    ]
+  },
+  "output": {
+    "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+    "meta": {
+      "resourceType": "User"
+    },
+    "schemas": [
+      "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "userName": "api@nango.dev",
+    "name": {
+      "formatted": "Updated Display Name",
+      "familyName": "Display Name",
+      "givenName": "Updated"
+    },
+    "displayName": "Updated Display Name",
+    "preferredLanguage": "en",
+    "active": true,
+    "emails": [
+      {
+        "value": "api@nango.dev",
+        "primary": true
+      }
+    ]
+  },
+  "nango": {},
+  "api": {
+    "patch": {
+      "/Users/WHIVOG5WFFDGJODAWIGRVZZU5A": {
+        "response": {
+          "active": true,
+          "displayName": "Updated Display Name",
+          "emails": [
+            {
+              "primary": true,
+              "value": "api@nango.dev"
+            }
+          ],
+          "id": "WHIVOG5WFFDGJODAWIGRVZZU5A",
+          "meta": {
+            "resourceType": "User"
+          },
+          "name": {
+            "familyName": "Display Name",
+            "formatted": "Updated Display Name",
+            "givenName": "Updated"
+          },
+          "preferredLanguage": "en",
+          "schemas": [
+            "urn:ietf:params:scim:schemas:core:2.0:User"
+          ],
+          "userName": "api@nango.dev"
+        },
+        "status": 200,
+        "headers": {
+          "date": "Thu, 21 May 2026 14:14:39 GMT",
+          "content-type": "application/scim+json",
+          "content-length": "373",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://*.posthog.com https://*.stripe.com;font-src 'self' https://*.googleapis.com https://*.gstatic.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://www.youtube.com https://*.stripe.com;img-src 'self' data: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4955",
+          "x-ratelimit-reset": "1779372909",
+          "etag": "W/\"175-c+qNAEVA23peEm4spNet9b0hWvs\""
+        },
+        "hash": "de34886d214cdaaaed3e2e29fcb5dad84b785b25",
+        "request": {
+          "data": {
+            "schemas": [
+              "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+            ],
+            "Operations": [
+              {
+                "op": "replace",
+                "path": "displayName",
+                "value": "Updated Display Name"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -1,3 +1,22 @@
+// -- Integration: 1password-scim
+import './1password-scim/syncs/scim-groups.js';
+import './1password-scim/syncs/scim-users.js';
+import './1password-scim/actions/create-scim-group.js';
+import './1password-scim/actions/create-scim-user.js';
+import './1password-scim/actions/delete-scim-group.js';
+import './1password-scim/actions/delete-scim-user.js';
+import './1password-scim/actions/get-scim-group.js';
+import './1password-scim/actions/get-scim-user.js';
+import './1password-scim/actions/get-service-provider-config.js';
+import './1password-scim/actions/list-resource-types.js';
+import './1password-scim/actions/list-schemas.js';
+import './1password-scim/actions/list-scim-groups.js';
+import './1password-scim/actions/list-scim-users.js';
+import './1password-scim/actions/patch-scim-group.js';
+import './1password-scim/actions/patch-scim-user.js';
+import './1password-scim/actions/update-scim-group.js';
+import './1password-scim/actions/update-scim-user.js';
+
 // -- Integration: adp
 import './adp/syncs/unified-employees.js';
 


### PR DESCRIPTION
## Describe your changes\
- Updated group data in scim-groups.test.json to include additional groups and their metadata.
- Enhanced scim-users.test.json with new user entries and updated existing user details.
- Adjusted update-scim-group.test.json to change the display name for a group.
- Revised update-scim-user.test.json to reflect changes in user details and IDs.
## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full `1password-scim` function templates with CRUD actions for SCIM users and groups, list/config endpoints, and two syncs. Strengthens typing and fixtures for more reliable provisioning.

- New Features
  - Actions for Users and Groups (create/get/list/update/patch/delete), plus list schemas/resource types and service provider config.
  - New syncs: scim-users and scim-groups with pagination and request retries.
  - Models and endpoints wired in `integrations/index.ts` and `integrations/.nango/nango.json`.
  - Vitest coverage with JSON fixtures for all actions and syncs.

- Refactors
  - SCIM Patch operation schemas now use discriminated unions for better type safety.
  - Removed baseUrlOverride; standardized SCIM paths with retries across requests.
  - Updated generated `schema.json`/`schema.ts` with `Group` and `ScimUser` and stricter `zod` types.
  - Refreshed test data for users and groups for consistency.

<sup>Written for commit 59b7f003ea6b3ca63c1d263621e98c92f92bbf67. Summary will update on new commits. <a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

