### PR TITLE
fix: rename conflicting schema variables

### DIFF
--- a/integrations/gong/actions/list-call-outcomes.ts
+++ b/integrations/gong/actions/list-call-outcomes.ts
@@ -19,7 +19,7 @@ const ProviderResponseSchema = z.object({
     cursor: z.string().optional()
 });
 
-const CallOutcomeSchema = z
+const CallOutcomeItemSchema = z
     .object({
         id: z.string().optional(),
         category: z.string().optional(),
@@ -28,7 +28,7 @@ const CallOutcomeSchema = z
     .passthrough();
 
 const OutputSchema = z.object({
-    items: z.array(CallOutcomeSchema),
+    items: z.array(CallOutcomeItemSchema),
     nextCursor: z.string().optional()
 });
 

--- a/integrations/gong/actions/list-call-transcripts.ts
+++ b/integrations/gong/actions/list-call-transcripts.ts
@@ -21,13 +21,13 @@ const MonologueSchema = z.object({
     sentences: z.array(SentenceSchema).optional()
 });
 
-const CallTranscriptSchema = z.object({
+const CallTranscriptItemSchema = z.object({
     callId: z.string().optional(),
     transcript: z.array(MonologueSchema).optional()
 });
 
 const OutputSchema = z.object({
-    callTranscripts: z.array(CallTranscriptSchema),
+    callTranscripts: z.array(CallTranscriptItemSchema),
     nextCursor: z.string().optional(),
     totalRecords: z.number().optional(),
     currentPageSize: z.number().optional()
@@ -49,7 +49,7 @@ const GongErrorSchema = z
     .passthrough();
 
 const ProviderResponseSchema = z.object({
-    callTranscripts: z.array(CallTranscriptSchema).optional(),
+    callTranscripts: z.array(CallTranscriptItemSchema).optional(),
     records: z
         .object({
             totalRecords: z.number().optional(),


### PR DESCRIPTION
## Describe your changes
Renamed the local schema variables in both action files to CallOutcomeItemSchema and CallTranscriptItemSchema respectively, so the compiler infers CallOutcomeItem / CallTranscriptItem instead: names that don't conflict with the sync models

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed local Zod schemas in Gong actions to avoid name conflicts with sync models and fix type inference. Ensures outputs use item-level types (`CallOutcomeItem`, `CallTranscriptItem`) without collisions.

- **Bug Fixes**
  - `list-call-outcomes.ts`: `CallOutcomeSchema` -> `CallOutcomeItemSchema`; updated `OutputSchema`.
  - `list-call-transcripts.ts`: `CallTranscriptSchema` -> `CallTranscriptItemSchema`; updated `OutputSchema` and `ProviderResponseSchema`.

<sup>Written for commit 59b5878a77265cfdab6ef8d29a11b42ea087e195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

