### PR TITLE
feat: refactor Google Ads functions

### DIFF
--- a/integrations/google-ads/actions/create-ad-group-ad.ts
+++ b/integrations/google-ads/actions/create-ad-group-ad.ts
@@ -21,8 +21,7 @@ const InputSchema = z.object({
     headlines: z.array(z.string()).min(3).describe('At least 3 headlines for the responsive search ad.'),
     descriptions: z.array(z.string()).min(2).describe('At least 2 descriptions for the responsive search ad.'),
     finalUrls: z.array(z.string()).min(1).describe('Final URLs for the ad.'),
-    status: z.enum(['ENABLED', 'PAUSED']).optional().describe('Ad status. Defaults to ENABLED.'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    status: z.enum(['ENABLED', 'PAUSED']).optional().describe('Ad status. Defaults to ENABLED.')
 });
 
 const OutputSchema = z.object({
@@ -33,12 +32,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create an ad inside an ad group.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const status = input.status ?? 'ENABLED';
 
         const requestBody = {
@@ -63,7 +71,7 @@ const action = createAction({
         const response = await nango.post({
             endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/adGroupAds:mutate`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: requestBody,

--- a/integrations/google-ads/actions/create-ad-group-ad.ts
+++ b/integrations/google-ads/actions/create-ad-group-ad.ts
@@ -32,7 +32,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create an ad inside an ad group.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -69,7 +69,7 @@ const action = createAction({
 
         // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/adGroupAds:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/adGroupAds:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/create-ad-group-ad.ts
+++ b/integrations/google-ads/actions/create-ad-group-ad.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const MutateResponseSchema = z.object({
     results: z
@@ -38,9 +39,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-ad-group.ts
+++ b/integrations/google-ads/actions/create-ad-group.ts
@@ -55,7 +55,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create an ad group in an existing Google Ads campaign',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -94,9 +94,9 @@ const action = createAction({
             responseContentType: 'MUTABLE_RESOURCE'
         };
 
-        // https://developers.google.com/google-ads/api/rest/reference/rest/v21/customers/adGroups/mutate
+        // https://developers.google.com/google-ads/api/rest/reference/rest/v25/customers/adGroups/mutate
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(customerId)}/adGroups:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(customerId)}/adGroups:mutate`,
             data: requestBody,
             headers: {
                 'developer-token': developerToken,

--- a/integrations/google-ads/actions/create-ad-group.ts
+++ b/integrations/google-ads/actions/create-ad-group.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     campaign: z.string().describe('Campaign resource name. Example: "customers/123/campaigns/456"'),
@@ -61,9 +62,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-ad-group.ts
+++ b/integrations/google-ads/actions/create-ad-group.ts
@@ -10,8 +10,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -56,12 +55,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create an ad group in an existing Google Ads campaign',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const campaignParts = input.campaign.split('/');
         const customerId = campaignParts[1];
         if (!customerId || campaignParts.length < 4) {
@@ -91,7 +99,7 @@ const action = createAction({
             endpoint: `v21/customers/${encodeURIComponent(customerId)}/adGroups:mutate`,
             data: requestBody,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             retries: 3

--- a/integrations/google-ads/actions/create-campaign-budget.ts
+++ b/integrations/google-ads/actions/create-campaign-budget.ts
@@ -36,7 +36,7 @@ const PartialFailureErrorSchema = z.object({
 
 const action = createAction({
     description: 'Create a campaign budget for one or more campaigns.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -52,8 +52,8 @@ const action = createAction({
         }
 
         const config: ProxyConfiguration = {
-            // https://developers.google.com/google-ads/api/reference/rpc/v21/CampaignBudgetService/MutateCampaignBudgets
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignBudgets:mutate`,
+            // https://developers.google.com/google-ads/api/reference/rpc/v25/CampaignBudgetService/MutateCampaignBudgets
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaignBudgets:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/create-campaign-budget.ts
+++ b/integrations/google-ads/actions/create-campaign-budget.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { ProxyConfiguration } from 'nango';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('The Google Ads customer ID. Example: "1781900691"'),
@@ -42,9 +43,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-campaign-budget.ts
+++ b/integrations/google-ads/actions/create-campaign-budget.ts
@@ -11,8 +11,7 @@ const InputSchema = z.object({
     name: z.string().describe('The name of the campaign budget.'),
     amountMicros: z.string().describe('The budget amount in micros. Example: "1000000"'),
     deliveryMethod: z.enum(['STANDARD', 'ACCELERATED']).describe('The delivery method for the budget.'),
-    explicitlyShared: z.boolean().describe('Whether the budget is shared across multiple campaigns.'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    explicitlyShared: z.boolean().describe('Whether the budget is shared across multiple campaigns.')
 });
 
 const OutputSchema = z.object({
@@ -37,12 +36,21 @@ const PartialFailureErrorSchema = z.object({
 
 const action = createAction({
     description: 'Create a campaign budget for one or more campaigns.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const config: ProxyConfiguration = {
             // https://developers.google.com/google-ads/api/reference/rpc/v21/CampaignBudgetService/MutateCampaignBudgets
             endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignBudgets:mutate`,
@@ -59,7 +67,7 @@ const action = createAction({
                 ]
             },
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             retries: 3

--- a/integrations/google-ads/actions/create-campaign-location-criterion.ts
+++ b/integrations/google-ads/actions/create-campaign-location-criterion.ts
@@ -22,7 +22,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add geographic location targeting to a campaign using a geo target constant.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -38,8 +38,8 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://developers.google.com/google-ads/api/rest/reference/rest/v21/customers/campaignCriteria/mutate
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
+            // https://developers.google.com/google-ads/api/rest/reference/rest/v25/customers/campaignCriteria/mutate
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/create-campaign-location-criterion.ts
+++ b/integrations/google-ads/actions/create-campaign-location-criterion.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Customer ID. Example: "1781900691"'),
@@ -28,9 +29,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-campaign-location-criterion.ts
+++ b/integrations/google-ads/actions/create-campaign-location-criterion.ts
@@ -8,8 +8,7 @@ const InputSchema = z.object({
         .optional()
         .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
     campaign: z.string().describe('Campaign resource name. Example: "customers/1781900691/campaigns/24027360183"'),
-    geoTargetConstant: z.string().describe('Geo target constant resource name. Example: "geoTargetConstants/21167"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    geoTargetConstant: z.string().describe('Geo target constant resource name. Example: "geoTargetConstants/21167"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -23,17 +22,26 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add geographic location targeting to a campaign using a geo target constant.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/rest/reference/rest/v21/customers/campaignCriteria/mutate
             endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: {

--- a/integrations/google-ads/actions/create-campaign-negative-keyword.ts
+++ b/integrations/google-ads/actions/create-campaign-negative-keyword.ts
@@ -28,7 +28,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add a negative keyword criterion at the campaign level.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -47,7 +47,7 @@ const action = createAction({
 
         // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/create-campaign-negative-keyword.ts
+++ b/integrations/google-ads/actions/create-campaign-negative-keyword.ts
@@ -9,8 +9,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -29,19 +28,28 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add a negative keyword criterion at the campaign level.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const campaignResourceName = `customers/${input.customerId}/campaigns/${input.campaignId}`;
 
         // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
         const response = await nango.post({
             endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: {

--- a/integrations/google-ads/actions/create-campaign-negative-keyword.ts
+++ b/integrations/google-ads/actions/create-campaign-negative-keyword.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -34,9 +35,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-campaign.ts
+++ b/integrations/google-ads/actions/create-campaign.ts
@@ -65,7 +65,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a campaign that references an existing budget.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -104,7 +104,7 @@ const action = createAction({
 
         // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaigns:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaigns:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/create-campaign.ts
+++ b/integrations/google-ads/actions/create-campaign.ts
@@ -47,8 +47,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResultSchema = z.object({
@@ -66,12 +65,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Create a campaign that references an existing budget.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         if (input.biddingStrategy === 'targetCpa' && input.targetCpaMicros === undefined) {
             throw new nango.ActionError({
                 type: 'invalid_input',
@@ -113,7 +121,7 @@ const action = createAction({
                 ]
             },
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             retries: 3

--- a/integrations/google-ads/actions/create-campaign.ts
+++ b/integrations/google-ads/actions/create-campaign.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const NetworkSettingsSchema = z.object({
     targetGoogleSearch: z.boolean(),
@@ -71,9 +72,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-conversion-action.ts
+++ b/integrations/google-ads/actions/create-conversion-action.ts
@@ -25,7 +25,7 @@ const MutateResponseSchema = z.object({
 
 const action = createAction({
     description: 'Create a conversion action for tracking conversions.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -49,8 +49,8 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://developers.google.com/google-ads/api/reference/rpc/v21/ConversionActionService/MutateConversionActions
-            endpoint: `/v21/customers/${encodeURIComponent(input.customerId)}/conversionActions:mutate`,
+            // https://developers.google.com/google-ads/api/reference/rpc/v25/ConversionActionService/MutateConversionActions
+            endpoint: `/v25/customers/${encodeURIComponent(input.customerId)}/conversionActions:mutate`,
             headers,
             data: {
                 operations: [

--- a/integrations/google-ads/actions/create-conversion-action.ts
+++ b/integrations/google-ads/actions/create-conversion-action.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -31,9 +32,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-conversion-action.ts
+++ b/integrations/google-ads/actions/create-conversion-action.ts
@@ -4,7 +4,6 @@ import { createAction } from 'nango';
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
     loginCustomerId: z.string().optional().describe('Manager account ID for API access. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"'),
     name: z.string().describe('Unique conversion action name.'),
     type: z.string().describe('Conversion action type. Example: "WEBPAGE"'),
     category: z.string().describe('Conversion action category. Example: "DEFAULT"'),
@@ -26,14 +25,23 @@ const MutateResponseSchema = z.object({
 
 const action = createAction({
     description: 'Create a conversion action for tracking conversions.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const headers: Record<string, string> = {
-            'developer-token': input.developerToken
+            'developer-token': developerToken
         };
 
         if (input.loginCustomerId !== undefined && input.loginCustomerId !== '') {

--- a/integrations/google-ads/actions/create-keyword-criterion.ts
+++ b/integrations/google-ads/actions/create-keyword-criterion.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -35,9 +36,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-keyword-criterion.ts
+++ b/integrations/google-ads/actions/create-keyword-criterion.ts
@@ -29,7 +29,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add a positive keyword criterion to an ad group.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -72,9 +72,9 @@ const action = createAction({
             ]
         };
 
-        // https://developers.google.com/google-ads/api/reference/rpc/v21/AdGroupCriterionService/MutateAdGroupCriteria
+        // https://developers.google.com/google-ads/api/reference/rpc/v25/AdGroupCriterionService/MutateAdGroupCriteria
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/adGroupCriteria:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/adGroupCriteria:mutate`,
             data: mutateBody,
             retries: 1,
             headers: {

--- a/integrations/google-ads/actions/create-keyword-criterion.ts
+++ b/integrations/google-ads/actions/create-keyword-criterion.ts
@@ -11,8 +11,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResultSchema = z.object({
@@ -30,12 +29,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add a positive keyword criterion to an ad group.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const mutateBody: {
             operations: Array<{
                 create: {
@@ -70,7 +78,7 @@ const action = createAction({
             data: mutateBody,
             retries: 1,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             }
         });

--- a/integrations/google-ads/actions/create-negative-keyword.ts
+++ b/integrations/google-ads/actions/create-negative-keyword.ts
@@ -28,7 +28,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add a negative keyword criterion to an ad group so its ads stop showing for that term.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -48,7 +48,7 @@ const action = createAction({
 
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
-            endpoint: `v21/customers/${customerId}/adGroupCriteria:mutate`,
+            endpoint: `v25/customers/${customerId}/adGroupCriteria:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.login_customer_id && { 'login-customer-id': input.login_customer_id })

--- a/integrations/google-ads/actions/create-negative-keyword.ts
+++ b/integrations/google-ads/actions/create-negative-keyword.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customer_id: z.string().describe('Customer ID. Example: "1781900691"'),
@@ -34,9 +35,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/create-negative-keyword.ts
+++ b/integrations/google-ads/actions/create-negative-keyword.ts
@@ -9,8 +9,7 @@ const InputSchema = z.object({
         .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
     ad_group_id: z.string().describe('Ad group ID. Example: "197714341345"'),
     text: z.string().describe('Keyword text. Example: "free"'),
-    match_type: z.enum(['EXACT', 'PHRASE', 'BROAD']).describe('Keyword match type. Example: "EXACT"'),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    match_type: z.enum(['EXACT', 'PHRASE', 'BROAD']).describe('Keyword match type. Example: "EXACT"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -29,12 +28,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Add a negative keyword criterion to an ad group so its ads stop showing for that term.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const customerId = encodeURIComponent(input.customer_id);
         const adGroup = `customers/${input.customer_id}/adGroups/${input.ad_group_id}`;
 
@@ -42,7 +50,7 @@ const action = createAction({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
             endpoint: `v21/customers/${customerId}/adGroupCriteria:mutate`,
             headers: {
-                'developer-token': input.developer_token,
+                'developer-token': developerToken,
                 ...(input.login_customer_id && { 'login-customer-id': input.login_customer_id })
             },
             data: {

--- a/integrations/google-ads/actions/generate-keyword-ideas.ts
+++ b/integrations/google-ads/actions/generate-keyword-ideas.ts
@@ -37,7 +37,6 @@ const InputSchema = z
         language: z.string().optional().describe('Language constant resource name. Example: "languageConstants/1000"'),
         geoTargetConstants: z.array(z.string()).optional().describe('Geo target constant resource names. Example: ["geoTargetConstants/2840"]'),
         keywordPlanNetwork: z.string().optional().describe('Keyword plan network. Example: "GOOGLE_SEARCH"'),
-        developerToken: z.string().describe('Google Ads developer token.'),
         loginCustomerId: z.string().optional().describe('Login customer ID when accessing via a manager account. Example: "3608201627"'),
         includeAdultKeywords: z.boolean().optional().describe('Whether to include adult keywords in the response.'),
         pageToken: z.string().optional().describe('Pagination token for the next page of results.'),
@@ -54,12 +53,21 @@ const InputSchema = z
 
 const action = createAction({
     description: 'Generate keyword ideas and search volume/competition metrics from a seed keyword list or URL.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input) => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const seed: Record<string, unknown> = {};
 
         if (input.keywords && input.keywords.length > 0 && input.url) {
@@ -92,7 +100,7 @@ const action = createAction({
         };
 
         const headers: Record<string, string> = {
-            'developer-token': input.developerToken
+            'developer-token': developerToken
         };
 
         if (input.loginCustomerId) {

--- a/integrations/google-ads/actions/generate-keyword-ideas.ts
+++ b/integrations/google-ads/actions/generate-keyword-ideas.ts
@@ -53,7 +53,7 @@ const InputSchema = z
 
 const action = createAction({
     description: 'Generate keyword ideas and search volume/competition metrics from a seed keyword list or URL.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -108,8 +108,8 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://developers.google.com/google-ads/api/reference/rpc/v21/KeywordPlanIdeaService/GenerateKeywordIdeas
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}:generateKeywordIdeas`,
+            // https://developers.google.com/google-ads/api/reference/rpc/v25/KeywordPlanIdeaService/GenerateKeywordIdeas
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}:generateKeywordIdeas`,
             data: body,
             headers,
             retries: 3

--- a/integrations/google-ads/actions/generate-keyword-ideas.ts
+++ b/integrations/google-ads/actions/generate-keyword-ideas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const MonthlySearchVolumeSchema = z.object({
     year: z.string().optional(),
@@ -59,9 +60,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input) => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/list-accessible-customers.ts
+++ b/integrations/google-ads/actions/list-accessible-customers.ts
@@ -1,9 +1,7 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
 
-const InputSchema = z.object({
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
-});
+const InputSchema = z.object({});
 
 const ProviderResponseSchema = z.object({
     resourceNames: z.array(z.string()).optional()
@@ -15,17 +13,26 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'List customer accounts directly accessible to the authenticated user.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
-    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+    exec: async (nango): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const response = await nango.get({
             // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
             endpoint: 'v21/customers:listAccessibleCustomers',
             headers: {
-                'developer-token': input.developerToken
+                'developer-token': developerToken
             },
             retries: 3
         });

--- a/integrations/google-ads/actions/list-accessible-customers.ts
+++ b/integrations/google-ads/actions/list-accessible-customers.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({});
 
@@ -19,9 +20,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/list-accessible-customers.ts
+++ b/integrations/google-ads/actions/list-accessible-customers.ts
@@ -13,7 +13,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'List customer accounts directly accessible to the authenticated user.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -30,7 +30,7 @@ const action = createAction({
 
         const response = await nango.get({
             // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
-            endpoint: 'v21/customers:listAccessibleCustomers',
+            endpoint: 'v25/customers:listAccessibleCustomers',
             headers: {
                 'developer-token': developerToken
             },

--- a/integrations/google-ads/actions/remove-ad-group-ad.ts
+++ b/integrations/google-ads/actions/remove-ad-group-ad.ts
@@ -6,8 +6,7 @@ const InputSchema = z.object({
     login_customer_id: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -26,12 +25,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove an ad from an ad group by resource name.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const resourceName = input.resource_name;
         const customerIdMatch = resourceName.match(/^customers\/(\d+)\/adGroupAds\//);
         if (!customerIdMatch) {
@@ -59,7 +67,7 @@ const action = createAction({
                 ]
             },
             headers: {
-                'developer-token': input.developer_token,
+                'developer-token': developerToken,
                 ...(input.login_customer_id && { 'login-customer-id': input.login_customer_id })
             },
             retries: 3

--- a/integrations/google-ads/actions/remove-ad-group-ad.ts
+++ b/integrations/google-ads/actions/remove-ad-group-ad.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     resource_name: z.string().describe('The resource name of the ad group ad to remove. Example: "customers/1781900691/adGroupAds/197714341345~816946667444"'),
@@ -31,9 +32,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/remove-ad-group-ad.ts
+++ b/integrations/google-ads/actions/remove-ad-group-ad.ts
@@ -25,7 +25,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove an ad from an ad group by resource name.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -58,7 +58,7 @@ const action = createAction({
 
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
-            endpoint: `v21/customers/${encodeURIComponent(customerId)}/adGroupAds:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(customerId)}/adGroupAds:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/remove-ad-group.ts
+++ b/integrations/google-ads/actions/remove-ad-group.ts
@@ -26,7 +26,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove an ad group by resource name.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -62,7 +62,7 @@ const action = createAction({
 
         // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(customerId)}/adGroups:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(customerId)}/adGroups:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/remove-ad-group.ts
+++ b/integrations/google-ads/actions/remove-ad-group.ts
@@ -7,8 +7,7 @@ const InputSchema = z.object({
         .string()
         .regex(/^\d+$/, 'loginCustomerId must contain only digits')
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderMutateResponseSchema = z.object({
@@ -27,12 +26,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove an ad group by resource name.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const resourceName = input.resourceName;
         const match = resourceName.match(/^customers\/([^/]+)\/adGroups\/([^/]+)$/);
 
@@ -63,7 +71,7 @@ const action = createAction({
                 ]
             },
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             retries: 1

--- a/integrations/google-ads/actions/remove-ad-group.ts
+++ b/integrations/google-ads/actions/remove-ad-group.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     resourceName: z.string().describe('Ad group resource name. Example: "customers/1781900691/adGroups/197714341425"'),
@@ -32,9 +33,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/remove-campaign-budget.ts
+++ b/integrations/google-ads/actions/remove-campaign-budget.ts
@@ -6,8 +6,7 @@ const InputSchema = z.object({
     login_customer_id: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const OutputSchema = z.object({
@@ -55,12 +54,21 @@ const ProviderErrorBodySchema = z.object({
 
 const action = createAction({
     description: 'Remove an unused campaign budget by resource name.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const parts = input.resource_name.split('/');
         const customerId = parts[1];
 
@@ -85,7 +93,7 @@ const action = createAction({
                 },
                 retries: 10,
                 headers: {
-                    'developer-token': input.developer_token,
+                    'developer-token': developerToken,
                     ...(input.login_customer_id && { 'login-customer-id': input.login_customer_id })
                 }
             });

--- a/integrations/google-ads/actions/remove-campaign-budget.ts
+++ b/integrations/google-ads/actions/remove-campaign-budget.ts
@@ -54,7 +54,7 @@ const ProviderErrorBodySchema = z.object({
 
 const action = createAction({
     description: 'Remove an unused campaign budget by resource name.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -83,7 +83,7 @@ const action = createAction({
         try {
             const response = await nango.post({
                 // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
-                endpoint: `v21/customers/${encodeURIComponent(customerId)}/campaignBudgets:mutate`,
+                endpoint: `v25/customers/${encodeURIComponent(customerId)}/campaignBudgets:mutate`,
                 data: {
                     operations: [
                         {

--- a/integrations/google-ads/actions/remove-campaign-budget.ts
+++ b/integrations/google-ads/actions/remove-campaign-budget.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     resource_name: z.string().describe('The campaign budget resource name. Example: "customers/123/campaignBudgets/456"'),
@@ -60,9 +61,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/remove-campaign-criterion.ts
+++ b/integrations/google-ads/actions/remove-campaign-criterion.ts
@@ -33,7 +33,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a campaign-level criterion (negative keyword or location target) by resource name.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -50,7 +50,7 @@ const action = createAction({
 
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/remove-campaign-criterion.ts
+++ b/integrations/google-ads/actions/remove-campaign-criterion.ts
@@ -9,8 +9,7 @@ const InputSchema = z.object({
         .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
     resourceName: z
         .string()
-        .describe('The resource name of the campaign criterion to remove. Example: "customers/1781900691/campaignCriteria/24027360183~2515302470834"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('The resource name of the campaign criterion to remove. Example: "customers/1781900691/campaignCriteria/24027360183~2515302470834"')
 });
 
 const ProviderResultSchema = z.object({
@@ -34,17 +33,26 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a campaign-level criterion (negative keyword or location target) by resource name.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
             endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignCriteria:mutate`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: {

--- a/integrations/google-ads/actions/remove-campaign-criterion.ts
+++ b/integrations/google-ads/actions/remove-campaign-criterion.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('The Google Ads customer ID. Example: "1781900691"'),
@@ -39,9 +40,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/remove-campaign.ts
+++ b/integrations/google-ads/actions/remove-campaign.ts
@@ -25,7 +25,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a campaign by resource name.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -60,7 +60,7 @@ const action = createAction({
 
         // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
         const response = await nango.post({
-            endpoint: `/v21/customers/${encodeURIComponent(customerId)}/campaigns:mutate`,
+            endpoint: `/v25/customers/${encodeURIComponent(customerId)}/campaigns:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/remove-campaign.ts
+++ b/integrations/google-ads/actions/remove-campaign.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     resourceName: z.string().describe('Campaign resource name. Example: "customers/1781900691/campaigns/24036861751"'),
@@ -31,9 +32,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/remove-campaign.ts
+++ b/integrations/google-ads/actions/remove-campaign.ts
@@ -6,8 +6,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -26,12 +25,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a campaign by resource name.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const match = input.resourceName.match(/^customers\/(\d+)\/campaigns\/(\d+)$/);
         if (!match) {
             throw new nango.ActionError({
@@ -54,7 +62,7 @@ const action = createAction({
         const response = await nango.post({
             endpoint: `/v21/customers/${encodeURIComponent(customerId)}/campaigns:mutate`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: {

--- a/integrations/google-ads/actions/remove-conversion-action.ts
+++ b/integrations/google-ads/actions/remove-conversion-action.ts
@@ -8,8 +8,7 @@ const InputSchema = z.object({
         .string()
         .regex(/^\d+$/, 'loginCustomerId must contain only digits')
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const ProviderResponseSchema = z.object({
@@ -28,12 +27,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a conversion action by resource name.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const match = input.resourceName.match(/^customers\/(\d+)\/conversionActions\/(\d+)$/);
         if (!match) {
             throw new nango.ActionError({
@@ -53,7 +61,7 @@ const action = createAction({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
             endpoint: `v21/customers/${encodeURIComponent(customerId)}/conversionActions:mutate`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: {

--- a/integrations/google-ads/actions/remove-conversion-action.ts
+++ b/integrations/google-ads/actions/remove-conversion-action.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import type { ProxyConfiguration } from 'nango';
 
 const InputSchema = z.object({
@@ -33,9 +34,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/remove-conversion-action.ts
+++ b/integrations/google-ads/actions/remove-conversion-action.ts
@@ -27,7 +27,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a conversion action by resource name.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -59,7 +59,7 @@ const action = createAction({
 
         const config: ProxyConfiguration = {
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
-            endpoint: `v21/customers/${encodeURIComponent(customerId)}/conversionActions:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(customerId)}/conversionActions:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/remove-keyword-criterion.ts
+++ b/integrations/google-ads/actions/remove-keyword-criterion.ts
@@ -26,7 +26,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a keyword criterion from an ad group.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -57,9 +57,9 @@ const action = createAction({
             });
         }
 
-        // https://developers.google.com/google-ads/api/reference/rpc/v21/AdGroupCriterionService/MutateAdGroupCriteria
+        // https://developers.google.com/google-ads/api/reference/rpc/v25/AdGroupCriterionService/MutateAdGroupCriteria
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(customerId)}/adGroupCriteria:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(customerId)}/adGroupCriteria:mutate`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.login_customer_id && { 'login-customer-id': input.login_customer_id })

--- a/integrations/google-ads/actions/remove-keyword-criterion.ts
+++ b/integrations/google-ads/actions/remove-keyword-criterion.ts
@@ -6,8 +6,7 @@ const InputSchema = z.object({
     login_customer_id: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: 3608201627'),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: 3608201627')
 });
 
 const ProviderResponseSchema = z.object({
@@ -27,12 +26,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Remove a keyword criterion from an ad group.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const match = input.resource_name.match(/^customers\/(\d+)\/adGroupCriteria\/(.+)$/);
         if (!match) {
             throw new nango.ActionError({
@@ -53,7 +61,7 @@ const action = createAction({
         const response = await nango.post({
             endpoint: `v21/customers/${encodeURIComponent(customerId)}/adGroupCriteria:mutate`,
             headers: {
-                'developer-token': input.developer_token,
+                'developer-token': developerToken,
                 ...(input.login_customer_id && { 'login-customer-id': input.login_customer_id })
             },
             data: {

--- a/integrations/google-ads/actions/remove-keyword-criterion.ts
+++ b/integrations/google-ads/actions/remove-keyword-criterion.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     resource_name: z.string().describe('Ad group criterion resource name. Example: customers/1781900691/adGroupCriteria/197714341345~2491223357239'),
@@ -32,9 +33,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/search-google-ads.ts
+++ b/integrations/google-ads/actions/search-google-ads.ts
@@ -24,7 +24,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Run a GAQL query and return paged Google Ads rows.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -41,7 +41,7 @@ const action = createAction({
 
         // https://developers.google.com/google-ads/api/docs/reporting/streaming
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/googleAds:search`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/googleAds:search`,
             headers: {
                 'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })

--- a/integrations/google-ads/actions/search-google-ads.ts
+++ b/integrations/google-ads/actions/search-google-ads.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -30,9 +31,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input) => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/search-google-ads.ts
+++ b/integrations/google-ads/actions/search-google-ads.ts
@@ -8,8 +8,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through a manager hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through a manager hierarchy. Example: "3608201627"')
 });
 
 const SearchResponseSchema = z.object({
@@ -25,17 +24,26 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Run a GAQL query and return paged Google Ads rows.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input) => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         // https://developers.google.com/google-ads/api/docs/reporting/streaming
         const response = await nango.post({
             endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/googleAds:search`,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             data: {

--- a/integrations/google-ads/actions/search-stream-google-ads.ts
+++ b/integrations/google-ads/actions/search-stream-google-ads.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -36,9 +37,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/search-stream-google-ads.ts
+++ b/integrations/google-ads/actions/search-stream-google-ads.ts
@@ -7,8 +7,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through a manager hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through a manager hierarchy. Example: "3608201627"')
 });
 
 const ProviderBatchSchema = z
@@ -31,12 +30,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Run a GAQL query with streamed results',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/reporting/streaming
             endpoint: `/v21/customers/${encodeURIComponent(input.customerId)}/googleAds:searchStream`,
@@ -45,7 +53,7 @@ const action = createAction({
             },
             retries: 3,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             }
         });

--- a/integrations/google-ads/actions/search-stream-google-ads.ts
+++ b/integrations/google-ads/actions/search-stream-google-ads.ts
@@ -30,7 +30,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Run a GAQL query with streamed results',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -47,7 +47,7 @@ const action = createAction({
 
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/reporting/streaming
-            endpoint: `/v21/customers/${encodeURIComponent(input.customerId)}/googleAds:searchStream`,
+            endpoint: `/v25/customers/${encodeURIComponent(input.customerId)}/googleAds:searchStream`,
             data: {
                 query: input.query
             },

--- a/integrations/google-ads/actions/suggest-geo-target-constants.ts
+++ b/integrations/google-ads/actions/suggest-geo-target-constants.ts
@@ -51,7 +51,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Look up geo target constant resource names for location names or codes, for use in campaign location targeting.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -74,8 +74,8 @@ const action = createAction({
         };
 
         const config: ProxyConfiguration = {
-            // https://developers.google.com/google-ads/api/rest/reference/rest/v21/geoTargetConstants/suggest
-            endpoint: 'v21/geoTargetConstants:suggest',
+            // https://developers.google.com/google-ads/api/rest/reference/rest/v25/geoTargetConstants/suggest
+            endpoint: 'v25/geoTargetConstants:suggest',
             data: requestBody,
             headers: {
                 'developer-token': developerToken

--- a/integrations/google-ads/actions/suggest-geo-target-constants.ts
+++ b/integrations/google-ads/actions/suggest-geo-target-constants.ts
@@ -17,8 +17,7 @@ const InputSchema = z
                 resourceNames: z.array(z.string())
             })
             .optional()
-            .describe('Geo target constant resource names to filter by.'),
-        developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+            .describe('Geo target constant resource names to filter by.')
     })
     .refine((data) => (data.locationNames !== undefined ? 1 : 0) + (data.geoTargetConstants !== undefined ? 1 : 0) === 1, {
         message: 'Exactly one of locationNames or geoTargetConstants must be provided, not both.'
@@ -52,12 +51,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Look up geo target constant resource names for location names or codes, for use in campaign location targeting.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const requestBody: Record<string, unknown> = {
             ...(input.locale !== undefined && { locale: input.locale }),
             ...(input.countryCode !== undefined && { countryCode: input.countryCode }),
@@ -70,7 +78,7 @@ const action = createAction({
             endpoint: 'v21/geoTargetConstants:suggest',
             data: requestBody,
             headers: {
-                'developer-token': input.developerToken
+                'developer-token': developerToken
             },
             retries: 3
         };

--- a/integrations/google-ads/actions/suggest-geo-target-constants.ts
+++ b/integrations/google-ads/actions/suggest-geo-target-constants.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import type { ProxyConfiguration } from 'nango';
 
 const InputSchema = z
@@ -57,9 +58,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/update-ad-group-ad.ts
+++ b/integrations/google-ads/actions/update-ad-group-ad.ts
@@ -11,8 +11,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const MutateResultSchema = z.object({
@@ -29,12 +28,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on an ad group ad',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const updateBody: Record<string, unknown> = {
             resourceName: input.resourceName
         };
@@ -65,7 +73,7 @@ const action = createAction({
                 ]
             },
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             retries: 3

--- a/integrations/google-ads/actions/update-ad-group-ad.ts
+++ b/integrations/google-ads/actions/update-ad-group-ad.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Customer ID. Example: "1781900691"'),
@@ -34,9 +35,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/update-ad-group-ad.ts
+++ b/integrations/google-ads/actions/update-ad-group-ad.ts
@@ -28,7 +28,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on an ad group ad',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -62,8 +62,8 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://developers.google.com/google-ads/api/reference/rpc/v21/AdGroupAdService/MutateAdGroupAds
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/adGroupAds:mutate`,
+            // https://developers.google.com/google-ads/api/reference/rpc/v25/AdGroupAdService/MutateAdGroupAds
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/adGroupAds:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/update-ad-group.ts
+++ b/integrations/google-ads/actions/update-ad-group.ts
@@ -20,8 +20,7 @@ const InputSchema = z.object({
                 .optional()
         })
         .optional()
-        .describe('Targeting settings to update.'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Targeting settings to update.')
 });
 
 const ProviderResponseSchema = z.object({
@@ -38,12 +37,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on an ad group.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const resourceName = `customers/${input.customerId}/adGroups/${input.adGroupId}`;
 
         const updateBody: Record<string, unknown> = {
@@ -80,7 +88,7 @@ const action = createAction({
         }
 
         const headers: Record<string, string> = {
-            'developer-token': input.developerToken
+            'developer-token': developerToken
         };
 
         if (input.loginCustomerId) {

--- a/integrations/google-ads/actions/update-ad-group.ts
+++ b/integrations/google-ads/actions/update-ad-group.ts
@@ -37,7 +37,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on an ad group.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -95,9 +95,9 @@ const action = createAction({
             headers['login-customer-id'] = input.loginCustomerId;
         }
 
-        // https://developers.google.com/google-ads/api/reference/rpc/v21/AdGroupService/MutateAdGroups
+        // https://developers.google.com/google-ads/api/reference/rpc/v25/AdGroupService/MutateAdGroups
         const response = await nango.post({
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/adGroups:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/adGroups:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/update-ad-group.ts
+++ b/integrations/google-ads/actions/update-ad-group.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('The customer ID. Example: "1781900691"'),
@@ -43,9 +44,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/update-campaign-budget.ts
+++ b/integrations/google-ads/actions/update-campaign-budget.ts
@@ -12,8 +12,7 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID (login-customer-id) required when accessing a client account through an MCC hierarchy. Example: "3608201627"')
 });
 
 const OutputSchema = z.object({
@@ -32,12 +31,21 @@ const MutateResponseSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on a campaign budget.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         if (input.amountMicros !== undefined && input.totalAmountMicros !== undefined) {
             throw new nango.ActionError({
                 type: 'invalid_input',
@@ -98,7 +106,7 @@ const action = createAction({
                 ]
             },
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             },
             retries: 1

--- a/integrations/google-ads/actions/update-campaign-budget.ts
+++ b/integrations/google-ads/actions/update-campaign-budget.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -37,9 +38,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/update-campaign-budget.ts
+++ b/integrations/google-ads/actions/update-campaign-budget.ts
@@ -31,7 +31,7 @@ const MutateResponseSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on a campaign budget.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -95,8 +95,8 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://developers.google.com/google-ads/api/reference/rest/v21/customers.campaignBudgets/mutate
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaignBudgets:mutate`,
+            // https://developers.google.com/google-ads/api/reference/rest/v25/customers.campaignBudgets/mutate
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaignBudgets:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/update-campaign.ts
+++ b/integrations/google-ads/actions/update-campaign.ts
@@ -43,10 +43,7 @@ const InputSchema = z.object({
             targetPartnerSearchNetwork: z.boolean().optional()
         })
         .optional(),
-    loginCustomerId: z
-        .string()
-        .optional()
-        .describe('Manager account ID for login-customer-id header. Falls back to connection metadata. Example: "3608201627"')
+    loginCustomerId: z.string().optional().describe('Manager account ID for login-customer-id header. Falls back to connection metadata. Example: "3608201627"')
 });
 
 const MetadataSchema = z.object({
@@ -59,7 +56,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable campaign settings.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     metadata: MetadataSchema,
@@ -147,7 +144,7 @@ const action = createAction({
 
         const response = await nango.post({
             // https://developers.google.com/google-ads/api/docs/mutating/service-mutates
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/campaigns:mutate`,
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/campaigns:mutate`,
             headers: {
                 'developer-token': developerToken,
                 'login-customer-id': loginCustomerId

--- a/integrations/google-ads/actions/update-campaign.ts
+++ b/integrations/google-ads/actions/update-campaign.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     customerId: z.string().describe('Google Ads customer ID. Example: "1781900691"'),
@@ -71,8 +72,7 @@ const action = createAction({
             loginCustomerId = loginCustomerId ?? metadata?.loginCustomerId;
         }
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
+        const developerToken = await getDeveloperToken(nango);
 
         if (!loginCustomerId || !developerToken) {
             throw new nango.ActionError({

--- a/integrations/google-ads/actions/update-campaign.ts
+++ b/integrations/google-ads/actions/update-campaign.ts
@@ -46,13 +46,11 @@ const InputSchema = z.object({
     loginCustomerId: z
         .string()
         .optional()
-        .describe('Manager account ID for login-customer-id header. Falls back to connection metadata. Example: "3608201627"'),
-    developerToken: z.string().optional().describe('Google Ads developer token. Falls back to connection metadata. Example: "YOUR_DEVELOPER_TOKEN"')
+        .describe('Manager account ID for login-customer-id header. Falls back to connection metadata. Example: "3608201627"')
 });
 
 const MetadataSchema = z.object({
-    loginCustomerId: z.string().describe('Manager account ID for login-customer-id header. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    loginCustomerId: z.string().describe('Manager account ID for login-customer-id header. Example: "3608201627"')
 });
 
 const OutputSchema = z.object({
@@ -61,7 +59,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable campaign settings.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     metadata: MetadataSchema,
@@ -69,19 +67,20 @@ const action = createAction({
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
         let loginCustomerId = input.loginCustomerId;
-        let developerToken = input.developerToken;
 
-        if (!loginCustomerId || !developerToken) {
+        if (!loginCustomerId) {
             const rawMetadata = await nango.getMetadata();
             const metadata = rawMetadata ? MetadataSchema.parse(rawMetadata) : null;
             loginCustomerId = loginCustomerId ?? metadata?.loginCustomerId;
-            developerToken = developerToken ?? metadata?.developerToken;
         }
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
 
         if (!loginCustomerId || !developerToken) {
             throw new nango.ActionError({
                 type: 'missing_configuration',
-                message: 'loginCustomerId and developerToken are required. Set them in connection metadata or pass as input.'
+                message: 'loginCustomerId is required (pass as input or set in connection metadata); developer_token is required in connection config.'
             });
         }
 

--- a/integrations/google-ads/actions/update-conversion-action.ts
+++ b/integrations/google-ads/actions/update-conversion-action.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import { createAction } from 'nango';
 
 const MetadataSchema = z.object({
-    developerToken: z.string().optional(),
     loginCustomerId: z.string().optional()
 });
 
@@ -19,7 +18,6 @@ const InputSchema = z.object({
         })
         .optional()
         .describe('Value settings for the conversion action'),
-    developerToken: z.string().optional().describe('Google Ads developer token'),
     loginCustomerId: z.string().optional().describe('Manager account ID for access. Example: "3608201627"')
 });
 
@@ -37,26 +35,27 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on a conversion action',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        let developerToken = input.developerToken;
         let loginCustomerId = input.loginCustomerId;
 
-        if (!developerToken || !loginCustomerId) {
+        if (!loginCustomerId) {
             const rawMetadata = await nango.getMetadata();
             const metadata = MetadataSchema.parse(rawMetadata ?? {});
-            developerToken = developerToken ?? metadata.developerToken;
             loginCustomerId = loginCustomerId ?? metadata.loginCustomerId;
         }
 
-        if (!developerToken) {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+
+        if (!developerToken || typeof developerToken !== 'string') {
             throw new nango.ActionError({
-                type: 'missing_developer_token',
-                message: 'developerToken is required in input or connection metadata.'
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
             });
         }
 

--- a/integrations/google-ads/actions/update-conversion-action.ts
+++ b/integrations/google-ads/actions/update-conversion-action.ts
@@ -35,7 +35,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on a conversion action',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -113,8 +113,8 @@ const action = createAction({
         }
 
         const response = await nango.post({
-            // https://developers.google.com/google-ads/api/reference/rpc/v21/ConversionActionService/MutateConversionActions
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/conversionActions:mutate`,
+            // https://developers.google.com/google-ads/api/reference/rpc/v25/ConversionActionService/MutateConversionActions
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/conversionActions:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/update-conversion-action.ts
+++ b/integrations/google-ads/actions/update-conversion-action.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const MetadataSchema = z.object({
     loginCustomerId: z.string().optional()
@@ -49,10 +50,9 @@ const action = createAction({
             loginCustomerId = loginCustomerId ?? metadata.loginCustomerId;
         }
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
+        const developerToken = await getDeveloperToken(nango);
 
-        if (!developerToken || typeof developerToken !== 'string') {
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/update-keyword-criterion.ts
+++ b/integrations/google-ads/actions/update-keyword-criterion.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import type { ProxyConfiguration } from 'nango';
 
 const InputSchema = z.object({
@@ -37,9 +38,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/update-keyword-criterion.ts
+++ b/integrations/google-ads/actions/update-keyword-criterion.ts
@@ -11,8 +11,7 @@ const InputSchema = z.object({
     resourceName: z.string().describe('Resource name of the ad group criterion. Example: "customers/1781900691/adGroupCriteria/197714341345~2491223357039"'),
     status: z.enum(['ENABLED', 'PAUSED', 'REMOVED']).optional().describe('Keyword status to update.'),
     cpcBidMicros: z.string().optional().describe('CPC bid in micros to update. Example: "1500000"'),
-    finalUrls: z.array(z.string()).optional().describe('Final URLs to update.'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    finalUrls: z.array(z.string()).optional().describe('Final URLs to update.')
 });
 
 const ProviderMutateResponseSchema = z.object({
@@ -32,12 +31,21 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on an ad group keyword criterion.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const updateFields: Record<string, unknown> = {
             resourceName: input.resourceName
         };
@@ -80,7 +88,7 @@ const action = createAction({
             // eslint-disable-next-line @nangohq/custom-integrations-linting/proxy-call-retries
             retries: 0,
             headers: {
-                'developer-token': input.developerToken,
+                'developer-token': developerToken,
                 ...(input.loginCustomerId && { 'login-customer-id': input.loginCustomerId })
             }
         };

--- a/integrations/google-ads/actions/update-keyword-criterion.ts
+++ b/integrations/google-ads/actions/update-keyword-criterion.ts
@@ -31,7 +31,7 @@ const OutputSchema = z.object({
 
 const action = createAction({
     description: 'Update mutable fields on an ad group keyword criterion.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
@@ -73,10 +73,10 @@ const action = createAction({
             });
         }
 
-        // https://developers.google.com/google-ads/api/reference/rpc/v21/AdGroupCriterionService/MutateAdGroupCriteria
+        // https://developers.google.com/google-ads/api/reference/rpc/v25/AdGroupCriterionService/MutateAdGroupCriteria
         const config: ProxyConfiguration = {
-            // https://developers.google.com/google-ads/api/reference/rpc/v21/AdGroupCriterionService/MutateAdGroupCriteria
-            endpoint: `v21/customers/${encodeURIComponent(input.customerId)}/adGroupCriteria:mutate`,
+            // https://developers.google.com/google-ads/api/reference/rpc/v25/AdGroupCriterionService/MutateAdGroupCriteria
+            endpoint: `v25/customers/${encodeURIComponent(input.customerId)}/adGroupCriteria:mutate`,
             data: {
                 operations: [
                     {

--- a/integrations/google-ads/actions/validate-google-ads-mutate.ts
+++ b/integrations/google-ads/actions/validate-google-ads-mutate.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createAction } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 
 const InputSchema = z.object({
     path: z.string().describe('Google Ads mutate endpoint path. Example: "v25/customers/1781900691/campaigns:mutate"'),
@@ -17,9 +18,8 @@ const action = createAction({
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new nango.ActionError({
                 type: 'missing_config',
                 message: 'developer_token is required in connection config'

--- a/integrations/google-ads/actions/validate-google-ads-mutate.ts
+++ b/integrations/google-ads/actions/validate-google-ads-mutate.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createAction } from 'nango';
 
 const InputSchema = z.object({
-    path: z.string().describe('Google Ads mutate endpoint path. Example: "v21/customers/1781900691/campaigns:mutate"'),
+    path: z.string().describe('Google Ads mutate endpoint path. Example: "v25/customers/1781900691/campaigns:mutate"'),
     body: z.record(z.string(), z.unknown()).describe('Mutate request body without validateOnly. Example: {"operations":[{"create":{...}}]}'),
     loginCustomerId: z.string().optional().describe('Manager customer ID for MCC hierarchy. Example: "3608201627"')
 });
@@ -11,7 +11,7 @@ const OutputSchema = z.object({}).passthrough();
 
 const action = createAction({
     description: 'Validate a mutate request without applying changes.',
-    version: '1.0.1',
+    version: '1.0.2',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],

--- a/integrations/google-ads/actions/validate-google-ads-mutate.ts
+++ b/integrations/google-ads/actions/validate-google-ads-mutate.ts
@@ -4,22 +4,30 @@ import { createAction } from 'nango';
 const InputSchema = z.object({
     path: z.string().describe('Google Ads mutate endpoint path. Example: "v21/customers/1781900691/campaigns:mutate"'),
     body: z.record(z.string(), z.unknown()).describe('Mutate request body without validateOnly. Example: {"operations":[{"create":{...}}]}'),
-    loginCustomerId: z.string().optional().describe('Manager customer ID for MCC hierarchy. Example: "3608201627"'),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    loginCustomerId: z.string().optional().describe('Manager customer ID for MCC hierarchy. Example: "3608201627"')
 });
 
 const OutputSchema = z.object({}).passthrough();
 
 const action = createAction({
     description: 'Validate a mutate request without applying changes.',
-    version: '1.0.0',
+    version: '1.0.1',
     input: InputSchema,
     output: OutputSchema,
     scopes: ['https://www.googleapis.com/auth/adwords'],
 
     exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new nango.ActionError({
+                type: 'missing_config',
+                message: 'developer_token is required in connection config'
+            });
+        }
+
         const headers: Record<string, string> = {
-            'developer-token': input.developerToken
+            'developer-token': developerToken
         };
 
         if (input.loginCustomerId) {

--- a/integrations/google-ads/helpers/get-developer-token.ts
+++ b/integrations/google-ads/helpers/get-developer-token.ts
@@ -1,0 +1,11 @@
+import type { NangoAction, NangoSync } from 'nango';
+
+// The developer token lives in connection_config (set once per integration via
+// integrations_config_defaults, not per end user - see connection_config.developer_token in
+// providers.yaml). Centralized here so the type check (string, not just truthy) can't drift
+// between the ~30 google-ads actions/syncs that all need this same value.
+export async function getDeveloperToken(nango: NangoAction | NangoSync): Promise<string | null> {
+    const connection = await nango.getConnection();
+    const developerToken = connection.connection_config?.['developer_token'];
+    return typeof developerToken === 'string' && developerToken.length > 0 ? developerToken : null;
+}

--- a/integrations/google-ads/syncs/accessible-customers.ts
+++ b/integrations/google-ads/syncs/accessible-customers.ts
@@ -1,10 +1,6 @@
 import { createSync } from 'nango';
 import { z } from 'zod';
 
-const MetadataSchema = z.object({
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
-});
-
 const CustomerSchema = z.object({
     id: z.string(),
     resourceName: z.string(),
@@ -69,27 +65,25 @@ const SearchStreamResponseSchema = z.array(z.union([SearchStreamResultSchema, Se
 
 const sync = createSync({
     description: 'Sync directly accessible Google Ads customer accounts',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
-    metadata: MetadataSchema,
     models: {
         Customer: CustomerSchema
     },
 
     exec: async (nango) => {
-        const rawMetadata = await nango.getMetadata();
-        const metadataResult = MetadataSchema.safeParse(rawMetadata);
-        if (!metadataResult.success) {
-            throw new Error('Invalid metadata: ' + metadataResult.error.message);
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
         }
-        const metadata = metadataResult.data;
 
         // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
         const listResponse = await nango.get({
             endpoint: 'v21/customers:listAccessibleCustomers',
             headers: {
-                'developer-token': metadata.developerToken
+                'developer-token': developerToken
             },
             retries: 3
         });
@@ -116,7 +110,7 @@ const sync = createSync({
                         query: 'SELECT customer.id, customer.descriptive_name, customer.manager, customer.test_account, customer.status FROM customer'
                     },
                     headers: {
-                        'developer-token': metadata.developerToken
+                        'developer-token': developerToken
                     },
                     retries: 3
                 });

--- a/integrations/google-ads/syncs/accessible-customers.ts
+++ b/integrations/google-ads/syncs/accessible-customers.ts
@@ -1,4 +1,5 @@
 import { createSync } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const CustomerSchema = z.object({
@@ -73,9 +74,8 @@ const sync = createSync({
     },
 
     exec: async (nango) => {
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/accessible-customers.ts
+++ b/integrations/google-ads/syncs/accessible-customers.ts
@@ -65,7 +65,7 @@ const SearchStreamResponseSchema = z.array(z.union([SearchStreamResultSchema, Se
 
 const sync = createSync({
     description: 'Sync directly accessible Google Ads customer accounts',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     models: {
@@ -81,7 +81,7 @@ const sync = createSync({
 
         // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
         const listResponse = await nango.get({
-            endpoint: 'v21/customers:listAccessibleCustomers',
+            endpoint: 'v25/customers:listAccessibleCustomers',
             headers: {
                 'developer-token': developerToken
             },
@@ -105,7 +105,7 @@ const sync = createSync({
             // Skip these accounts gracefully; in production with an approved token this branch is unreachable.
             try {
                 searchResponse = await nango.post({
-                    endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+                    endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
                     data: {
                         query: 'SELECT customer.id, customer.descriptive_name, customer.manager, customer.test_account, customer.status FROM customer'
                     },

--- a/integrations/google-ads/syncs/ad-group-ads.ts
+++ b/integrations/google-ads/syncs/ad-group-ads.ts
@@ -22,8 +22,7 @@ const CheckpointSchema = z.object({
 
 const MetadataSchema = z.object({
     customer_ids: z.array(z.string()).optional(),
-    login_customer_id: z.string().optional(),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    login_customer_id: z.string().optional()
 });
 
 const ListAccessibleCustomersResponseSchema = z.object({
@@ -314,7 +313,7 @@ function mapAdGroupAdRows(rawResults: unknown[], updatedAt: string | undefined, 
 
 const sync = createSync({
     description: 'Sync ad group ads for customer accounts in scope.',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -330,6 +329,12 @@ const sync = createSync({
             throw new Error(`Invalid metadata: ${metadataResult.error.message}`);
         }
         const metadata = metadataResult.data;
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
+        }
 
         const rawCheckpoint = await nango.getCheckpoint();
         const checkpointResult = rawCheckpoint ? CheckpointSchema.safeParse(rawCheckpoint) : null;
@@ -354,7 +359,7 @@ const sync = createSync({
             const accessibleResponse = await nango.get({
                 endpoint: 'v21/customers:listAccessibleCustomers',
                 headers: {
-                    'developer-token': metadata.developer_token
+                    'developer-token': developerToken
                 },
                 retries: 3
             });
@@ -381,7 +386,7 @@ const sync = createSync({
                             endpoint: `v21/customers/${encodeURIComponent(accessibleId)}/googleAds:search`,
                             method: 'POST',
                             headers: {
-                                'developer-token': metadata.developer_token
+                                'developer-token': developerToken
                             },
                             data: {
                                 query: 'SELECT customer_client.id, customer_client.manager FROM customer_client WHERE customer_client.manager = FALSE',
@@ -466,7 +471,7 @@ const sync = createSync({
 
         for (const account of accountsToProcess) {
             const headers: Record<string, string> = {
-                'developer-token': metadata.developer_token,
+                'developer-token': developerToken,
                 ...(account.loginCustomerId && { 'login-customer-id': account.loginCustomerId })
             };
 

--- a/integrations/google-ads/syncs/ad-group-ads.ts
+++ b/integrations/google-ads/syncs/ad-group-ads.ts
@@ -1,4 +1,5 @@
 import { createSync, type ProxyConfiguration } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const AdGroupAdSchema = z.object({
@@ -330,9 +331,8 @@ const sync = createSync({
         }
         const metadata = metadataResult.data;
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/ad-group-ads.ts
+++ b/integrations/google-ads/syncs/ad-group-ads.ts
@@ -313,7 +313,7 @@ function mapAdGroupAdRows(rawResults: unknown[], updatedAt: string | undefined, 
 
 const sync = createSync({
     description: 'Sync ad group ads for customer accounts in scope.',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -357,7 +357,7 @@ const sync = createSync({
         } else {
             // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
             const accessibleResponse = await nango.get({
-                endpoint: 'v21/customers:listAccessibleCustomers',
+                endpoint: 'v25/customers:listAccessibleCustomers',
                 headers: {
                     'developer-token': developerToken
                 },
@@ -383,7 +383,7 @@ const sync = createSync({
                     do {
                         const clientConfig: ProxyConfiguration = {
                             // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
-                            endpoint: `v21/customers/${encodeURIComponent(accessibleId)}/googleAds:search`,
+                            endpoint: `v25/customers/${encodeURIComponent(accessibleId)}/googleAds:search`,
                             method: 'POST',
                             headers: {
                                 'developer-token': developerToken
@@ -481,7 +481,7 @@ const sync = createSync({
             try {
                 if (needsFullRefresh) {
                     const fullResponse = await nango.post({
-                        endpoint: `v21/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
+                        endpoint: `v25/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
                         headers,
                         data: { query: FULL_FETCH_QUERY },
                         retries: 3
@@ -531,7 +531,7 @@ const sync = createSync({
 
                         // https://developers.google.com/google-ads/api/docs/change-status
                         const changeStatusResponse = await nango.post({
-                            endpoint: `v21/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
+                            endpoint: `v25/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
                             headers,
                             data: { query: changeStatusQuery },
                             retries: 3
@@ -583,7 +583,7 @@ const sync = createSync({
                         const fetchQuery = `${FULL_FETCH_QUERY} WHERE ad_group_ad.resource_name IN (${inClause}) LIMIT 10000`;
 
                         const fetchResponse = await nango.post({
-                            endpoint: `v21/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
+                            endpoint: `v25/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
                             headers,
                             data: { query: fetchQuery },
                             retries: 3

--- a/integrations/google-ads/syncs/ad-groups.ts
+++ b/integrations/google-ads/syncs/ad-groups.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 
 const MetadataSchema = z.object({
     customer_ids: z.array(z.string()).optional(),
-    login_customer_id: z.string().optional(),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    login_customer_id: z.string().optional()
 });
 
 // Checkpoint values must be scalars (string/number/boolean); the set of initialized customer IDs
@@ -250,7 +249,7 @@ function extractCustomerId(resourceName: string): string | undefined {
 
 const sync = createSync({
     description: 'Sync ad groups for customer accounts in scope.',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -266,6 +265,12 @@ const sync = createSync({
             throw new Error(`Invalid metadata: ${metadataResult.error.message}`);
         }
         const metadata = metadataResult.data;
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
+        }
 
         const rawCheckpoint = await nango.getCheckpoint();
         const checkpointResult = rawCheckpoint ? CheckpointSchema.safeParse(rawCheckpoint) : null;
@@ -290,7 +295,7 @@ const sync = createSync({
                 // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
                 endpoint: 'v21/customers:listAccessibleCustomers',
                 headers: {
-                    'developer-token': metadata.developer_token
+                    'developer-token': developerToken
                 },
                 retries: 3
             };
@@ -304,7 +309,7 @@ const sync = createSync({
                     endpoint: `v21/customers/${encodeURIComponent(accessibleId)}/googleAds:search`,
                     method: 'POST',
                     headers: {
-                        'developer-token': metadata.developer_token
+                        'developer-token': developerToken
                     },
                     data: {
                         query: 'SELECT customer_client.id, customer_client.manager FROM customer_client WHERE customer_client.manager = FALSE'
@@ -384,7 +389,7 @@ const sync = createSync({
 
         for (const account of accountsToProcess) {
             const headers: Record<string, string> = {
-                'developer-token': metadata.developer_token
+                'developer-token': developerToken
             };
             if (account.loginCustomerId) {
                 headers['login-customer-id'] = account.loginCustomerId;

--- a/integrations/google-ads/syncs/ad-groups.ts
+++ b/integrations/google-ads/syncs/ad-groups.ts
@@ -249,7 +249,7 @@ function extractCustomerId(resourceName: string): string | undefined {
 
 const sync = createSync({
     description: 'Sync ad groups for customer accounts in scope.',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -293,7 +293,7 @@ const sync = createSync({
         } else {
             const listConfig: ProxyConfiguration = {
                 // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
-                endpoint: 'v21/customers:listAccessibleCustomers',
+                endpoint: 'v25/customers:listAccessibleCustomers',
                 headers: {
                     'developer-token': developerToken
                 },
@@ -306,7 +306,7 @@ const sync = createSync({
             for (const accessibleId of accessibleIds) {
                 const clientConfig: ProxyConfiguration = {
                     // https://developers.google.com/google-ads/api/docs/account-management/listing-accounts
-                    endpoint: `v21/customers/${encodeURIComponent(accessibleId)}/googleAds:search`,
+                    endpoint: `v25/customers/${encodeURIComponent(accessibleId)}/googleAds:search`,
                     method: 'POST',
                     headers: {
                         'developer-token': developerToken
@@ -402,7 +402,7 @@ const sync = createSync({
                 // history, or a checkpoint too old for change_status's 90-day retention window.
                 const streamConfig: ProxyConfiguration = {
                     // https://developers.google.com/google-ads/api/docs/reporting/streaming
-                    endpoint: `v21/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
+                    endpoint: `v25/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
                     method: 'POST',
                     headers,
                     data: {
@@ -454,7 +454,7 @@ const sync = createSync({
 
                     const changeStatusConfig: ProxyConfiguration = {
                         // https://developers.google.com/google-ads/api/docs/change-status
-                        endpoint: `v21/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
+                        endpoint: `v25/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
                         method: 'POST',
                         headers,
                         data: { query: changeStatusQuery },
@@ -514,7 +514,7 @@ const sync = createSync({
 
                     const refetchConfig: ProxyConfiguration = {
                         // https://developers.google.com/google-ads/api/docs/reporting/streaming
-                        endpoint: `v21/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
+                        endpoint: `v25/customers/${encodeURIComponent(account.customerId)}/googleAds:searchStream`,
                         method: 'POST',
                         headers,
                         data: { query: refetchQuery },

--- a/integrations/google-ads/syncs/ad-groups.ts
+++ b/integrations/google-ads/syncs/ad-groups.ts
@@ -1,4 +1,5 @@
 import { createSync, type ProxyConfiguration } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const MetadataSchema = z.object({
@@ -266,9 +267,8 @@ const sync = createSync({
         }
         const metadata = metadataResult.data;
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/campaign-budgets.ts
+++ b/integrations/google-ads/syncs/campaign-budgets.ts
@@ -223,7 +223,7 @@ function mapCampaignBudgetRows(rows: z.infer<typeof CampaignBudgetResultSchema>[
 
 const sync = createSync({
     description: 'Sync campaign budgets for customer accounts in scope',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -339,7 +339,7 @@ async function runFullFetch(
 
     const proxyConfig: ProxyConfiguration = {
         // https://developers.google.com/google-ads/api/docs/reporting/streaming
-        endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+        endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
         method: 'POST',
         data: { query: fullQuery },
         headers,
@@ -406,7 +406,7 @@ async function runIncrementalFetch(
 
         const changeStatusProxyConfig: ProxyConfiguration = {
             // https://developers.google.com/google-ads/api/docs/reporting/streaming
-            endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+            endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
             method: 'POST',
             data: { query: changeStatusQuery },
             headers,
@@ -476,7 +476,7 @@ async function runIncrementalFetch(
 
             const budgetProxyConfig: ProxyConfiguration = {
                 // https://developers.google.com/google-ads/api/docs/reporting/streaming
-                endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+                endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
                 method: 'POST',
                 data: { query: budgetQuery },
                 headers,

--- a/integrations/google-ads/syncs/campaign-budgets.ts
+++ b/integrations/google-ads/syncs/campaign-budgets.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 
 const MetadataSchema = z.object({
     customer_ids: z.array(z.string()).min(1).describe('Google Ads customer IDs to sync campaign budgets for'),
-    login_customer_id: z.string().optional().describe('Manager account ID for API access hierarchy'),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    login_customer_id: z.string().optional().describe('Manager account ID for API access hierarchy')
 });
 
 // Checkpoint values must be scalars (string/number/boolean); the set of initialized customer IDs
@@ -224,7 +223,7 @@ function mapCampaignBudgetRows(rows: z.infer<typeof CampaignBudgetResultSchema>[
 
 const sync = createSync({
     description: 'Sync campaign budgets for customer accounts in scope',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -240,9 +239,15 @@ const sync = createSync({
             throw new Error(`Invalid metadata: ${metadataResult.error.message}`);
         }
 
-        const { customer_ids: customerIds, login_customer_id: loginCustomerId, developer_token: developerToken } = metadataResult.data;
+        const { customer_ids: customerIds, login_customer_id: loginCustomerId } = metadataResult.data;
         if (!customerIds || customerIds.length === 0) {
             throw new Error('customer_ids is required in metadata');
+        }
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
         }
 
         const rawCheckpoint = await nango.getCheckpoint();

--- a/integrations/google-ads/syncs/campaign-budgets.ts
+++ b/integrations/google-ads/syncs/campaign-budgets.ts
@@ -1,4 +1,5 @@
 import { createSync, type ProxyConfiguration } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const MetadataSchema = z.object({
@@ -244,9 +245,8 @@ const sync = createSync({
             throw new Error('customer_ids is required in metadata');
         }
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/campaign-criteria.ts
+++ b/integrations/google-ads/syncs/campaign-criteria.ts
@@ -201,7 +201,7 @@ function mapRowToCampaignCriterion(row: z.infer<typeof GoogleAdsRowSchema>): z.i
 
 const sync = createSync({
     description: 'Sync campaign-level criteria (negative keywords and location targeting) for customer accounts in scope.',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -294,7 +294,7 @@ const sync = createSync({
 
                         const csConfig: ProxyConfiguration = {
                             // https://developers.google.com/google-ads/api/docs/reporting/streaming
-                            endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:search`,
+                            endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:search`,
                             data: {
                                 query: csQuery,
                                 ...(csPageToken && { pageToken: csPageToken })
@@ -360,7 +360,7 @@ const sync = createSync({
 
                             const fetchConfig: ProxyConfiguration = {
                                 // https://developers.google.com/google-ads/api/docs/reporting/streaming
-                                endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:search`,
+                                endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:search`,
                                 data: {
                                     query: fetchQuery,
                                     ...(fetchPageToken && { pageToken: fetchPageToken })
@@ -405,7 +405,7 @@ const sync = createSync({
 
                     const config: ProxyConfiguration = {
                         // https://developers.google.com/google-ads/api/docs/reporting/streaming
-                        endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:search`,
+                        endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:search`,
                         data: {
                             query,
                             ...(pageToken && { pageToken })

--- a/integrations/google-ads/syncs/campaign-criteria.ts
+++ b/integrations/google-ads/syncs/campaign-criteria.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 
 const MetadataSchema = z.object({
     customerIds: z.array(z.string()),
-    loginCustomerId: z.string().optional(),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    loginCustomerId: z.string().optional()
 });
 
 // Checkpoint values must be scalars (string/number/boolean); the set of initialized customer IDs
@@ -60,9 +59,9 @@ const SearchResponseSchema = z.object({
     nextPageToken: z.string().optional()
 });
 
-function buildHeaders(metadata: z.infer<typeof MetadataSchema>): Record<string, string> {
+function buildHeaders(metadata: z.infer<typeof MetadataSchema>, developerToken: string): Record<string, string> {
     const headers: Record<string, string> = {
-        'developer-token': metadata.developerToken
+        'developer-token': developerToken
     };
     if (metadata.loginCustomerId) {
         headers['login-customer-id'] = metadata.loginCustomerId;
@@ -202,7 +201,7 @@ function mapRowToCampaignCriterion(row: z.infer<typeof GoogleAdsRowSchema>): z.i
 
 const sync = createSync({
     description: 'Sync campaign-level criteria (negative keywords and location targeting) for customer accounts in scope.',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -216,6 +215,12 @@ const sync = createSync({
         const metadata = MetadataSchema.parse(metadataRaw);
         if (metadata.customerIds.length === 0) {
             throw new Error('customerIds is required in metadata');
+        }
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
         }
 
         const checkpointRaw = await nango.getCheckpoint();
@@ -262,7 +267,7 @@ const sync = createSync({
         }
 
         for (const customerId of metadata.customerIds) {
-            const headers = buildHeaders(metadata);
+            const headers = buildHeaders(metadata, developerToken);
             const needsFullRefresh = customerNeedsFullRefresh.get(customerId) ?? true;
 
             if (!needsFullRefresh) {

--- a/integrations/google-ads/syncs/campaign-criteria.ts
+++ b/integrations/google-ads/syncs/campaign-criteria.ts
@@ -1,4 +1,5 @@
 import { createSync, type ProxyConfiguration } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const MetadataSchema = z.object({
@@ -217,9 +218,8 @@ const sync = createSync({
             throw new Error('customerIds is required in metadata');
         }
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/campaigns.ts
+++ b/integrations/google-ads/syncs/campaigns.ts
@@ -1,4 +1,5 @@
 import { createSync } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const MetadataSchema = z.object({
@@ -216,9 +217,8 @@ const sync = createSync({
             throw new Error('customer_ids is required in metadata');
         }
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 
@@ -238,7 +238,7 @@ const sync = createSync({
         );
         const now = formatDate(new Date());
 
-        async function searchStream(customerId: string, loginCustomerId: string, query: string): Promise<unknown[]> {
+        const searchStream = async (customerId: string, loginCustomerId: string, query: string): Promise<unknown[]> => {
             // https://developers.google.com/google-ads/api/docs/reporting/streaming
             const response = await nango.post({
                 endpoint: `/v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
@@ -252,7 +252,7 @@ const sync = createSync({
                 retries: 3
             });
             return extractSearchStreamRows(response.data);
-        }
+        };
 
         function parseCampaignRows(rows: unknown[]): Array<z.infer<typeof CampaignSchema>> {
             const campaigns: Array<z.infer<typeof CampaignSchema>> = [];

--- a/integrations/google-ads/syncs/campaigns.ts
+++ b/integrations/google-ads/syncs/campaigns.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 
 const MetadataSchema = z.object({
     customer_ids: z.array(z.string()).min(1),
-    login_customer_id: z.string(),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    login_customer_id: z.string()
 });
 
 // Checkpoint values must be scalars (string/number/boolean); the set of initialized customer IDs
@@ -197,7 +196,7 @@ function extractSearchStreamRows(data: unknown): unknown[] {
 
 const sync = createSync({
     description: 'Sync campaigns for customer accounts in scope.',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -215,6 +214,12 @@ const sync = createSync({
         const metadata = metadataResult.data;
         if (!metadata.customer_ids.length) {
             throw new Error('customer_ids is required in metadata');
+        }
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
         }
 
         const rawCheckpoint = await nango.getCheckpoint();
@@ -238,7 +243,7 @@ const sync = createSync({
             const response = await nango.post({
                 endpoint: `/v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
                 headers: {
-                    'developer-token': metadata.developer_token,
+                    'developer-token': developerToken,
                     'login-customer-id': loginCustomerId
                 },
                 data: {

--- a/integrations/google-ads/syncs/campaigns.ts
+++ b/integrations/google-ads/syncs/campaigns.ts
@@ -196,7 +196,7 @@ function extractSearchStreamRows(data: unknown): unknown[] {
 
 const sync = createSync({
     description: 'Sync campaigns for customer accounts in scope.',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -241,7 +241,7 @@ const sync = createSync({
         async function searchStream(customerId: string, loginCustomerId: string, query: string): Promise<unknown[]> {
             // https://developers.google.com/google-ads/api/docs/reporting/streaming
             const response = await nango.post({
-                endpoint: `/v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+                endpoint: `/v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
                 headers: {
                     'developer-token': developerToken,
                     'login-customer-id': loginCustomerId

--- a/integrations/google-ads/syncs/conversion-actions.ts
+++ b/integrations/google-ads/syncs/conversion-actions.ts
@@ -1,4 +1,5 @@
 import { createSync } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const ConversionActionSchema = z.object({
@@ -70,9 +71,8 @@ const sync = createSync({
         }
         const metadata = metadataResult.data;
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/conversion-actions.ts
+++ b/integrations/google-ads/syncs/conversion-actions.ts
@@ -20,8 +20,7 @@ const ConversionActionSchema = z.object({
 
 const MetadataSchema = z.object({
     customerIds: z.array(z.string()).min(1),
-    loginCustomerId: z.string().optional(),
-    developerToken: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    loginCustomerId: z.string().optional()
 });
 
 const GoogleAdsRowSchema = z.object({
@@ -55,7 +54,7 @@ const SearchStreamChunkSchema = z.object({
 
 const sync = createSync({
     description: 'Sync conversion actions configured on customer accounts in scope',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -71,6 +70,12 @@ const sync = createSync({
         }
         const metadata = metadataResult.data;
 
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
+        }
+
         // Blocker: Google Ads SearchStream does not support incremental filters,
         // resumable cursor pagination, or a deleted-record endpoint for conversion_action.
         // Conversion actions are a small, low-cardinality, long-lived reference set,
@@ -82,7 +87,7 @@ const sync = createSync({
             const response = await nango.post({
                 endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
                 headers: {
-                    'developer-token': metadata.developerToken,
+                    'developer-token': developerToken,
                     ...(metadata.loginCustomerId && {
                         'login-customer-id': metadata.loginCustomerId
                     })

--- a/integrations/google-ads/syncs/conversion-actions.ts
+++ b/integrations/google-ads/syncs/conversion-actions.ts
@@ -54,7 +54,7 @@ const SearchStreamChunkSchema = z.object({
 
 const sync = createSync({
     description: 'Sync conversion actions configured on customer accounts in scope',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -85,7 +85,7 @@ const sync = createSync({
         for (const customerId of metadata.customerIds) {
             // https://developers.google.com/google-ads/api/docs/reporting/streaming
             const response = await nango.post({
-                endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+                endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
                 headers: {
                     'developer-token': developerToken,
                     ...(metadata.loginCustomerId && {

--- a/integrations/google-ads/syncs/keyword-criteria.ts
+++ b/integrations/google-ads/syncs/keyword-criteria.ts
@@ -239,7 +239,7 @@ function mapResultToKeywordCriterion(result: z.infer<typeof SearchStreamResultSc
 async function fetchKeywordCriteriaViaSearchStream(nango: NangoSyncLocal, customerId: string, headers: Record<string, string>, query: string) {
     const proxyConfig: ProxyConfiguration = {
         // https://developers.google.com/google-ads/api/docs/reporting/streaming
-        endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+        endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
         method: 'POST',
         headers,
         data: { query },
@@ -284,7 +284,7 @@ async function fetchChangeStatusForWindow(
 
     const proxyConfig: ProxyConfiguration = {
         // https://developers.google.com/google-ads/api/docs/change-status
-        endpoint: `v21/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
+        endpoint: `v25/customers/${encodeURIComponent(customerId)}/googleAds:searchStream`,
         method: 'POST',
         headers,
         data: { query },
@@ -311,7 +311,7 @@ async function fetchChangeStatusForWindow(
 
 const sync = createSync({
     description: 'Sync ad group keyword criteria for customer accounts in scope',
-    version: '1.0.1',
+    version: '1.0.2',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,

--- a/integrations/google-ads/syncs/keyword-criteria.ts
+++ b/integrations/google-ads/syncs/keyword-criteria.ts
@@ -1,4 +1,5 @@
 import { createSync, ProxyConfiguration } from 'nango';
+import { getDeveloperToken } from '../helpers/get-developer-token.js';
 import { z } from 'zod';
 
 const KeywordCriterionSchema = z.object({
@@ -333,9 +334,8 @@ const sync = createSync({
 
         const loginCustomerId = parsedMetadata.data.login_customer_id;
 
-        const connection = await nango.getConnection();
-        const developerToken = connection.connection_config?.['developer_token'];
-        if (!developerToken || typeof developerToken !== 'string') {
+        const developerToken = await getDeveloperToken(nango);
+        if (!developerToken) {
             throw new Error('developer_token is required in connection config');
         }
 

--- a/integrations/google-ads/syncs/keyword-criteria.ts
+++ b/integrations/google-ads/syncs/keyword-criteria.ts
@@ -23,8 +23,7 @@ const CheckpointSchema = z.object({
 
 const MetadataSchema = z.object({
     customer_ids: z.array(z.string()).optional(),
-    login_customer_id: z.string().optional(),
-    developer_token: z.string().describe('Google Ads developer token. Example: "YOUR_DEVELOPER_TOKEN"')
+    login_customer_id: z.string().optional()
 });
 
 const SearchStreamResultSchema = z.object({
@@ -312,7 +311,7 @@ async function fetchChangeStatusForWindow(
 
 const sync = createSync({
     description: 'Sync ad group keyword criteria for customer accounts in scope',
-    version: '1.0.0',
+    version: '1.0.1',
     frequency: 'every hour',
     autoStart: false,
     metadata: MetadataSchema,
@@ -333,7 +332,13 @@ const sync = createSync({
         }
 
         const loginCustomerId = parsedMetadata.data.login_customer_id;
-        const developerToken = parsedMetadata.data.developer_token;
+
+        const connection = await nango.getConnection();
+        const developerToken = connection.connection_config?.['developer_token'];
+        if (!developerToken || typeof developerToken !== 'string') {
+            throw new Error('developer_token is required in connection config');
+        }
+
         const headers: Record<string, string> = {
             'developer-token': developerToken,
             ...(loginCustomerId && { 'login-customer-id': loginCustomerId })

--- a/integrations/google-ads/tests/accessible-customers.test.json
+++ b/integrations/google-ads/tests/accessible-customers.test.json
@@ -24,7 +24,7 @@
   },
   "api": {
     "get": {
-      "/v21/customers:listAccessibleCustomers": {
+      "/v25/customers:listAccessibleCustomers": {
         "response": {
           "resourceNames": [
             "customers/3608201627",
@@ -63,7 +63,7 @@
       }
     },
     "post": {
-      "/v21/customers/3608201627/googleAds:searchStream": {
+      "/v25/customers/3608201627/googleAds:searchStream": {
         "response": [
           {
             "results": [
@@ -115,7 +115,7 @@
           }
         }
       },
-      "/v21/customers/7202353356/googleAds:searchStream": {
+      "/v25/customers/7202353356/googleAds:searchStream": {
         "response": [
           {
             "error": {
@@ -124,7 +124,7 @@
               "status": "PERMISSION_DENIED",
               "details": [
                 {
-                  "@type": "type.googleapis.com/google.ads.googleads.v21.errors.GoogleAdsFailure",
+                  "@type": "type.googleapis.com/google.ads.googleads.v25.errors.GoogleAdsFailure",
                   "errors": [
                     {
                       "errorCode": {

--- a/integrations/google-ads/tests/accessible-customers.test.json
+++ b/integrations/google-ads/tests/accessible-customers.test.json
@@ -15,8 +15,11 @@
     "batchDelete": {
       "Customer": []
     },
-    "getMetadata": {
-      "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "getMetadata": {},
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     }
   },
   "api": {

--- a/integrations/google-ads/tests/ad-group-ads.test.json
+++ b/integrations/google-ads/tests/ad-group-ads.test.json
@@ -61,7 +61,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:searchStream": [
+      "/v25/customers/1781900691/googleAds:searchStream": [
         {
           "response": [
             {

--- a/integrations/google-ads/tests/ad-group-ads.test.json
+++ b/integrations/google-ads/tests/ad-group-ads.test.json
@@ -4,8 +4,12 @@
       "customer_ids": [
         "1781900691"
       ],
-      "login_customer_id": "3608201627",
-      "developer_token": "YOUR_DEVELOPER_TOKEN"
+      "login_customer_id": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "AdGroupAd": [

--- a/integrations/google-ads/tests/ad-groups.test.json
+++ b/integrations/google-ads/tests/ad-groups.test.json
@@ -4,8 +4,12 @@
       "customer_ids": [
         "1781900691"
       ],
-      "login_customer_id": "3608201627",
-      "developer_token": "YOUR_DEVELOPER_TOKEN"
+      "login_customer_id": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "AdGroup": [

--- a/integrations/google-ads/tests/ad-groups.test.json
+++ b/integrations/google-ads/tests/ad-groups.test.json
@@ -69,7 +69,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:searchStream": {
+      "/v25/customers/1781900691/googleAds:searchStream": {
         "response": [
           {
             "results": [

--- a/integrations/google-ads/tests/campaign-budgets.test.json
+++ b/integrations/google-ads/tests/campaign-budgets.test.json
@@ -89,7 +89,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:searchStream": {
+      "/v25/customers/1781900691/googleAds:searchStream": {
         "response": [
           {
             "results": [

--- a/integrations/google-ads/tests/campaign-budgets.test.json
+++ b/integrations/google-ads/tests/campaign-budgets.test.json
@@ -4,8 +4,12 @@
       "customer_ids": [
         "1781900691"
       ],
-      "login_customer_id": "3608201627",
-      "developer_token": "YOUR_DEVELOPER_TOKEN"
+      "login_customer_id": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "CampaignBudget": [

--- a/integrations/google-ads/tests/campaign-criteria.test.json
+++ b/integrations/google-ads/tests/campaign-criteria.test.json
@@ -4,8 +4,12 @@
       "customerIds": [
         "1781900691"
       ],
-      "loginCustomerId": "3608201627",
-      "developerToken": "YOUR_DEVELOPER_TOKEN"
+      "loginCustomerId": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "CampaignCriterion": [

--- a/integrations/google-ads/tests/campaign-criteria.test.json
+++ b/integrations/google-ads/tests/campaign-criteria.test.json
@@ -55,7 +55,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:search": {
+      "/v25/customers/1781900691/googleAds:search": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/campaigns.test.json
+++ b/integrations/google-ads/tests/campaigns.test.json
@@ -4,8 +4,12 @@
       "customer_ids": [
         "1781900691"
       ],
-      "login_customer_id": "3608201627",
-      "developer_token": "YOUR_DEVELOPER_TOKEN"
+      "login_customer_id": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "Campaign": [

--- a/integrations/google-ads/tests/campaigns.test.json
+++ b/integrations/google-ads/tests/campaigns.test.json
@@ -81,7 +81,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:searchStream": {
+      "/v25/customers/1781900691/googleAds:searchStream": {
         "response": [
           {
             "results": [

--- a/integrations/google-ads/tests/conversion-actions.test.json
+++ b/integrations/google-ads/tests/conversion-actions.test.json
@@ -4,8 +4,12 @@
       "customerIds": [
         "1781900691"
       ],
-      "loginCustomerId": "3608201627",
-      "developerToken": "YOUR_DEVELOPER_TOKEN"
+      "loginCustomerId": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "ConversionAction": [

--- a/integrations/google-ads/tests/conversion-actions.test.json
+++ b/integrations/google-ads/tests/conversion-actions.test.json
@@ -87,7 +87,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:searchStream": {
+      "/v25/customers/1781900691/googleAds:searchStream": {
         "response": [
           {
             "results": [

--- a/integrations/google-ads/tests/create-ad-group-ad.test.json
+++ b/integrations/google-ads/tests/create-ad-group-ad.test.json
@@ -31,7 +31,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/adGroupAds:mutate": {
+      "/v25/customers/1781900691/adGroupAds:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/create-ad-group-ad.test.json
+++ b/integrations/google-ads/tests/create-ad-group-ad.test.json
@@ -15,15 +15,20 @@
     "finalUrls": [
       "https://example.com"
     ],
-    "status": "ENABLED",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "status": "ENABLED"
   },
   "output": {
     "resourceName": "customers/1781900691/adGroupAds/197714341345~816948922766",
     "adGroupAdId": "197714341345~816948922766",
     "adId": "816948922766"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/adGroupAds:mutate": {

--- a/integrations/google-ads/tests/create-ad-group.test.json
+++ b/integrations/google-ads/tests/create-ad-group.test.json
@@ -5,8 +5,7 @@
         "type": "SEARCH_STANDARD",
         "status": "ENABLED",
         "cpcBidMicros": "1000000",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/adGroups/199918694042",
@@ -17,7 +16,13 @@
         "campaign": "customers/1781900691/campaigns/24027360183",
         "cpcBidMicros": "1000000"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/adGroups:mutate": {

--- a/integrations/google-ads/tests/create-ad-group.test.json
+++ b/integrations/google-ads/tests/create-ad-group.test.json
@@ -25,7 +25,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/adGroups:mutate": {
+            "/v25/customers/1781900691/adGroups:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/create-campaign-budget.test.json
+++ b/integrations/google-ads/tests/create-campaign-budget.test.json
@@ -5,14 +5,19 @@
     "name": "Nango Test Budget",
     "amountMicros": "1000000",
     "deliveryMethod": "STANDARD",
-    "explicitlyShared": false,
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "explicitlyShared": false
   },
   "output": {
     "resourceName": "customers/1781900691/campaignBudgets/15722764465",
     "id": "15722764465"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/campaignBudgets:mutate": {

--- a/integrations/google-ads/tests/create-campaign-budget.test.json
+++ b/integrations/google-ads/tests/create-campaign-budget.test.json
@@ -20,7 +20,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/campaignBudgets:mutate": {
+      "/v25/customers/1781900691/campaignBudgets:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/create-campaign-location-criterion.test.json
+++ b/integrations/google-ads/tests/create-campaign-location-criterion.test.json
@@ -17,7 +17,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/campaignCriteria:mutate": {
+      "/v25/customers/1781900691/campaignCriteria:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/create-campaign-location-criterion.test.json
+++ b/integrations/google-ads/tests/create-campaign-location-criterion.test.json
@@ -3,13 +3,18 @@
     "customerId": "1781900691",
     "loginCustomerId": "3608201627",
     "campaign": "customers/1781900691/campaigns/24027360183",
-    "geoTargetConstant": "geoTargetConstants/2840",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "geoTargetConstant": "geoTargetConstants/2840"
   },
   "output": {
     "resourceName": "customers/1781900691/campaignCriteria/24027360183~2840"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/campaignCriteria:mutate": {

--- a/integrations/google-ads/tests/create-campaign-negative-keyword.test.json
+++ b/integrations/google-ads/tests/create-campaign-negative-keyword.test.json
@@ -4,13 +4,18 @@
         "campaignId": "24027360183",
         "text": "test-negative-keyword-2026-07-15",
         "matchType": "EXACT",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/campaignCriteria/24027360183~2491232117279"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/campaignCriteria:mutate": {

--- a/integrations/google-ads/tests/create-campaign-negative-keyword.test.json
+++ b/integrations/google-ads/tests/create-campaign-negative-keyword.test.json
@@ -18,7 +18,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/campaignCriteria:mutate": {
+            "/v25/customers/1781900691/campaignCriteria:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/create-campaign.test.json
+++ b/integrations/google-ads/tests/create-campaign.test.json
@@ -28,7 +28,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/campaigns:mutate": {
+            "/v25/customers/1781900691/campaigns:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/create-campaign.test.json
+++ b/integrations/google-ads/tests/create-campaign.test.json
@@ -13,14 +13,19 @@
             "targetPartnerSearchNetwork": false
         },
         "containsEuPoliticalAdvertising": "DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/campaigns/24036880939",
         "campaignId": "24036880939"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/campaigns:mutate": {

--- a/integrations/google-ads/tests/create-conversion-action.test.json
+++ b/integrations/google-ads/tests/create-conversion-action.test.json
@@ -20,7 +20,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/conversionActions:mutate": {
+      "/v25/customers/1781900691/conversionActions:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/create-conversion-action.test.json
+++ b/integrations/google-ads/tests/create-conversion-action.test.json
@@ -2,7 +2,6 @@
   "input": {
     "customerId": "1781900691",
     "loginCustomerId": "3608201627",
-    "developerToken": "YOUR_DEVELOPER_TOKEN",
     "name": "Nango Test Conversion 1784076979",
     "type": "WEBPAGE",
     "category": "DEFAULT",
@@ -12,7 +11,13 @@
   "output": {
     "resourceName": "customers/1781900691/conversionActions/7685281095"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/conversionActions:mutate": {

--- a/integrations/google-ads/tests/create-keyword-criterion.test.json
+++ b/integrations/google-ads/tests/create-keyword-criterion.test.json
@@ -20,7 +20,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/adGroupCriteria:mutate": {
+            "/v25/customers/1781900691/adGroupCriteria:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/create-keyword-criterion.test.json
+++ b/integrations/google-ads/tests/create-keyword-criterion.test.json
@@ -5,14 +5,19 @@
         "keywordText": "nango-test-exact-12345",
         "keywordMatchType": "EXACT",
         "status": "ENABLED",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/adGroupCriteria/197714341345~2493641512920",
         "criterionId": "2493641512920"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/adGroupCriteria:mutate": {

--- a/integrations/google-ads/tests/create-negative-keyword.test.json
+++ b/integrations/google-ads/tests/create-negative-keyword.test.json
@@ -4,13 +4,18 @@
     "login_customer_id": "3608201627",
     "ad_group_id": "197714341345",
     "text": "test-negative-exact-002",
-    "match_type": "EXACT",
-    "developer_token": "YOUR_DEVELOPER_TOKEN"
+    "match_type": "EXACT"
   },
   "output": {
     "resource_name": "customers/1781900691/adGroupCriteria/197714341345~2493166445236"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/adGroupCriteria:mutate": {

--- a/integrations/google-ads/tests/create-negative-keyword.test.json
+++ b/integrations/google-ads/tests/create-negative-keyword.test.json
@@ -18,7 +18,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/adGroupCriteria:mutate": {
+      "/v25/customers/1781900691/adGroupCriteria:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/generate-keyword-ideas.test.json
+++ b/integrations/google-ads/tests/generate-keyword-ideas.test.json
@@ -54545,7 +54545,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691:generateKeywordIdeas": {
+      "/v25/customers/1781900691:generateKeywordIdeas": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/generate-keyword-ideas.test.json
+++ b/integrations/google-ads/tests/generate-keyword-ideas.test.json
@@ -9,7 +9,6 @@
       "geoTargetConstants/2840"
     ],
     "keywordPlanNetwork": "GOOGLE_SEARCH",
-    "developerToken": "YOUR_DEVELOPER_TOKEN",
     "loginCustomerId": "3608201627"
   },
   "output": {
@@ -54537,7 +54536,13 @@
     ],
     "totalSize": "758"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691:generateKeywordIdeas": {

--- a/integrations/google-ads/tests/keyword-criteria.test.json
+++ b/integrations/google-ads/tests/keyword-criteria.test.json
@@ -4,8 +4,12 @@
       "customer_ids": [
         "1781900691"
       ],
-      "login_customer_id": "3608201627",
-      "developer_token": "YOUR_DEVELOPER_TOKEN"
+      "login_customer_id": "3608201627"
+    },
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
     },
     "batchSave": {
       "KeywordCriterion": [

--- a/integrations/google-ads/tests/keyword-criteria.test.json
+++ b/integrations/google-ads/tests/keyword-criteria.test.json
@@ -93,7 +93,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:searchStream": {
+      "/v25/customers/1781900691/googleAds:searchStream": {
         "response": [
           {
             "results": [

--- a/integrations/google-ads/tests/list-accessible-customers.test.json
+++ b/integrations/google-ads/tests/list-accessible-customers.test.json
@@ -1,14 +1,18 @@
 {
-  "input": {
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
-  },
+  "input": {},
   "output": {
     "resourceNames": [
       "customers/3608201627",
       "customers/7202353356"
     ]
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "get": {
       "/v21/customers:listAccessibleCustomers": {

--- a/integrations/google-ads/tests/list-accessible-customers.test.json
+++ b/integrations/google-ads/tests/list-accessible-customers.test.json
@@ -15,7 +15,7 @@
   },
   "api": {
     "get": {
-      "/v21/customers:listAccessibleCustomers": {
+      "/v25/customers:listAccessibleCustomers": {
         "response": {
           "resourceNames": [
             "customers/3608201627",

--- a/integrations/google-ads/tests/remove-ad-group-ad.test.json
+++ b/integrations/google-ads/tests/remove-ad-group-ad.test.json
@@ -15,7 +15,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/adGroupAds:mutate": {
+            "/v25/customers/1781900691/adGroupAds:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/remove-ad-group-ad.test.json
+++ b/integrations/google-ads/tests/remove-ad-group-ad.test.json
@@ -1,13 +1,18 @@
 {
     "input": {
         "resource_name": "customers/1781900691/adGroupAds/197714341385~816946667447",
-        "login_customer_id": "3608201627",
-        "developer_token": "YOUR_DEVELOPER_TOKEN"
+        "login_customer_id": "3608201627"
     },
     "output": {
         "resource_name": "customers/1781900691/adGroupAds/197714341385~816946667447"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/adGroupAds:mutate": {

--- a/integrations/google-ads/tests/remove-ad-group.test.json
+++ b/integrations/google-ads/tests/remove-ad-group.test.json
@@ -15,7 +15,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/adGroups:mutate": {
+            "/v25/customers/1781900691/adGroups:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/remove-ad-group.test.json
+++ b/integrations/google-ads/tests/remove-ad-group.test.json
@@ -1,13 +1,18 @@
 {
     "input": {
         "resourceName": "customers/1781900691/adGroups/197714341425",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/adGroups/197714341425"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/adGroups:mutate": {

--- a/integrations/google-ads/tests/remove-campaign-budget.test.json
+++ b/integrations/google-ads/tests/remove-campaign-budget.test.json
@@ -1,13 +1,18 @@
 {
     "input": {
         "resource_name": "customers/1781900691/campaignBudgets/15722745985",
-        "login_customer_id": "3608201627",
-        "developer_token": "YOUR_DEVELOPER_TOKEN"
+        "login_customer_id": "3608201627"
     },
     "output": {
         "resource_name": "customers/1781900691/campaignBudgets/15722745985"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/campaignBudgets:mutate": {

--- a/integrations/google-ads/tests/remove-campaign-budget.test.json
+++ b/integrations/google-ads/tests/remove-campaign-budget.test.json
@@ -15,7 +15,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/campaignBudgets:mutate": {
+            "/v25/customers/1781900691/campaignBudgets:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/remove-campaign-criterion.test.json
+++ b/integrations/google-ads/tests/remove-campaign-criterion.test.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/campaignCriteria:mutate": {
+      "/v25/customers/1781900691/campaignCriteria:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/remove-campaign-criterion.test.json
+++ b/integrations/google-ads/tests/remove-campaign-criterion.test.json
@@ -2,13 +2,18 @@
   "input": {
     "customerId": "1781900691",
     "loginCustomerId": "3608201627",
-    "resourceName": "customers/1781900691/campaignCriteria/24027360183~2493641548280",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "resourceName": "customers/1781900691/campaignCriteria/24027360183~2493641548280"
   },
   "output": {
     "resourceName": "customers/1781900691/campaignCriteria/24027360183~2493641548280"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/campaignCriteria:mutate": {

--- a/integrations/google-ads/tests/remove-campaign.test.json
+++ b/integrations/google-ads/tests/remove-campaign.test.json
@@ -15,7 +15,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/campaigns:mutate": {
+      "/v25/customers/1781900691/campaigns:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/remove-campaign.test.json
+++ b/integrations/google-ads/tests/remove-campaign.test.json
@@ -1,13 +1,18 @@
 {
   "input": {
     "resourceName": "customers/1781900691/campaigns/24036861754",
-    "loginCustomerId": "3608201627",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "loginCustomerId": "3608201627"
   },
   "output": {
     "resourceName": "customers/1781900691/campaigns/24036861754"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/campaigns:mutate": {

--- a/integrations/google-ads/tests/remove-conversion-action.test.json
+++ b/integrations/google-ads/tests/remove-conversion-action.test.json
@@ -15,7 +15,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/conversionActions:mutate": {
+            "/v25/customers/1781900691/conversionActions:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/remove-conversion-action.test.json
+++ b/integrations/google-ads/tests/remove-conversion-action.test.json
@@ -1,13 +1,18 @@
 {
     "input": {
         "resourceName": "customers/1781900691/conversionActions/7684896446",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/conversionActions/7684896446"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/conversionActions:mutate": {

--- a/integrations/google-ads/tests/remove-keyword-criterion.test.json
+++ b/integrations/google-ads/tests/remove-keyword-criterion.test.json
@@ -1,14 +1,19 @@
 {
   "input": {
     "resource_name": "customers/1781900691/adGroupCriteria/197714341385~2491223357279",
-    "login_customer_id": "3608201627",
-    "developer_token": "YOUR_DEVELOPER_TOKEN"
+    "login_customer_id": "3608201627"
   },
   "output": {
     "resource_name": "customers/1781900691/adGroupCriteria/197714341385~2491223357279",
     "success": true
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/adGroupCriteria:mutate": {

--- a/integrations/google-ads/tests/remove-keyword-criterion.test.json
+++ b/integrations/google-ads/tests/remove-keyword-criterion.test.json
@@ -16,7 +16,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/adGroupCriteria:mutate": {
+      "/v25/customers/1781900691/adGroupCriteria:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/search-google-ads.test.json
+++ b/integrations/google-ads/tests/search-google-ads.test.json
@@ -24,7 +24,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/googleAds:search": {
+      "/v25/customers/1781900691/googleAds:search": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/search-google-ads.test.json
+++ b/integrations/google-ads/tests/search-google-ads.test.json
@@ -2,8 +2,7 @@
   "input": {
     "customerId": "1781900691",
     "query": "SELECT campaign.id, campaign.name FROM campaign LIMIT 1",
-    "loginCustomerId": "3608201627",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "loginCustomerId": "3608201627"
   },
   "output": {
     "results": [
@@ -16,7 +15,13 @@
       }
     ]
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/googleAds:search": {

--- a/integrations/google-ads/tests/search-stream-google-ads.test.json
+++ b/integrations/google-ads/tests/search-stream-google-ads.test.json
@@ -26,7 +26,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/googleAds:searchStream": {
+            "/v25/customers/1781900691/googleAds:searchStream": {
                 "response": [
                     {
                         "results": [

--- a/integrations/google-ads/tests/search-stream-google-ads.test.json
+++ b/integrations/google-ads/tests/search-stream-google-ads.test.json
@@ -2,8 +2,7 @@
     "input": {
         "customerId": "1781900691",
         "query": "SELECT campaign.id, campaign.name FROM campaign WHERE campaign.id = 24027360183",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "rows": [
@@ -18,7 +17,13 @@
         "fieldMask": "campaign.id,campaign.name",
         "requestId": "-wmLytVuBONxut172E248A"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/googleAds:searchStream": {

--- a/integrations/google-ads/tests/suggest-geo-target-constants.test.json
+++ b/integrations/google-ads/tests/suggest-geo-target-constants.test.json
@@ -325,7 +325,7 @@
   },
   "api": {
     "post": {
-      "/v21/geoTargetConstants:suggest": {
+      "/v25/geoTargetConstants:suggest": {
         "response": {
           "geoTargetConstantSuggestions": [
             {

--- a/integrations/google-ads/tests/suggest-geo-target-constants.test.json
+++ b/integrations/google-ads/tests/suggest-geo-target-constants.test.json
@@ -6,8 +6,7 @@
       "names": [
         "New York"
       ]
-    },
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    }
   },
   "output": {
     "geoTargetConstantSuggestions": [
@@ -317,7 +316,13 @@
       }
     ]
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/geoTargetConstants:suggest": {

--- a/integrations/google-ads/tests/update-ad-group-ad.test.json
+++ b/integrations/google-ads/tests/update-ad-group-ad.test.json
@@ -18,7 +18,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/adGroupAds:mutate": {
+            "/v25/customers/1781900691/adGroupAds:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/update-ad-group-ad.test.json
+++ b/integrations/google-ads/tests/update-ad-group-ad.test.json
@@ -4,13 +4,18 @@
         "resourceName": "customers/1781900691/adGroupAds/197714341345~816946667438",
         "updateMask": "status",
         "status": "PAUSED",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/adGroupAds/197714341345~816946667438"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/adGroupAds:mutate": {

--- a/integrations/google-ads/tests/update-ad-group.test.json
+++ b/integrations/google-ads/tests/update-ad-group.test.json
@@ -3,13 +3,18 @@
     "customerId": "1781900691",
     "loginCustomerId": "3608201627",
     "adGroupId": "197714341345",
-    "name": "Seed Ad Group Keep 1 - Updated",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "name": "Seed Ad Group Keep 1 - Updated"
   },
   "output": {
     "resourceName": "customers/1781900691/adGroups/197714341345"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/adGroups:mutate": {

--- a/integrations/google-ads/tests/update-ad-group.test.json
+++ b/integrations/google-ads/tests/update-ad-group.test.json
@@ -17,7 +17,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/adGroups:mutate": {
+      "/v25/customers/1781900691/adGroups:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/update-campaign-budget.test.json
+++ b/integrations/google-ads/tests/update-campaign-budget.test.json
@@ -17,7 +17,7 @@
     },
     "api": {
         "post": {
-            "/v21/customers/1781900691/campaignBudgets:mutate": {
+            "/v25/customers/1781900691/campaignBudgets:mutate": {
                 "response": {
                     "results": [
                         {

--- a/integrations/google-ads/tests/update-campaign-budget.test.json
+++ b/integrations/google-ads/tests/update-campaign-budget.test.json
@@ -3,13 +3,18 @@
         "customerId": "1781900691",
         "campaignBudgetId": "15717542877",
         "amountMicros": "600000",
-        "loginCustomerId": "3608201627",
-        "developerToken": "YOUR_DEVELOPER_TOKEN"
+        "loginCustomerId": "3608201627"
     },
     "output": {
         "resourceName": "customers/1781900691/campaignBudgets/15717542877"
     },
-    "nango": {},
+    "nango": {
+        "getConnection": {
+            "connection_config": {
+                "developer_token": "YOUR_DEVELOPER_TOKEN"
+            }
+        }
+    },
     "api": {
         "post": {
             "/v21/customers/1781900691/campaignBudgets:mutate": {

--- a/integrations/google-ads/tests/update-campaign.test.json
+++ b/integrations/google-ads/tests/update-campaign.test.json
@@ -6,14 +6,17 @@
       "name"
     ],
     "name": "Seed Campaign Keep 1 Updated",
-    "loginCustomerId": "3608201627",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "loginCustomerId": "3608201627"
   },
   "output": {
     "resourceName": "customers/1781900691/campaigns/24027360183"
   },
   "nango": {
-    "getConnection": {}
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
   },
   "api": {
     "post": {

--- a/integrations/google-ads/tests/update-campaign.test.json
+++ b/integrations/google-ads/tests/update-campaign.test.json
@@ -20,7 +20,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/campaigns:mutate": {
+      "/v25/customers/1781900691/campaigns:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/update-conversion-action.test.json
+++ b/integrations/google-ads/tests/update-conversion-action.test.json
@@ -3,13 +3,18 @@
     "customerId": "1781900691",
     "conversionActionId": "7685274465",
     "name": "Seed Conversion Action Keep 1 Updated",
-    "developerToken": "YOUR_DEVELOPER_TOKEN",
     "loginCustomerId": "3608201627"
   },
   "output": {
     "resourceName": "customers/1781900691/conversionActions/7685274465"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/conversionActions:mutate": {

--- a/integrations/google-ads/tests/update-conversion-action.test.json
+++ b/integrations/google-ads/tests/update-conversion-action.test.json
@@ -17,7 +17,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/conversionActions:mutate": {
+      "/v25/customers/1781900691/conversionActions:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/update-keyword-criterion.test.json
+++ b/integrations/google-ads/tests/update-keyword-criterion.test.json
@@ -3,13 +3,18 @@
     "customerId": "1781900691",
     "loginCustomerId": "3608201627",
     "resourceName": "customers/1781900691/adGroupCriteria/197714341345~2491223357039",
-    "cpcBidMicros": "1500000",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "cpcBidMicros": "1500000"
   },
   "output": {
     "resourceName": "customers/1781900691/adGroupCriteria/197714341345~2491223357039"
   },
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/adGroupCriteria:mutate": {

--- a/integrations/google-ads/tests/update-keyword-criterion.test.json
+++ b/integrations/google-ads/tests/update-keyword-criterion.test.json
@@ -17,7 +17,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/adGroupCriteria:mutate": {
+      "/v25/customers/1781900691/adGroupCriteria:mutate": {
         "response": {
           "results": [
             {

--- a/integrations/google-ads/tests/validate-google-ads-mutate.test.json
+++ b/integrations/google-ads/tests/validate-google-ads-mutate.test.json
@@ -12,11 +12,16 @@
         }
       ]
     },
-    "loginCustomerId": "3608201627",
-    "developerToken": "YOUR_DEVELOPER_TOKEN"
+    "loginCustomerId": "3608201627"
   },
   "output": {},
-  "nango": {},
+  "nango": {
+    "getConnection": {
+      "connection_config": {
+        "developer_token": "YOUR_DEVELOPER_TOKEN"
+      }
+    }
+  },
   "api": {
     "post": {
       "/v21/customers/1781900691/campaignBudgets:mutate": {

--- a/integrations/google-ads/tests/validate-google-ads-mutate.test.json
+++ b/integrations/google-ads/tests/validate-google-ads-mutate.test.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "path": "v21/customers/1781900691/campaignBudgets:mutate",
+    "path": "v25/customers/1781900691/campaignBudgets:mutate",
     "body": {
       "operations": [
         {
@@ -24,7 +24,7 @@
   },
   "api": {
     "post": {
-      "/v21/customers/1781900691/campaignBudgets:mutate": {
+      "/v25/customers/1781900691/campaignBudgets:mutate": {
         "response": {},
         "status": 200,
         "headers": {


### PR DESCRIPTION
## Describe your changes
- Migrate to latest API version (v25)
- Use`developer-token` from connection configuration

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Google Ads developer token handling and upgrades all routes to API v25. Previously actions and syncs accepted developerToken and called v21; now they read `developer_token` from connection config via `getDeveloperToken` and call v25, rejecting extra input properties.

- Migration
  - Set `developer_token` on each Google Ads connection’s connection_config.
  - Stop sending developerToken in action inputs and sync metadata; unknown fields are rejected.
  - Verify GAQL queries and resource names on v25; update any v21-only paths.

- Review notes
  - Actions/syncs build headers using the config `developer_token`; optional login-customer-id continues to be forwarded.
  - Schemas drop developerToken and bump versions to 1.0.2; `integrations/.nango/nango.json` and `internal/flows.zero.json` updated.
  - Tests and endpoints switched from v21 to v25, including the `validate-google-ads-mutate` path.

<sup>Written for commit e26d3c5abb24fa656ba6c8905cfabc9e6c8ce137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

