### PR TITLE
fix: linear oauth scopes v2

### DIFF
--- a/integrations/linear/actions/add-issue-label.ts
+++ b/integrations/linear/actions/add-issue-label.ts
@@ -44,10 +44,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Attach a label to a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/add-issue-label.ts
+++ b/integrations/linear/actions/add-issue-label.ts
@@ -51,7 +51,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers/api-reference/graphql/mutations#issue-add-label
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/archive-cycle.ts
+++ b/integrations/linear/actions/archive-cycle.ts
@@ -50,7 +50,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers/api-ops/cycle-archive
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/archive-cycle.ts
+++ b/integrations/linear/actions/archive-cycle.ts
@@ -43,7 +43,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Archive a Linear cycle.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/archive-issue.ts
+++ b/integrations/linear/actions/archive-issue.ts
@@ -53,7 +53,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Archive a Linear issue so it is removed from active workflows.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/create-attachment.ts
+++ b/integrations/linear/actions/create-attachment.ts
@@ -55,7 +55,7 @@ const action = createAction({
     version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues:create'],
+    scopes: ['issues:create', 'comments:create'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const variables = {

--- a/integrations/linear/actions/create-attachment.ts
+++ b/integrations/linear/actions/create-attachment.ts
@@ -52,10 +52,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create an attachment on a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues'],
+    scopes: ['issues:create'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const variables = {

--- a/integrations/linear/actions/create-comment.ts
+++ b/integrations/linear/actions/create-comment.ts
@@ -67,10 +67,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a comment on a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['write:comments'],
+    scopes: ['comments:create'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const mutation = `

--- a/integrations/linear/actions/create-comment.ts
+++ b/integrations/linear/actions/create-comment.ts
@@ -108,7 +108,7 @@ const action = createAction({
         };
 
         const response = await nango.post({
-            // https://linear.app/developers/api-reference/graphql
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: mutation,

--- a/integrations/linear/actions/create-cycle.ts
+++ b/integrations/linear/actions/create-cycle.ts
@@ -56,10 +56,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a cycle for a Linear team.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['cycles'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const variables = {

--- a/integrations/linear/actions/create-issue-label.ts
+++ b/integrations/linear/actions/create-issue-label.ts
@@ -45,7 +45,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a Linear issue label.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/create-issue-label.ts
+++ b/integrations/linear/actions/create-issue-label.ts
@@ -77,7 +77,7 @@ const action = createAction({
         };
 
         const response = await nango.post({
-            // https://linear.app/developers/api/graphql
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query,

--- a/integrations/linear/actions/create-issue-relation.ts
+++ b/integrations/linear/actions/create-issue-relation.ts
@@ -50,7 +50,7 @@ const action = createAction({
     scopes: ['write'], // Linear GraphQL mutations require a write-capable token
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        // https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/create-issue-relation.ts
+++ b/integrations/linear/actions/create-issue-relation.ts
@@ -44,7 +44,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a relationship between two Linear issues.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'], // Linear GraphQL mutations require a write-capable token

--- a/integrations/linear/actions/create-issue.ts
+++ b/integrations/linear/actions/create-issue.ts
@@ -156,7 +156,7 @@ const action = createAction({
             }
         `;
 
-        // https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/create-issue.ts
+++ b/integrations/linear/actions/create-issue.ts
@@ -85,10 +85,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a new Linear issue.',
-    version: '3.0.1',
+    version: '3.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['write'],
+    scopes: ['issues:create'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const variables: Record<string, unknown> = {

--- a/integrations/linear/actions/create-project.ts
+++ b/integrations/linear/actions/create-project.ts
@@ -92,7 +92,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a Linear project.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/delete-attachment.ts
+++ b/integrations/linear/actions/delete-attachment.ts
@@ -38,10 +38,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Delete an attachment from a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/delete-attachment.ts
+++ b/integrations/linear/actions/delete-attachment.ts
@@ -45,7 +45,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers/attachments
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/delete-comment.ts
+++ b/integrations/linear/actions/delete-comment.ts
@@ -19,7 +19,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Delete a comment from a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/delete-comment.ts
+++ b/integrations/linear/actions/delete-comment.ts
@@ -26,7 +26,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: 'mutation CommentDelete($id: String!) { commentDelete(id: $id) { success } }',

--- a/integrations/linear/actions/delete-issue-label.ts
+++ b/integrations/linear/actions/delete-issue-label.ts
@@ -23,10 +23,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Delete a Linear issue label.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['admin'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/delete-issue-label.ts
+++ b/integrations/linear/actions/delete-issue-label.ts
@@ -30,7 +30,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: 'mutation IssueLabelDelete($id: String!) { issueLabelDelete(id: $id) { entityId lastSyncId success } }',

--- a/integrations/linear/actions/delete-issue-relation.ts
+++ b/integrations/linear/actions/delete-issue-relation.ts
@@ -19,10 +19,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Delete a relationship between two Linear issues.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/delete-issue.ts
+++ b/integrations/linear/actions/delete-issue.ts
@@ -45,7 +45,7 @@ const action = createAction({
     scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        // https://linear.app/developers/api-reference/GraphQL/mutations/issueDelete
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/delete-issue.ts
+++ b/integrations/linear/actions/delete-issue.ts
@@ -39,9 +39,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Delete a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         // https://linear.app/developers/api-reference/GraphQL/mutations/issueDelete

--- a/integrations/linear/actions/get-attachment.ts
+++ b/integrations/linear/actions/get-attachment.ts
@@ -106,7 +106,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/attachments
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/get-attachment.ts
+++ b/integrations/linear/actions/get-attachment.ts
@@ -99,10 +99,10 @@ const GraphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear attachment by attachment ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/get-comment.ts
+++ b/integrations/linear/actions/get-comment.ts
@@ -48,10 +48,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear comment by comment ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: [],
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const query = `

--- a/integrations/linear/actions/get-comment.ts
+++ b/integrations/linear/actions/get-comment.ts
@@ -74,7 +74,7 @@ const action = createAction({
             }
         `;
 
-        // https://linear.app/developers
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/get-cycle.ts
+++ b/integrations/linear/actions/get-cycle.ts
@@ -40,7 +40,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: 'query Cycle($id: String!) { cycle(id: $id) { id team { id name } progress startsAt endsAt } }',

--- a/integrations/linear/actions/get-cycle.ts
+++ b/integrations/linear/actions/get-cycle.ts
@@ -33,9 +33,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear cycle by cycle ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/get-issue-label.ts
+++ b/integrations/linear/actions/get-issue-label.ts
@@ -37,7 +37,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 const action = createAction({
     description: 'Retrieve a Linear issue label by label ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/get-issue-label.ts
+++ b/integrations/linear/actions/get-issue-label.ts
@@ -58,7 +58,7 @@ const action = createAction({
             }
         `;
 
-        // https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/get-issue.ts
+++ b/integrations/linear/actions/get-issue.ts
@@ -98,10 +98,10 @@ const GraphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear issue by issue ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues:read'],
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/get-project.ts
+++ b/integrations/linear/actions/get-project.ts
@@ -47,7 +47,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear project by project ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/get-team.ts
+++ b/integrations/linear/actions/get-team.ts
@@ -57,7 +57,7 @@ const GraphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear team by team ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/get-user.ts
+++ b/integrations/linear/actions/get-user.ts
@@ -31,7 +31,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear user by user ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/get-user.ts
+++ b/integrations/linear/actions/get-user.ts
@@ -37,7 +37,7 @@ const action = createAction({
     scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        // https://developers.linear.app/docs/graphql/overview
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/get-viewer.ts
+++ b/integrations/linear/actions/get-viewer.ts
@@ -42,7 +42,7 @@ const action = createAction({
 
     exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers/api/graphql#viewer
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/get-viewer.ts
+++ b/integrations/linear/actions/get-viewer.ts
@@ -35,10 +35,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve the currently authenticated Linear user.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['viewer'],
+    scopes: ['read'],
 
     exec: async (nango, _input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/get-workflow-state.ts
+++ b/integrations/linear/actions/get-workflow-state.ts
@@ -52,7 +52,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Retrieve a Linear workflow state by state ID.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/get-workflow-state.ts
+++ b/integrations/linear/actions/get-workflow-state.ts
@@ -59,7 +59,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers/api-reference/GraphQL-queries/workflow-state
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/list-attachments.ts
+++ b/integrations/linear/actions/list-attachments.ts
@@ -117,7 +117,7 @@ const action = createAction({
             }
         `;
 
-        // https://linear.app/developers/graphql
+        // https://linear.app/developers/attachments
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/list-attachments.ts
+++ b/integrations/linear/actions/list-attachments.ts
@@ -67,10 +67,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'List Linear attachments with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues'],
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const query = `

--- a/integrations/linear/actions/list-comments.ts
+++ b/integrations/linear/actions/list-comments.ts
@@ -115,7 +115,7 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query,

--- a/integrations/linear/actions/list-comments.ts
+++ b/integrations/linear/actions/list-comments.ts
@@ -60,7 +60,7 @@ const GraphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'List Linear comments with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/list-cycles.ts
+++ b/integrations/linear/actions/list-cycles.ts
@@ -58,9 +58,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'List Linear cycles with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const query = `

--- a/integrations/linear/actions/list-issue-labels.ts
+++ b/integrations/linear/actions/list-issue-labels.ts
@@ -80,7 +80,7 @@ const action = createAction({
             variables['orderBy'] = input.orderBy;
         }
 
-        // https://developers.linear.app/docs/graphql/working-with-the-graphql-api/pagination
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/list-issue-labels.ts
+++ b/integrations/linear/actions/list-issue-labels.ts
@@ -59,7 +59,7 @@ const GraphQLIssueLabelsResponseSchema = z.object({
 
 const action = createAction({
     description: 'List Linear issue labels with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/list-issues.ts
+++ b/integrations/linear/actions/list-issues.ts
@@ -72,10 +72,10 @@ const GraphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'List Linear issues with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues:read'],
+    scopes: ['read'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const query = `

--- a/integrations/linear/actions/list-issues.ts
+++ b/integrations/linear/actions/list-issues.ts
@@ -131,7 +131,7 @@ const action = createAction({
             variables['filter'] = input.filter;
         }
 
-        // https://linear.app/developers/api-graphql
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/list-projects.ts
+++ b/integrations/linear/actions/list-projects.ts
@@ -67,7 +67,7 @@ const RawProjectSchema = z.object({
 
 const action = createAction({
     description: 'List Linear projects with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/list-projects.ts
+++ b/integrations/linear/actions/list-projects.ts
@@ -108,7 +108,7 @@ const action = createAction({
             }
         `;
 
-        // https://linear.app/developers
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/list-teams.ts
+++ b/integrations/linear/actions/list-teams.ts
@@ -47,7 +47,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'List Linear teams available to the authenticated user.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/list-users.ts
+++ b/integrations/linear/actions/list-users.ts
@@ -66,7 +66,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'List Linear users with filtering and pagination.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/list-workflow-states.ts
+++ b/integrations/linear/actions/list-workflow-states.ts
@@ -59,7 +59,7 @@ const ListOutputSchema = z.object({
 
 const action = createAction({
     description: 'List Linear workflow states across teams.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: ListOutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/remove-issue-label.ts
+++ b/integrations/linear/actions/remove-issue-label.ts
@@ -46,7 +46,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers/docs/graphql/working-with-the-graphql-api
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/remove-issue-label.ts
+++ b/integrations/linear/actions/remove-issue-label.ts
@@ -39,7 +39,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a label from a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/resolve-comment.ts
+++ b/integrations/linear/actions/resolve-comment.ts
@@ -36,7 +36,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Resolve a Linear comment thread.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/resolve-comment.ts
+++ b/integrations/linear/actions/resolve-comment.ts
@@ -43,7 +43,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/search-issues.ts
+++ b/integrations/linear/actions/search-issues.ts
@@ -90,7 +90,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Search Linear issues with full-text query support.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['read'],

--- a/integrations/linear/actions/unarchive-issue.ts
+++ b/integrations/linear/actions/unarchive-issue.ts
@@ -38,7 +38,7 @@ const action = createAction({
     scopes: ['write'],
 
     exec: async (nango, input) => {
-        // https://linear.app/developers
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             retries: 3,

--- a/integrations/linear/actions/unarchive-issue.ts
+++ b/integrations/linear/actions/unarchive-issue.ts
@@ -32,9 +32,10 @@ const graphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'Restore an archived Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: inputSchema,
     output: outputSchema,
+    scopes: ['write'],
 
     exec: async (nango, input) => {
         // https://linear.app/developers

--- a/integrations/linear/actions/unarchive-project.ts
+++ b/integrations/linear/actions/unarchive-project.ts
@@ -39,7 +39,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Restore an archived Linear project.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/actions/unarchive-project.ts
+++ b/integrations/linear/actions/unarchive-project.ts
@@ -46,7 +46,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/unresolve-comment.ts
+++ b/integrations/linear/actions/unresolve-comment.ts
@@ -31,7 +31,7 @@ const action = createAction({
     scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        // https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/unresolve-comment.ts
+++ b/integrations/linear/actions/unresolve-comment.ts
@@ -25,10 +25,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Reopen a previously resolved Linear comment thread.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['comments'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         // https://developers.linear.app/docs/graphql/working-with-the-graphql-api

--- a/integrations/linear/actions/update-comment.ts
+++ b/integrations/linear/actions/update-comment.ts
@@ -42,7 +42,7 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `mutation UpdateComment($id: String!, $body: String!) {

--- a/integrations/linear/actions/update-comment.ts
+++ b/integrations/linear/actions/update-comment.ts
@@ -35,10 +35,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update a comment on a Linear issue.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['comments'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const response = await nango.post({

--- a/integrations/linear/actions/update-cycle.ts
+++ b/integrations/linear/actions/update-cycle.ts
@@ -70,9 +70,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update an existing Linear cycle.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const cycleInput = {

--- a/integrations/linear/actions/update-issue-label.ts
+++ b/integrations/linear/actions/update-issue-label.ts
@@ -75,7 +75,7 @@ const action = createAction({
             }
         };
 
-        // https://linear.app/developers/graphql/mutations#issueLabelUpdate
+        // https://linear.app/developers/graphql
         const response = await nango.post({
             endpoint: '/graphql',
             data: {

--- a/integrations/linear/actions/update-issue-label.ts
+++ b/integrations/linear/actions/update-issue-label.ts
@@ -46,7 +46,8 @@ const action = createAction({
     description: 'Update an existing Linear issue label.',
     input: InputSchema,
     output: OutputSchema,
-    version: '1.0.1',
+    version: '1.0.2',
+    scopes: ['write'],
     exec: async (nango, input) => {
         const mutation = `
             mutation UpdateIssueLabel($id: String!, $input: IssueLabelUpdateInput!) {

--- a/integrations/linear/actions/update-issue-relation.ts
+++ b/integrations/linear/actions/update-issue-relation.ts
@@ -51,10 +51,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update fields on an existing Linear issue relation.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const variables: {

--- a/integrations/linear/actions/update-issue-relation.ts
+++ b/integrations/linear/actions/update-issue-relation.ts
@@ -80,7 +80,7 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://linear.app/developers/api-reference/graphql/issue-relation-update
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/update-issue.ts
+++ b/integrations/linear/actions/update-issue.ts
@@ -83,10 +83,10 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update fields on an existing Linear issue',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
-    scopes: ['issues'],
+    scopes: ['write'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         const updateInput: {

--- a/integrations/linear/actions/update-project.ts
+++ b/integrations/linear/actions/update-project.ts
@@ -90,7 +90,7 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             endpoint: '/graphql',
             data: {
                 query: `

--- a/integrations/linear/actions/update-project.ts
+++ b/integrations/linear/actions/update-project.ts
@@ -66,7 +66,7 @@ const GraphQLResponseSchema = z.object({
 
 const action = createAction({
     description: 'Update an existing Linear project.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['write'],

--- a/integrations/linear/syncs/cycles.ts
+++ b/integrations/linear/syncs/cycles.ts
@@ -82,9 +82,10 @@ query Cycles($first: Int, $after: String, $filter: CycleFilter, $orderBy: Pagina
 
 const sync = createSync({
     description: 'Sync Linear cycles for planning and iteration tracking.',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: true,
+    scopes: ['read'],
     endpoints: [{ method: 'GET', path: '/syncs/cycles' }],
     metadata: MetadataSchema,
     checkpoint: CheckpointSchema,

--- a/integrations/linear/syncs/cycles.ts
+++ b/integrations/linear/syncs/cycles.ts
@@ -121,7 +121,7 @@ const sync = createSync({
                 variables['filter'] = filter;
             }
 
-            // https://linear.app/developers
+            // https://linear.app/developers/graphql
             const response = await nango.post({
                 endpoint: '/graphql',
                 data: {

--- a/integrations/linear/syncs/issue-labels.ts
+++ b/integrations/linear/syncs/issue-labels.ts
@@ -61,10 +61,11 @@ type IssueLabelsVariables = {
 
 const sync = createSync({
     description: 'Sync Linear issue labels across teams.',
-    version: '1.0.0',
+    version: '1.0.1',
     endpoints: [{ method: 'POST', path: '/syncs/issue-labels' }],
     frequency: 'every hour',
     autoStart: true,
+    scopes: ['read'],
     checkpoint: CheckpointSchema,
     metadata: MetadataSchema,
     models: {

--- a/integrations/linear/syncs/issues.ts
+++ b/integrations/linear/syncs/issues.ts
@@ -172,7 +172,7 @@ const sync = createSync({
                 }
             `;
 
-            // https://linear.app/developers/api/graphql
+            // https://linear.app/developers/graphql
             const response = await nango.post({
                 endpoint: '/graphql',
                 data: {

--- a/integrations/linear/syncs/issues.ts
+++ b/integrations/linear/syncs/issues.ts
@@ -74,9 +74,10 @@ const CheckpointSchema = z.object({
 
 const sync = createSync({
     description: 'Sync Linear issues with state, assignee, labels, project, and cycle data.',
-    version: '3.0.0',
+    version: '3.0.1',
     frequency: 'every 5 minutes',
     autoStart: true,
+    scopes: ['read'],
     endpoints: [
         {
             method: 'POST',

--- a/integrations/linear/syncs/milestones.ts
+++ b/integrations/linear/syncs/milestones.ts
@@ -136,7 +136,7 @@ const sync = createSync({
             `;
 
             const config: ProxyConfiguration = {
-                // https://linear.app/developers/docs/graphql/working-with-the-graphql-api
+                // https://linear.app/developers/graphql
                 endpoint: '/graphql',
                 data: {
                     query,
@@ -145,7 +145,7 @@ const sync = createSync({
                 retries: 3
             };
 
-            // https://linear.app/developers/docs/graphql/working-with-the-graphql-api
+            // https://linear.app/developers/graphql
             const response = await nango.post(config);
 
             const parsed = ResponseSchema.safeParse(response.data);

--- a/integrations/linear/syncs/milestones.ts
+++ b/integrations/linear/syncs/milestones.ts
@@ -69,9 +69,10 @@ type MilestonesVariables = {
 
 const sync = createSync({
     description: 'Sync Linear milestones for project planning.',
-    version: '3.0.0',
+    version: '3.0.1',
     frequency: 'every 6min',
     autoStart: true,
+    scopes: ['read'],
     checkpoint: CheckpointSchema,
     endpoints: [
         {

--- a/integrations/linear/syncs/projects.ts
+++ b/integrations/linear/syncs/projects.ts
@@ -132,7 +132,7 @@ const sync = createSync({
             };
 
             const response = await nango.post({
-                // https://linear.app/developers
+                // https://linear.app/developers/graphql
                 endpoint: '/graphql',
                 data: {
                     query: `

--- a/integrations/linear/syncs/projects.ts
+++ b/integrations/linear/syncs/projects.ts
@@ -91,9 +91,10 @@ const LinearProjectsResponseSchema = z.object({
 
 const sync = createSync({
     description: 'Sync Linear projects with lead, status, and progress fields',
-    version: '3.0.0',
+    version: '3.0.1',
     frequency: 'every hour',
     autoStart: true,
+    scopes: ['read'],
     checkpoint: CheckpointSchema,
     models: {
         Project: ProjectSchema

--- a/integrations/linear/syncs/roadmaps.ts
+++ b/integrations/linear/syncs/roadmaps.ts
@@ -64,9 +64,10 @@ const RoadmapsResponseSchema = z.object({
 
 const sync = createSync({
     description: 'Sync Linear roadmaps and their project relationships.',
-    version: '3.0.0',
+    version: '3.0.1',
     frequency: 'every hour',
     autoStart: true,
+    scopes: ['read'],
     endpoints: [
         {
             method: 'POST',

--- a/integrations/linear/syncs/teams.ts
+++ b/integrations/linear/syncs/teams.ts
@@ -86,7 +86,7 @@ const sync = createSync({
             }
 
             const response = await nango.post({
-                // https://linear.app/developers
+                // https://linear.app/developers/graphql
                 endpoint: '/graphql',
                 data: {
                     query: `

--- a/integrations/linear/syncs/teams.ts
+++ b/integrations/linear/syncs/teams.ts
@@ -52,9 +52,10 @@ type TeamVariables = {
 
 const sync = createSync({
     description: 'Sync Linear teams visible to the authenticated user.',
-    version: '3.0.0',
+    version: '3.0.1',
     frequency: 'every hour',
     autoStart: true,
+    scopes: ['read'],
     checkpoint: CheckpointSchema,
     endpoints: [{ method: 'GET', path: '/syncs/teams' }],
     models: {

--- a/integrations/linear/syncs/users.ts
+++ b/integrations/linear/syncs/users.ts
@@ -45,9 +45,10 @@ const GraphQLResponseSchema = z.object({
 
 const sync = createSync({
     description: 'Sync Linear users with profile and active state fields.',
-    version: '3.0.0',
+    version: '3.0.1',
     frequency: 'every 5 minutes',
     autoStart: true,
+    scopes: ['read'],
     endpoints: [{ method: 'GET', path: '/syncs/users' }],
     checkpoint: CheckpointSchema,
     models: {

--- a/integrations/linear/syncs/users.ts
+++ b/integrations/linear/syncs/users.ts
@@ -73,7 +73,7 @@ const sync = createSync({
         const filter = checkpoint?.updated_after ? { updatedAt: { gte: checkpoint.updated_after } } : undefined;
 
         while (continuePagination) {
-            // https://linear.app/developers/api-reference/graphql#query-users
+            // https://linear.app/developers/graphql
             const response = await nango.post({
                 endpoint: '/graphql',
                 data: {

--- a/integrations/linear/syncs/workflow-states.ts
+++ b/integrations/linear/syncs/workflow-states.ts
@@ -112,7 +112,7 @@ const sync = createSync({
                 ...(Object.keys(filter).length > 0 ? { filter } : {})
             };
 
-            // https://linear.app/developers/api/workflow-states
+            // https://linear.app/developers/graphql
             const response = await nango.post({
                 endpoint: '/graphql',
                 data: {

--- a/integrations/linear/syncs/workflow-states.ts
+++ b/integrations/linear/syncs/workflow-states.ts
@@ -59,9 +59,10 @@ const GraphQLResponseSchema = z.object({
 
 const sync = createSync({
     description: 'Sync Linear workflow states across teams.',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: true,
+    scopes: ['read'],
     checkpoint: CheckpointSchema,
     models: {
         WorkflowState: WorkflowStateSchema


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid OAuth scopes across the Linear integration and aligns them with Linear’s current GraphQL permissions. This resolves failing actions/syncs and enforces correct least‑privilege access.

- **Bug Fixes**
  - Standardized scopes: queries use `read`, mutations use `write`, and creations use `issues:create`/`comments:create` where needed. Added `comments:create` to the create‑attachment action.
  - Added missing scopes to several actions and all syncs; bumped versions to propagate changes.
  - Synced internal manifests (`integrations/.nango/nango.json`, `internal/flows.zero.json`) and updated links to https://linear.app/developers/graphql.

- **Migration**
  - Existing Linear connections may need re-auth to grant new scopes (`read`, `write`, `issues:create`, `comments:create`).
  - No API contract changes; only scope requirements were corrected.

<sup>Written for commit 47f02a832fdb088344234c572a1249a233a9353b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

