### PR TITLE
feat: add workday-cc untested functions

### DIFF
--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -5440,6 +5440,25 @@ import './workday/actions/list-organizations.js';
 import './workday/actions/list-positions.js';
 import './workday/actions/list-workers.js';
 
+// -- Integration: workday-cc
+import './workday-cc/syncs/employees.js';
+import './workday-cc/syncs/groups.js';
+import './workday-cc/syncs/job-profiles.js';
+import './workday-cc/syncs/locations.js';
+import './workday-cc/syncs/organizations.js';
+import './workday-cc/syncs/positions.js';
+import './workday-cc/syncs/workers.js';
+import './workday-cc/actions/get-job-profile.js';
+import './workday-cc/actions/get-location.js';
+import './workday-cc/actions/get-organization.js';
+import './workday-cc/actions/get-position.js';
+import './workday-cc/actions/get-worker.js';
+import './workday-cc/actions/list-job-profiles.js';
+import './workday-cc/actions/list-locations.js';
+import './workday-cc/actions/list-organizations.js';
+import './workday-cc/actions/list-positions.js';
+import './workday-cc/actions/list-workers.js';
+
 // -- Integration: xero
 import './xero/syncs/accounts.js';
 import './xero/syncs/bank-transactions.js';

--- a/integrations/workday-cc/actions/get-job-profile.ts
+++ b/integrations/workday-cc/actions/get-job-profile.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+
+const InputSchema = z.object({
+    id: z.string().describe('Job_Profile_ID. Example: "JOB_PROFILE_001"')
+});
+
+const OutputSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    inactive: z.boolean().optional(),
+    job_family: z.string().optional(),
+    management_level: z.string().optional(),
+    job_category: z.string().optional(),
+    reference_id: z.string().optional()
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderJobFamilySchema = z.object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderJobProfileSchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    summary: z.string().optional(),
+    inactive: z.boolean().optional(),
+    jobFamilies: z.array(ProviderJobFamilySchema).optional(),
+    managementLevel: ProviderRelatedViewSchema.optional(),
+    jobCategory: ProviderRelatedViewSchema.optional()
+});
+
+const action = createAction({
+    description: 'Retrieve a single job profile from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/jobProfiles
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/jobProfiles/${encodeURIComponent(input.id)}`,
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({ type: 'not_found', message: `Job Profile not found: ${input.id}` });
+        }
+
+        const jobProfile = ProviderJobProfileSchema.parse(response.data);
+
+        return {
+            id: jobProfile.id,
+            name: jobProfile.name ?? '',
+            description: jobProfile.summary,
+            inactive: jobProfile.inactive,
+            job_family: jobProfile.jobFamilies?.[0]?.name ?? jobProfile.jobFamilies?.[0]?.descriptor,
+            management_level: jobProfile.managementLevel?.descriptor,
+            job_category: jobProfile.jobCategory?.descriptor,
+            reference_id: jobProfile.id
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/get-location.ts
+++ b/integrations/workday-cc/actions/get-location.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+
+const InputSchema = z.object({
+    id: z.string().describe('Location ID. Example: "San_Francisco_Site"')
+});
+
+// Workday's Staffing REST API has no dedicated Location master-data resource (no /locations
+// collection or /locations/{id}). The closest available substitute is the "prompt values" endpoint
+// used to populate the location field on job change transactions, filtered down to a single ID.
+// It only exposes id/descriptor — location code, usage, and inactive status aren't available here.
+const OutputSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    location_code: z.string().optional(),
+    location_usage: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const ProviderLocationValueSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderLocationValueSchema).optional(),
+    total: z.number().optional()
+});
+
+const action = createAction({
+    description: 'Retrieve a single location from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/values~jobChangesGroup~locations
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/values/jobChangesGroup/locations`,
+            params: { location: input.id },
+            retries: 3
+        });
+
+        const providerResponse = ProviderResponseSchema.parse(response.data);
+        const location = providerResponse.data?.find((item) => item.id === input.id) ?? providerResponse.data?.[0];
+
+        if (!location) {
+            throw new nango.ActionError({ type: 'not_found', message: `Location not found: ${input.id}` });
+        }
+
+        return {
+            id: location.id,
+            name: location.descriptor ?? ''
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/get-organization.ts
+++ b/integrations/workday-cc/actions/get-organization.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+
+const InputSchema = z.object({
+    id: z.string().describe('Supervisory organization ID. Example: "SUPERVISORY_ORG-6-9"')
+});
+
+// Workday's Staffing REST API only exposes Supervisory Organizations, unlike the SOAP Human
+// Resources API which covered every organization type (company, cost center, matrix, etc.).
+const OutputSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    type: z.string().optional(),
+    subtype: z.string().optional(),
+    description: z.string().optional(),
+    external_id: z.string().optional()
+});
+
+const ProviderOrganizationSchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    code: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const action = createAction({
+    description: 'Retrieve a single supervisory organization from Workday by its ID.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/supervisoryOrganizations
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/supervisoryOrganizations/${encodeURIComponent(input.id)}`,
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({ type: 'not_found', message: `Organization not found: ${input.id}` });
+        }
+
+        const org = ProviderOrganizationSchema.parse(response.data);
+
+        return {
+            id: org.id,
+            name: org.name ?? '',
+            type: 'Supervisory',
+            external_id: org.code
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/get-position.ts
+++ b/integrations/workday-cc/actions/get-position.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+
+const InputSchema = z.object({
+    id: z.string().describe('Job (position) ID. Example: "21001_JR1"')
+});
+
+// Workday's Staffing REST API models a filled/vacant position as a "Job" resource. It doesn't
+// expose a separate effective-date or open/closed status field the way the SOAP Position resource did.
+const OutputSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    position_code: z.string().optional(),
+    effective_date: z.string().optional(),
+    status: z.string().optional(),
+    inactive: z.boolean().optional(),
+    job_profile: z.string().optional(),
+    location: z.string().optional(),
+    worker: z.string().optional()
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderJobSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    businessTitle: z.string().optional(),
+    location: ProviderRelatedViewSchema.optional(),
+    worker: ProviderRelatedViewSchema.optional(),
+    jobProfile: ProviderRelatedViewSchema.optional()
+});
+
+const action = createAction({
+    description: 'Retrieve a single position from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/jobs
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/jobs/${encodeURIComponent(input.id)}`,
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({ type: 'not_found', message: `Position not found: ${input.id}` });
+        }
+
+        const job = ProviderJobSchema.parse(response.data);
+
+        return {
+            id: job.id,
+            name: job.businessTitle ?? job.descriptor ?? '',
+            position_code: job.id,
+            job_profile: job.jobProfile?.descriptor ?? job.jobProfile?.id,
+            location: job.location?.descriptor ?? job.location?.id,
+            worker: job.worker?.descriptor ?? job.worker?.id
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/get-worker.ts
+++ b/integrations/workday-cc/actions/get-worker.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+
+const InputSchema = z.object({
+    id: z.string().describe('Worker ID (Employee_ID or Contingent_Worker_ID). Example: "21001"')
+});
+
+// Workday's Staffing REST /workers resource doesn't expose a User_ID or an explicit active/terminated
+// flag on the single-worker view — that's only filterable at the collection level via includeTerminatedWorkers.
+const OutputSchema = z.object({
+    id: z.string(),
+    employee_id: z.string().optional(),
+    contingent_worker_id: z.string().optional(),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    user_id: z.string().optional(),
+    active: z.boolean().optional()
+});
+
+const ProviderWorkerTypeSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderPersonSchema = z.object({
+    id: z.string().optional(),
+    email: z.string().optional(),
+    phone: z.string().optional()
+});
+
+const ProviderWorkerSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    workerId: z.string().optional(),
+    workerType: ProviderWorkerTypeSchema.optional(),
+    person: ProviderPersonSchema.optional()
+});
+
+const action = createAction({
+    description: 'Retrieve a single worker from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/workers
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/workers/${encodeURIComponent(input.id)}`,
+            retries: 3
+        });
+
+        if (!response.data) {
+            throw new nango.ActionError({ type: 'not_found', message: `Worker not found: ${input.id}` });
+        }
+
+        const worker = ProviderWorkerSchema.parse(response.data);
+        const workerId = worker.workerId ?? worker.id;
+        const isContingent = (worker.workerType?.descriptor ?? '').toLowerCase().includes('contingent');
+
+        return {
+            id: workerId,
+            ...(isContingent ? { contingent_worker_id: workerId } : { employee_id: workerId }),
+            ...(worker.descriptor !== undefined && { name: worker.descriptor }),
+            ...(worker.person?.email !== undefined && { email: worker.person.email })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/list-job-profiles.ts
+++ b/integrations/workday-cc/actions/list-job-profiles.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination offset. Omit for the first page.')
+});
+
+const JobProfileSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    reference_id: z.string().optional(),
+    inactive: z.boolean(),
+    description: z.string().optional(),
+    effective_date: z.string().optional()
+});
+
+const OutputSchema = z.object({
+    items: z.array(JobProfileSchema),
+    next_cursor: z.string().optional()
+});
+
+const ProviderJobProfileSummarySchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderJobProfileSummarySchema).optional(),
+    total: z.number().optional()
+});
+
+const action = createAction({
+    description: 'List job profiles from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        const offset = input.cursor ? parseInt(input.cursor, 10) : 0;
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/jobProfiles
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/jobProfiles`,
+            params: {
+                limit: PAGE_SIZE,
+                offset,
+                includeInactive: 'true'
+            },
+            retries: 3
+        });
+
+        const providerResponse = ProviderResponseSchema.parse(response.data);
+        const items = (providerResponse.data ?? []).map((profile) => ({
+            id: profile.id,
+            name: profile.name ?? '',
+            inactive: profile.inactive ?? false
+        }));
+
+        const total = providerResponse.total ?? offset + items.length;
+        const hasMoreData = offset + items.length < total;
+
+        return {
+            items,
+            ...(hasMoreData && { next_cursor: String(offset + PAGE_SIZE) })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/list-locations.ts
+++ b/integrations/workday-cc/actions/list-locations.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination offset. Omit for the first page.')
+});
+
+const LocationOutputSchema = z.object({
+    id: z.string(),
+    reference_id: z.string().optional(),
+    name: z.string(),
+    location_usage: z.string().optional(),
+    country: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const OutputSchema = z.object({
+    items: z.array(LocationOutputSchema),
+    next_page: z.string().optional().describe('Next page offset for pagination.')
+});
+
+// Workday's Staffing REST API has no dedicated Location master-data resource; the "prompt values"
+// endpoint used for job-change location pickers is the closest available substitute (id/descriptor only).
+const ProviderLocationValueSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderLocationValueSchema).optional(),
+    total: z.number().optional()
+});
+
+const action = createAction({
+    description: 'List locations from Workday with pagination support.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        const offset = input.cursor ? parseInt(input.cursor, 10) : 0;
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/values~jobChangesGroup~locations
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/values/jobChangesGroup/locations`,
+            params: { limit: PAGE_SIZE, offset },
+            retries: 3
+        });
+
+        const providerResponse = ProviderResponseSchema.parse(response.data);
+        const items = (providerResponse.data ?? []).map((location) => ({
+            id: location.id,
+            name: location.descriptor ?? ''
+        }));
+
+        const total = providerResponse.total ?? offset + items.length;
+        const hasMoreData = offset + items.length < total;
+
+        return {
+            items,
+            ...(hasMoreData && { next_page: String(offset + PAGE_SIZE) })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/list-organizations.ts
+++ b/integrations/workday-cc/actions/list-organizations.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination offset. Omit for the first page.')
+});
+
+// Workday's Staffing REST API only exposes Supervisory Organizations, unlike the SOAP Human
+// Resources API which covered every organization type (company, cost center, matrix, etc.).
+const OrganizationSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    type: z.string().optional(),
+    subtype: z.string().optional(),
+    description: z.string().optional(),
+    inactive: z.boolean(),
+    external_id: z.string().optional()
+});
+
+const OutputSchema = z.object({
+    items: z.array(OrganizationSchema),
+    next_cursor: z.string().optional()
+});
+
+const ProviderOrganizationSchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    code: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderOrganizationSchema).optional(),
+    total: z.number().optional()
+});
+
+const action = createAction({
+    description: 'List organizations from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        const offset = input.cursor ? parseInt(input.cursor, 10) : 0;
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/supervisoryOrganizations
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/supervisoryOrganizations`,
+            params: {
+                limit: PAGE_SIZE,
+                offset,
+                includeInactive: 'true'
+            },
+            retries: 3
+        });
+
+        const providerResponse = ProviderResponseSchema.parse(response.data);
+        const items = (providerResponse.data ?? []).map((org) => ({
+            id: org.id,
+            name: org.name ?? '',
+            type: 'Supervisory',
+            inactive: org.inactive ?? false,
+            external_id: org.code
+        }));
+
+        const total = providerResponse.total ?? offset + items.length;
+        const hasMoreData = offset + items.length < total;
+
+        return {
+            items,
+            ...(hasMoreData && { next_cursor: String(offset + PAGE_SIZE) })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/list-positions.ts
+++ b/integrations/workday-cc/actions/list-positions.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST API models a filled/vacant position as a "Job" resource. It doesn't
+// expose an open/closed status, organization hierarchy, or pay-rate detail the way SOAP's
+// Position resource did, so those fields are omitted here rather than fabricated.
+const PositionSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+    job_profile_id: z.string().optional(),
+    job_profile_name: z.string().optional(),
+    location_id: z.string().optional(),
+    location_name: z.string().optional(),
+    worker_id: z.string().optional(),
+    worker_name: z.string().optional(),
+    inactive: z.boolean(),
+    organization_id: z.string().optional(),
+    organization_name: z.string().optional()
+});
+
+const OutputSchema = z.object({
+    items: z.array(PositionSchema)
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderJobSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    businessTitle: z.string().optional(),
+    location: ProviderRelatedViewSchema.optional(),
+    worker: ProviderRelatedViewSchema.optional(),
+    jobProfile: ProviderRelatedViewSchema.optional(),
+    supervisoryOrganization: ProviderRelatedViewSchema.optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderJobSchema).optional(),
+    total: z.number().optional()
+});
+
+const action = createAction({
+    description: 'List positions from Workday.',
+    version: '1.0.0',
+    input: z.object({}),
+    output: OutputSchema,
+
+    exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        const positions: z.infer<typeof PositionSchema>[] = [];
+        let offset = 0;
+        let total = 0;
+
+        do {
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/jobs
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/jobs`,
+                    params: { limit: PAGE_SIZE, offset },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const jobs = providerResponse.data ?? [];
+            total = providerResponse.total ?? jobs.length;
+
+            for (const job of jobs) {
+                positions.push({
+                    id: job.id,
+                    title: job.businessTitle ?? job.descriptor ?? '',
+                    job_profile_id: job.jobProfile?.id,
+                    job_profile_name: job.jobProfile?.descriptor,
+                    location_id: job.location?.id,
+                    location_name: job.location?.descriptor,
+                    worker_id: job.worker?.id,
+                    worker_name: job.worker?.descriptor,
+                    inactive: false,
+                    organization_id: job.supervisoryOrganization?.id,
+                    organization_name: job.supervisoryOrganization?.descriptor
+                });
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        return { items: positions };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/actions/list-workers.ts
+++ b/integrations/workday-cc/actions/list-workers.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination offset. Omit for the first page.')
+});
+
+// Workday's Staffing REST /workers resource doesn't expose hire/termination dates, manager,
+// department, or cost-center references the way the SOAP Get_Workers response did.
+const WorkerSchema = z.object({
+    id: z.string(),
+    employee_id: z.string().optional(),
+    contingent_worker_id: z.string().optional(),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    phone: z.string().optional(),
+    worker_type: z.string().optional(),
+    business_title: z.string().optional(),
+    job_profile: z.string().optional(),
+    location: z.string().optional(),
+    is_active: z.boolean().optional()
+});
+
+const OutputSchema = z.object({
+    items: z.array(WorkerSchema),
+    next_cursor: z.string().optional()
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderPrimaryJobSchema = z.object({
+    businessTitle: z.string().optional(),
+    jobProfile: ProviderRelatedViewSchema.optional(),
+    location: ProviderRelatedViewSchema.optional()
+});
+
+const ProviderWorkerSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    workerId: z.string().optional(),
+    workerType: ProviderRelatedViewSchema.optional(),
+    person: z.object({ email: z.string().optional(), phone: z.string().optional() }).optional(),
+    primaryJob: ProviderPrimaryJobSchema.optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderWorkerSchema).optional(),
+    total: z.number().optional()
+});
+
+const action = createAction({
+    description: 'List workers from Workday.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        const offset = input.cursor ? parseInt(input.cursor, 10) : 0;
+
+        // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/workers
+        const response = await nango.get({
+            endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/workers`,
+            params: { limit: PAGE_SIZE, offset, includeTerminatedWorkers: 'true' },
+            retries: 3
+        });
+
+        const providerResponse = ProviderResponseSchema.parse(response.data);
+        const items = (providerResponse.data ?? []).map((worker) => {
+            const workerId = worker.workerId ?? worker.id;
+            const isContingent = (worker.workerType?.descriptor ?? '').toLowerCase().includes('contingent');
+
+            return {
+                id: workerId,
+                ...(isContingent ? { contingent_worker_id: workerId } : { employee_id: workerId }),
+                ...(worker.descriptor !== undefined && { name: worker.descriptor }),
+                ...(worker.person?.email !== undefined && { email: worker.person.email }),
+                ...(worker.person?.phone !== undefined && { phone: worker.person.phone }),
+                ...(worker.workerType?.descriptor !== undefined && { worker_type: worker.workerType.descriptor }),
+                ...(worker.primaryJob?.businessTitle !== undefined && { business_title: worker.primaryJob.businessTitle }),
+                ...(worker.primaryJob?.jobProfile?.descriptor !== undefined && { job_profile: worker.primaryJob.jobProfile.descriptor }),
+                ...(worker.primaryJob?.location?.descriptor !== undefined && { location: worker.primaryJob.location.descriptor })
+            };
+        });
+
+        const total = providerResponse.total ?? offset + items.length;
+        const hasMoreData = offset + items.length < total;
+
+        return {
+            items,
+            ...(hasMoreData && { next_cursor: String(offset + PAGE_SIZE) })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workday-cc/syncs/employees.ts
+++ b/integrations/workday-cc/syncs/employees.ts
@@ -1,0 +1,124 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST /workers resource doesn't expose first/last name components, hire/termination
+// dates, department, or manager references the way the SOAP Get_Workers response did.
+const EmployeeSchema = z.object({
+    id: z.string(),
+    worker_id: z.string().optional(),
+    employee_id: z.string().optional(),
+    contingent_worker_id: z.string().optional(),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    phone: z.string().optional(),
+    active: z.boolean().optional(),
+    job_title: z.string().optional(),
+    location: z.string().optional(),
+    employment_type: z.string().optional()
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderWorkerSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    workerId: z.string().optional(),
+    workerType: ProviderRelatedViewSchema.optional(),
+    person: z.object({ email: z.string().optional(), phone: z.string().optional() }).optional(),
+    primaryJob: z
+        .object({
+            businessTitle: z.string().optional(),
+            location: ProviderRelatedViewSchema.optional()
+        })
+        .optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderWorkerSchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync Workday employees and contingent workers.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    endpoints: [{ method: 'GET', path: '/syncs/employees' }],
+    models: {
+        Employee: EmployeeSchema
+    },
+
+    exec: async (nango) => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        await nango.trackDeletesStart('Employee');
+
+        let offset = 0;
+        let total = 0;
+
+        do {
+            await nango.log(`Fetching offset ${offset}`);
+
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/workers
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/workers`,
+                    params: { limit: PAGE_SIZE, offset, includeTerminatedWorkers: 'true' },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const workers = providerResponse.data ?? [];
+            total = providerResponse.total ?? workers.length;
+
+            const employees: z.infer<typeof EmployeeSchema>[] = workers.map((worker) => {
+                const workerId = worker.workerId ?? worker.id;
+                const isContingent = (worker.workerType?.descriptor ?? '').toLowerCase().includes('contingent');
+
+                return {
+                    id: workerId,
+                    worker_id: worker.id,
+                    ...(isContingent ? { contingent_worker_id: workerId } : { employee_id: workerId }),
+                    ...(worker.descriptor !== undefined && { name: worker.descriptor }),
+                    ...(worker.person?.email !== undefined && { email: worker.person.email }),
+                    ...(worker.person?.phone !== undefined && { phone: worker.person.phone }),
+                    ...(worker.primaryJob?.businessTitle !== undefined && { job_title: worker.primaryJob.businessTitle }),
+                    ...(worker.primaryJob?.location?.descriptor !== undefined && { location: worker.primaryJob.location.descriptor }),
+                    employment_type: isContingent ? 'Contingent Worker' : 'Employee'
+                };
+            });
+
+            if (employees.length > 0) {
+                await nango.batchSave(employees, 'Employee');
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('Employee');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/workday-cc/syncs/groups.ts
+++ b/integrations/workday-cc/syncs/groups.ts
@@ -1,0 +1,97 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST API only exposes Supervisory Organizations, unlike the SOAP Human
+// Resources API which covered security/matrix/company/cost-center organizations too.
+const GroupSchema = z.object({
+    id: z.string().describe('Supervisory organization ID'),
+    name: z.string(),
+    type: z.string().optional(),
+    inactive: z.boolean()
+});
+
+const ProviderOrganizationSchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderOrganizationSchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync Workday supervisory organizations as groups.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    syncType: 'full',
+    models: {
+        Group: GroupSchema
+    },
+    endpoints: [{ method: 'POST', path: '/syncs/groups' }],
+
+    exec: async (nango) => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // Blocker: Workday's supervisoryOrganizations resource does not support a modified_since
+        // filter. Full refresh with deletion tracking is required.
+        await nango.trackDeletesStart('Group');
+
+        let offset = 0;
+        let total = 0;
+
+        do {
+            await nango.log(`Fetching offset ${offset}`);
+
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/supervisoryOrganizations
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/supervisoryOrganizations`,
+                    params: { limit: PAGE_SIZE, offset, includeInactive: 'true' },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const organizations = providerResponse.data ?? [];
+            total = providerResponse.total ?? organizations.length;
+
+            const groups: z.infer<typeof GroupSchema>[] = organizations.map((org) => ({
+                id: org.id,
+                name: org.name ?? '',
+                type: 'Supervisory',
+                inactive: org.inactive ?? false
+            }));
+
+            if (groups.length > 0) {
+                await nango.batchSave(groups, 'Group');
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('Group');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/workday-cc/syncs/job-profiles.ts
+++ b/integrations/workday-cc/syncs/job-profiles.ts
@@ -1,0 +1,95 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// The jobProfiles list endpoint only returns a summary view (id/name/inactive) — management level,
+// job family, and job category are only available from the per-profile detail endpoint, which isn't
+// fetched here to avoid an N+1 call per profile on every sync run.
+const JobProfileSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    active: z.boolean()
+});
+
+const ProviderJobProfileSummarySchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderJobProfileSummarySchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync job profiles from Workday.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    models: {
+        JobProfile: JobProfileSchema
+    },
+
+    endpoints: [{ method: 'POST', path: '/syncs/job-profiles' }],
+
+    exec: async (nango) => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // Blocker: jobProfiles has no incremental filter; full refresh required.
+        await nango.trackDeletesStart('JobProfile');
+
+        let offset = 0;
+        let total = 0;
+
+        do {
+            await nango.log(`Fetching offset ${offset}`);
+
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/jobProfiles
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/jobProfiles`,
+                    params: { limit: PAGE_SIZE, offset, includeInactive: 'true' },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const summaries = providerResponse.data ?? [];
+            total = providerResponse.total ?? summaries.length;
+
+            const mapped: z.infer<typeof JobProfileSchema>[] = summaries.map((summary) => ({
+                id: summary.id,
+                name: summary.name ?? '',
+                active: summary.inactive !== true
+            }));
+
+            if (mapped.length > 0) {
+                await nango.batchSave(mapped, 'JobProfile');
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('JobProfile');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/workday-cc/syncs/locations.ts
+++ b/integrations/workday-cc/syncs/locations.ts
@@ -1,0 +1,94 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST API has no dedicated Location master-data resource; the "prompt values"
+// endpoint used for job-change location pickers is the closest available substitute (id/descriptor only).
+const LocationSchema = z.object({
+    id: z.string(),
+    name: z.string()
+});
+
+const ProviderLocationValueSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderLocationValueSchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync locations from Workday.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    endpoints: [
+        {
+            method: 'GET',
+            path: '/syncs/locations'
+        }
+    ],
+    models: {
+        Location: LocationSchema
+    },
+
+    exec: async (nango) => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        await nango.trackDeletesStart('Location');
+
+        let offset = 0;
+        let total = 0;
+
+        do {
+            await nango.log(`Fetching offset ${offset}`);
+
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/values~jobChangesGroup~locations
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/values/jobChangesGroup/locations`,
+                    params: { limit: PAGE_SIZE, offset },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const values = providerResponse.data ?? [];
+            total = providerResponse.total ?? values.length;
+
+            const locations: z.infer<typeof LocationSchema>[] = values.map((location) => ({
+                id: location.id,
+                name: location.descriptor ?? ''
+            }));
+
+            if (locations.length > 0) {
+                await nango.batchSave(locations, 'Location');
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('Location');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/workday-cc/syncs/organizations.ts
+++ b/integrations/workday-cc/syncs/organizations.ts
@@ -1,0 +1,99 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST API only exposes Supervisory Organizations, unlike the SOAP Human
+// Resources API which covered every organization type (company, cost center, matrix, etc.) — so
+// this sync and the "groups" sync read from the same underlying resource.
+const OrganizationSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    type: z.string().optional(),
+    inactive: z.boolean(),
+    external_id: z.string().optional()
+});
+
+const ProviderOrganizationSchema = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    code: z.string().optional(),
+    inactive: z.boolean().optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderOrganizationSchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync organizations from Workday.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    endpoints: [{ method: 'GET', path: '/syncs/organizations' }],
+    models: {
+        Organization: OrganizationSchema
+    },
+
+    exec: async (nango) => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // Blocker: Workday's supervisoryOrganizations resource does not support modified_since filtering.
+        await nango.trackDeletesStart('Organization');
+
+        let offset = 0;
+        let total = 0;
+
+        do {
+            await nango.log(`Fetching offset ${offset}`);
+
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/supervisoryOrganizations
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/supervisoryOrganizations`,
+                    params: { limit: PAGE_SIZE, offset, includeInactive: 'true' },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const organizations = providerResponse.data ?? [];
+            total = providerResponse.total ?? organizations.length;
+
+            const mapped: z.infer<typeof OrganizationSchema>[] = organizations.map((org) => ({
+                id: org.id,
+                name: org.name ?? '',
+                type: 'Supervisory',
+                inactive: org.inactive ?? false,
+                external_id: org.code
+            }));
+
+            if (mapped.length > 0) {
+                await nango.batchSave(mapped, 'Organization');
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('Organization');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/workday-cc/syncs/positions.ts
+++ b/integrations/workday-cc/syncs/positions.ts
@@ -1,0 +1,116 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST API models a filled/vacant position as a "Job" resource. It doesn't expose
+// an effective date, open/closed status, or pay-rate detail the way the SOAP Position resource did.
+const PositionSchema = z.object({
+    id: z.string().describe('Job (position) ID'),
+    name: z.string().optional().describe('Business title'),
+    job_profile_id: z.string().optional().describe('Job profile reference ID'),
+    job_profile_name: z.string().optional().describe('Job profile name'),
+    location_id: z.string().optional().describe('Location reference ID'),
+    location_name: z.string().optional().describe('Location name'),
+    supervisory_org_id: z.string().optional().describe('Supervisory organization reference ID'),
+    supervisory_org_name: z.string().optional().describe('Supervisory organization name'),
+    worker_id: z.string().optional().describe('Assigned worker ID'),
+    worker_name: z.string().optional().describe('Assigned worker name')
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderJobSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    businessTitle: z.string().optional(),
+    location: ProviderRelatedViewSchema.optional(),
+    worker: ProviderRelatedViewSchema.optional(),
+    jobProfile: ProviderRelatedViewSchema.optional(),
+    supervisoryOrganization: ProviderRelatedViewSchema.optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderJobSchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync positions from Workday.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    endpoints: [{ method: 'GET', path: '/syncs/positions' }],
+    models: {
+        Position: PositionSchema
+    },
+
+    exec: async (nango) => {
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // Blocker: Workday's jobs resource does not support changed-since filtering.
+        await nango.trackDeletesStart('Position');
+
+        let offset = 0;
+        let total = 0;
+
+        do {
+            await nango.log(`Fetching offset ${offset}`);
+
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/jobs
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/jobs`,
+                    params: { limit: PAGE_SIZE, offset },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const jobs = providerResponse.data ?? [];
+            total = providerResponse.total ?? jobs.length;
+
+            const mapped: z.infer<typeof PositionSchema>[] = jobs.map((job) => ({
+                id: job.id,
+                name: job.businessTitle ?? job.descriptor ?? undefined,
+                job_profile_id: job.jobProfile?.id,
+                job_profile_name: job.jobProfile?.descriptor,
+                location_id: job.location?.id,
+                location_name: job.location?.descriptor,
+                supervisory_org_id: job.supervisoryOrganization?.id,
+                supervisory_org_name: job.supervisoryOrganization?.descriptor,
+                worker_id: job.worker?.id,
+                worker_name: job.worker?.descriptor
+            }));
+
+            if (mapped.length > 0) {
+                await nango.batchSave(mapped, 'Position');
+            }
+
+            offset += PAGE_SIZE;
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('Position');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/workday-cc/syncs/workers.ts
+++ b/integrations/workday-cc/syncs/workers.ts
@@ -1,0 +1,135 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const STAFFING_API_VERSION = 'v6';
+const PAGE_SIZE = 100;
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt < retries; attempt++) {
+        // @allowTryCatch
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt === retries - 1) throw err;
+            await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+        }
+    }
+    throw new Error('unreachable');
+}
+
+// Workday's Staffing REST /workers resource doesn't expose hire/termination dates, manager,
+// company, cost-center, or department references the way the SOAP Get_Workers response did.
+const WorkerSchema = z.object({
+    id: z.string().describe('Worker unique identifier'),
+    employee_id: z.string().optional().describe('Employee ID from Workday'),
+    contingent_worker_id: z.string().optional().describe('Contingent Worker ID from Workday'),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    phone: z.string().optional(),
+    worker_type: z.string().optional().describe('Employee or Contingent Worker'),
+    business_title: z.string().optional(),
+    job_profile_id: z.string().optional(),
+    location_id: z.string().optional()
+});
+
+const CheckpointSchema = z.object({
+    offset: z.number()
+});
+
+const ProviderRelatedViewSchema = z.object({
+    id: z.string().optional(),
+    descriptor: z.string().optional()
+});
+
+const ProviderWorkerSchema = z.object({
+    id: z.string(),
+    descriptor: z.string().optional(),
+    workerId: z.string().optional(),
+    workerType: ProviderRelatedViewSchema.optional(),
+    person: z.object({ email: z.string().optional(), phone: z.string().optional() }).optional(),
+    primaryJob: z
+        .object({
+            businessTitle: z.string().optional(),
+            jobProfile: ProviderRelatedViewSchema.optional(),
+            location: ProviderRelatedViewSchema.optional()
+        })
+        .optional()
+});
+
+const ProviderResponseSchema = z.object({
+    data: z.array(ProviderWorkerSchema).optional(),
+    total: z.number().optional()
+});
+
+const sync = createSync({
+    description: 'Sync workers from Workday.',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    endpoints: [{ method: 'GET', path: '/syncs/workers' }],
+    checkpoint: CheckpointSchema,
+    models: {
+        Worker: WorkerSchema
+    },
+
+    exec: async (nango) => {
+        const checkpointRaw = await nango.getCheckpoint();
+        const checkpoint = checkpointRaw || { offset: 0 };
+        const connection = await nango.getConnection();
+        const tenant = connection.connection_config['tenant'];
+
+        // Blocker: Workday's workers resource does not support modified_since or updated_after
+        // filters. It only supports pagination via limit/offset. Therefore, we perform a full
+        // refresh with trackDeletesStart/trackDeletesEnd.
+        await nango.trackDeletesStart('Worker');
+
+        let offset = checkpoint.offset;
+        let total = 0;
+
+        do {
+            // https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#staffing/v6/workers
+            const response = await withRetry(() =>
+                nango.get({
+                    endpoint: `/staffing/${STAFFING_API_VERSION}/${tenant}/workers`,
+                    params: { limit: PAGE_SIZE, offset, includeTerminatedWorkers: 'true' },
+                    retries: 3
+                })
+            );
+
+            const providerResponse = ProviderResponseSchema.parse(response.data);
+            const workers = providerResponse.data ?? [];
+            total = providerResponse.total ?? workers.length;
+
+            const mappedWorkers: z.infer<typeof WorkerSchema>[] = workers.map((worker) => {
+                const workerId = worker.workerId ?? worker.id;
+                const isContingent = (worker.workerType?.descriptor ?? '').toLowerCase().includes('contingent');
+
+                return {
+                    id: workerId,
+                    ...(isContingent ? { contingent_worker_id: workerId } : { employee_id: workerId }),
+                    ...(worker.descriptor !== undefined && { name: worker.descriptor }),
+                    ...(worker.person?.email !== undefined && { email: worker.person.email }),
+                    ...(worker.person?.phone !== undefined && { phone: worker.person.phone }),
+                    ...(worker.workerType?.descriptor !== undefined && { worker_type: worker.workerType.descriptor }),
+                    ...(worker.primaryJob?.businessTitle !== undefined && { business_title: worker.primaryJob.businessTitle }),
+                    ...(worker.primaryJob?.jobProfile?.id !== undefined && { job_profile_id: worker.primaryJob.jobProfile.id }),
+                    ...(worker.primaryJob?.location?.id !== undefined && { location_id: worker.primaryJob.location.id })
+                };
+            });
+
+            if (mappedWorkers.length > 0) {
+                await nango.batchSave(mappedWorkers, 'Worker');
+            }
+
+            offset += PAGE_SIZE;
+            if (offset < total) {
+                await nango.saveCheckpoint({ offset });
+            }
+        } while (offset < total);
+
+        await nango.trackDeletesEnd('Worker');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `workday-cc` integration using Workday Staffing API v6 with actions and syncs for workers, positions, organizations, locations, and job profiles. Schemas are added to `integrations/.nango/nango.json` and modules registered in `integrations/index.ts` and `internal/flows.zero.json`.

- **New Features**
  - Actions: `get-*` and `list-*` for job profiles, locations, organizations, positions, workers.
  - Syncs: employees, groups, job-profiles, locations, organizations, positions, workers.
  - Pagination via `cursor` and basic retries; outputs validated with `zod`.
  - API constraints handled: locations via prompt values, supervisory orgs only, positions modeled as jobs, limited worker fields.

<sup>Written for commit 17c7938b5ad01e569478ed73c2e0ca982094457f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

