### PR TITLE
fix(gong): allow null topic/speakerId in call-transcripts sync

### DIFF
--- a/integrations/gong/syncs/call-transcripts.ts
+++ b/integrations/gong/syncs/call-transcripts.ts
@@ -19,8 +19,8 @@ const SentenceSchema = z.object({
 });
 
 const MonologueSchema = z.object({
-    speakerId: z.string().optional(),
-    topic: z.string().optional(),
+    speakerId: z.string().nullable().optional(),
+    topic: z.string().nullable().optional(),
     sentences: z.array(SentenceSchema).optional()
 });
 
@@ -48,8 +48,8 @@ const CallTranscriptSchema = z.object({
     transcript: z
         .array(
             z.object({
-                speakerId: z.string().optional(),
-                topic: z.string().optional(),
+                speakerId: z.string().nullable().optional(),
+                topic: z.string().nullable().optional(),
                 sentences: z
                     .array(
                         z.object({


### PR DESCRIPTION
## What

Make `topic` and `speakerId` nullable in the Gong `call-transcripts` sync schemas (input `MonologueSchema` + output `CallTranscriptSchema.transcript[]`).

## Why

Gong's `POST /v2/calls/transcript` returns `null` for `topic` (and sometimes `speakerId`) on monologues with no assigned topic/speaker. The schemas declared both as `z.string().optional()`, which rejects `null`, so `ProviderResponseSchema.parse(response.data)` throws and the sync never checkpoints:

```
ZodError: expected string, received null
  at path callTranscripts[N].transcript[M].topic
  call-transcripts-gong.cjs:173 (the .parse call)
```

The output model had the same flaw, so it would also fail `batchSave` once input parsing passed.

## Change

```diff
-    speakerId: z.string().optional(),
-    topic: z.string().optional(),
+    speakerId: z.string().nullable().optional(),
+    topic: z.string().nullable().optional(),
```

(in both schemas). The `exec` mapping is unchanged — `null` flows straight through into the saved record.

Fixes #560


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow null `topic` and `speakerId` in Gong call-transcripts sync to prevent Zod parse errors and let the sync checkpoint and save records when Gong returns nulls. Fixes #560.

- **Bug Fixes**
  - Updated `MonologueSchema` and `CallTranscriptSchema` to `z.string().nullable().optional()` for `topic` and `speakerId` so nulls pass through unchanged.

<sup>Written for commit 01e78fa4079e626b2e89dc0b20dfd8a3572c85bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

