### PR TITLE
feat: add Granola templates

### DIFF
--- a/integrations/granola/actions/get-note.ts
+++ b/integrations/granola/actions/get-note.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z
+    .object({
+        note_id: z.string().describe('The ID of the note to retrieve. Example: not_1d3tmYTlCICgjy'),
+        include_transcript: z
+            .boolean()
+            .optional()
+            .describe('Whether to include the transcript inline in the response. If the transcript is too large, the API returns a 413 error.')
+    })
+    .describe('Input for retrieving a single Granola meeting note.');
+
+const UserSchema = z.object({
+    name: z.string().nullable().describe('The name of the user, or null if not set.'),
+    email: z.string().describe('The email of the user.')
+});
+
+const CalendarInviteeSchema = z.object({
+    email: z.string().describe('The email of the calendar invitee.')
+});
+
+const CalendarEventSchema = z.object({
+    event_title: z.string().nullable().describe('The title of the calendar event, or null if not available.'),
+    invitees: z.array(CalendarInviteeSchema).describe('The invitees of the calendar event.'),
+    organiser: z.string().nullable().describe('The email of the organiser, or null if not available.'),
+    calendar_event_id: z.string().nullable().describe('The ID of the calendar event, or null if not available.'),
+    scheduled_start_time: z.string().nullable().describe('The scheduled start time of the calendar event, or null if not available.'),
+    scheduled_end_time: z.string().nullable().describe('The scheduled end time of the calendar event, or null if not available.')
+});
+
+const FolderSchema = z.object({
+    id: z.string().describe('The ID of the folder.'),
+    object: z.string().describe('The object type of the folder.'),
+    name: z.string().describe('The name of the folder.'),
+    parent_folder_id: z.string().nullable().describe('The ID of the parent folder, or null if the folder is top-level.')
+});
+
+const SpeakerSchema = z.object({
+    source: z.string().describe('The source of the speaker.'),
+    attribution: z.string().optional().describe('Who said this relative to the note owner.'),
+    diarization_label: z.string().optional().describe('The diarized anonymous speaker label assigned in the transcript.'),
+    name: z.string().optional().describe('The resolved name of the identified speaker.')
+});
+
+const TranscriptSchema = z.object({
+    speaker: SpeakerSchema.describe('The speaker information for this transcript segment.'),
+    text: z.string().describe('The text of the transcript segment.'),
+    start_time: z.string().describe('The start time of the transcript segment.'),
+    end_time: z.string().describe('The end time of the transcript segment.')
+});
+
+const OutputSchema = z
+    .object({
+        id: z.string().describe('The ID of the note.'),
+        object: z.string().describe('The object type of the note.'),
+        title: z.string().nullable().describe('The title of the note, or null if not set.'),
+        owner: UserSchema.describe('The owner of the note.'),
+        created_at: z.string().describe('The creation time of the note.'),
+        updated_at: z.string().describe('The last update time of the note.'),
+        web_url: z.string().describe('The URL to view the note in the Granola web app.'),
+        calendar_event: CalendarEventSchema.nullable().describe('The calendar event associated with the note, or null if not available.'),
+        attendees: z.array(UserSchema).describe('The attendees of the meeting.'),
+        folder_membership: z.array(FolderSchema).describe('The folders this note belongs to.'),
+        summary_text: z.string().describe('The summary text of the note.'),
+        summary_markdown: z.string().nullable().describe('The summary of the note in markdown format, or null if not available.'),
+        private_notes_text: z.string().nullable().describe('The private notes text of the note owner, or null if the API key does not belong to the owner.'),
+        private_notes_markdown: z
+            .string()
+            .nullable()
+            .describe('The private notes markdown of the note owner, or null if the API key does not belong to the owner.'),
+        transcript: z.array(TranscriptSchema).nullable().describe('The inline transcript of the note, or null if not included or too large to return.')
+    })
+    .describe('A Granola meeting note.');
+
+/**
+ * @tags: [read]
+ * @tagReason: Retrieves a single meeting note from the Granola API.
+ * @pitfalls: When include_transcript is true and the transcript is too large, the action throws an error instead of returning a note with a null transcript; use the get-transcript action to retrieve large transcripts.
+ */
+const action = createAction({
+    description: 'Retrieve a single meeting note, optionally with its transcript inlined.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://docs.granola.ai/api-reference/get-note.md
+        const response = await nango.get({
+            endpoint: `/v1/notes/${encodeURIComponent(input.note_id)}`,
+            params: {
+                ...(input.include_transcript && { include: 'transcript' })
+            },
+            retries: 3
+        });
+
+        if (response.status === 404) {
+            throw new nango.ActionError({
+                type: 'not_found',
+                message: 'Note not found',
+                note_id: input.note_id
+            });
+        }
+
+        if (response.status === 413) {
+            throw new nango.ActionError({
+                type: 'transcript_too_large',
+                message: 'The transcript is too large to return inline. Use the get-transcript action to retrieve it in pages.',
+                note_id: input.note_id
+            });
+        }
+
+        const note = OutputSchema.parse(response.data);
+        return note;
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/granola/actions/get-note.ts
+++ b/integrations/granola/actions/get-note.ts
@@ -69,7 +69,7 @@ const OutputSchema = z
         calendar_event: CalendarEventSchema.nullable().describe('The calendar event associated with the note, or null if not available.'),
         attendees: z.array(UserSchema).describe('The attendees of the meeting.'),
         folder_membership: z.array(FolderSchema).describe('The folders this note belongs to.'),
-        space_membership: z.array(SpaceSchema).describe('The spaces this note belongs to.'),
+        space_membership: z.array(SpaceSchema).default([]).describe('The spaces this note belongs to.'),
         summary_text: z.string().describe('The summary text of the note.'),
         summary_markdown: z.string().nullable().describe('The summary of the note in markdown format, or null if not available.'),
         private_notes_text: z.string().nullable().describe('The private notes text of the note owner, or null if the API key does not belong to the owner.'),

--- a/integrations/granola/actions/get-note.ts
+++ b/integrations/granola/actions/get-note.ts
@@ -33,7 +33,14 @@ const FolderSchema = z.object({
     id: z.string().describe('The ID of the folder.'),
     object: z.string().describe('The object type of the folder.'),
     name: z.string().describe('The name of the folder.'),
-    parent_folder_id: z.string().nullable().describe('The ID of the parent folder, or null if the folder is top-level.')
+    parent_folder_id: z.string().nullable().describe('The ID of the parent folder, or null if the folder is top-level.'),
+    space_id: z.string().optional().describe('The ID of the space this folder belongs to.')
+});
+
+const SpaceSchema = z.object({
+    id: z.string().describe('The ID of the space.'),
+    object: z.string().describe('The object type of the space.'),
+    name: z.string().describe('The name of the space.')
 });
 
 const SpeakerSchema = z.object({
@@ -62,6 +69,7 @@ const OutputSchema = z
         calendar_event: CalendarEventSchema.nullable().describe('The calendar event associated with the note, or null if not available.'),
         attendees: z.array(UserSchema).describe('The attendees of the meeting.'),
         folder_membership: z.array(FolderSchema).describe('The folders this note belongs to.'),
+        space_membership: z.array(SpaceSchema).describe('The spaces this note belongs to.'),
         summary_text: z.string().describe('The summary text of the note.'),
         summary_markdown: z.string().nullable().describe('The summary of the note in markdown format, or null if not available.'),
         private_notes_text: z.string().nullable().describe('The private notes text of the note owner, or null if the API key does not belong to the owner.'),

--- a/integrations/granola/actions/get-transcript.ts
+++ b/integrations/granola/actions/get-transcript.ts
@@ -5,7 +5,7 @@ const InputSchema = z
     .object({
         note_id: z.string().describe('Unique identifier of the note whose transcript to retrieve. Example: "not_IBuThyr2eJgage"'),
         cursor: z.string().optional().describe('Opaque pagination cursor from a previous response. Omit for the first page.'),
-        page_size: z.number().min(1).max(100).optional().describe('Number of transcript segments per page. Maximum 100, default 50.')
+        page_size: z.number().int().min(1).max(100).optional().describe('Number of transcript segments per page. Maximum 100, default 50.')
     })
     .describe('Input for retrieving a paginated meeting transcript.');
 

--- a/integrations/granola/actions/get-transcript.ts
+++ b/integrations/granola/actions/get-transcript.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z
+    .object({
+        note_id: z.string().describe('Unique identifier of the note whose transcript to retrieve. Example: "not_IBuThyr2eJgage"'),
+        cursor: z.string().optional().describe('Opaque pagination cursor from a previous response. Omit for the first page.'),
+        page_size: z.number().min(1).max(100).optional().describe('Number of transcript segments per page. Maximum 100, default 50.')
+    })
+    .describe('Input for retrieving a paginated meeting transcript.');
+
+const SpeakerSchema = z
+    .object({
+        source: z.string().describe('Source of the speaker attribution, such as "microphone" or "speaker".'),
+        attribution: z
+            .string()
+            .optional()
+            .describe('Who said this relative to the note: "me" is the note-taker, "them" is other participants. Omitted when unknown.'),
+        diarization_label: z
+            .string()
+            .optional()
+            .describe('Diarized anonymous speaker label, such as "Speaker A". Present only on iOS transcripts when diarization is available.'),
+        name: z.string().optional().describe('Resolved name of the identified speaker, such as "Alice Smith". Present only when a speaker could be identified.')
+    })
+    .describe('Speaker information for a transcript segment.');
+
+const TranscriptSegmentSchema = z
+    .object({
+        text: z.string().describe('Spoken text of the segment.'),
+        start_time: z.string().describe('ISO 8601 start time of the segment.'),
+        end_time: z.string().describe('ISO 8601 end time of the segment.'),
+        speaker: SpeakerSchema.describe('Speaker information for this segment.')
+    })
+    .describe('A single segment of a meeting transcript.');
+
+const OutputSchema = z
+    .object({
+        transcript: z.array(TranscriptSegmentSchema).describe('Array of transcript segments for the requested page.'),
+        hasMore: z.boolean().describe('Whether additional pages of transcript segments exist.'),
+        cursor: z.string().optional().describe('Opaque cursor to request the next page. Omitted when hasMore is false.')
+    })
+    .describe('Output containing a page of transcript segments and pagination state.');
+
+/**
+ * @tags: [read]
+ * @tagReason: Retrieves paginated transcript segments from a meeting note.
+ * @pitfalls: On iOS transcripts, speaker attribution may be omitted and diarization_label can appear instead when diarization is available.
+ */
+const action = createAction({
+    description: "Retrieve a meeting transcript in pages - use when get-note's inline transcript is too large, or to page through a transcript directly.",
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const params: { cursor?: string; page_size?: string } = {};
+        if (input.cursor !== undefined) {
+            params.cursor = input.cursor;
+        }
+        if (input.page_size !== undefined) {
+            params.page_size = String(input.page_size);
+        }
+
+        // https://docs.granola.ai/api-reference/get-transcript.md
+        const response = await nango.get({
+            endpoint: `/v1/notes/${encodeURIComponent(input.note_id)}/transcript`,
+            params,
+            retries: 3
+        });
+
+        const ProviderResponseSchema = z.object({
+            transcript: z.array(
+                z.object({
+                    text: z.string(),
+                    start_time: z.string(),
+                    end_time: z.string(),
+                    speaker: z.object({
+                        source: z.string(),
+                        attribution: z.string().optional(),
+                        diarization_label: z.string().optional(),
+                        name: z.string().optional()
+                    })
+                })
+            ),
+            hasMore: z.boolean(),
+            cursor: z.string().nullable()
+        });
+
+        const providerData = ProviderResponseSchema.parse(response.data);
+
+        return {
+            transcript: providerData.transcript.map((segment) => ({
+                text: segment.text,
+                start_time: segment.start_time,
+                end_time: segment.end_time,
+                speaker: {
+                    source: segment.speaker.source,
+                    ...(segment.speaker.attribution !== undefined && { attribution: segment.speaker.attribution }),
+                    ...(segment.speaker.diarization_label !== undefined && { diarization_label: segment.speaker.diarization_label }),
+                    ...(segment.speaker.name !== undefined && { name: segment.speaker.name })
+                }
+            })),
+            hasMore: providerData.hasMore,
+            ...(providerData.cursor != null && { cursor: providerData.cursor })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/granola/actions/list-folders.ts
+++ b/integrations/granola/actions/list-folders.ts
@@ -4,7 +4,7 @@ import { createAction } from 'nango';
 const InputSchema = z
     .object({
         cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
-        page_size: z.number().optional().describe('Number of folders per page, between 1 and 30. Defaults to 10.')
+        page_size: z.number().int().min(1).max(30).optional().describe('Number of folders per page, between 1 and 30. Defaults to 10.')
     })
     .describe('Input for listing folders.');
 
@@ -12,7 +12,8 @@ const ProviderFolderSchema = z.object({
     id: z.string().describe('Unique identifier for the folder.'),
     object: z.string().describe('The object type, typically "folder".'),
     name: z.string().describe('Name of the folder.'),
-    parent_folder_id: z.string().nullable().describe('ID of the parent folder, or null for top-level folders.')
+    parent_folder_id: z.string().nullable().describe('ID of the parent folder, or null for top-level folders.'),
+    space_id: z.string().optional().describe('ID of the space this folder belongs to.')
 });
 
 const OutputSchema = z
@@ -56,7 +57,8 @@ const action = createAction({
                         id: z.string(),
                         object: z.string(),
                         name: z.string(),
-                        parent_folder_id: z.string().nullable()
+                        parent_folder_id: z.string().nullable(),
+                        space_id: z.string().optional()
                     })
                 ),
                 hasMore: z.boolean(),
@@ -69,7 +71,8 @@ const action = createAction({
                 id: folder.id,
                 object: folder.object,
                 name: folder.name,
-                parent_folder_id: folder.parent_folder_id
+                parent_folder_id: folder.parent_folder_id,
+                ...(folder.space_id != null && { space_id: folder.space_id })
             })),
             hasMore: providerResponse.hasMore,
             ...(providerResponse.cursor != null && { next_cursor: providerResponse.cursor })

--- a/integrations/granola/actions/list-folders.ts
+++ b/integrations/granola/actions/list-folders.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z
+    .object({
+        cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
+        page_size: z.number().optional().describe('Number of folders per page, between 1 and 30. Defaults to 10.')
+    })
+    .describe('Input for listing folders.');
+
+const ProviderFolderSchema = z.object({
+    id: z.string().describe('Unique identifier for the folder.'),
+    object: z.string().describe('The object type, typically "folder".'),
+    name: z.string().describe('Name of the folder.'),
+    parent_folder_id: z.string().nullable().describe('ID of the parent folder, or null for top-level folders.')
+});
+
+const OutputSchema = z
+    .object({
+        folders: z.array(ProviderFolderSchema).describe('Array of folders.'),
+        hasMore: z.boolean().describe('Whether there are more pages of results.'),
+        next_cursor: z.string().optional().describe('Cursor to fetch the next page of results.')
+    })
+    .describe('Output for listing folders.');
+
+/**
+ * @tags: [read]
+ * @tagReason: This action only reads folder data from the Granola API.
+ */
+const action = createAction({
+    description: 'List folders, including their parent/child hierarchy.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const params: Record<string, string | number> = {};
+        if (input.cursor !== undefined) {
+            params['cursor'] = input.cursor;
+        }
+        if (input.page_size !== undefined) {
+            params['page_size'] = input.page_size;
+        }
+
+        const response = await nango.get({
+            // https://docs.granola.ai/api-reference/list-folders.md
+            endpoint: '/v1/folders',
+            params,
+            retries: 3
+        });
+
+        const providerResponse = z
+            .object({
+                folders: z.array(
+                    z.object({
+                        id: z.string(),
+                        object: z.string(),
+                        name: z.string(),
+                        parent_folder_id: z.string().nullable()
+                    })
+                ),
+                hasMore: z.boolean(),
+                cursor: z.string().nullable()
+            })
+            .parse(response.data);
+
+        return {
+            folders: providerResponse.folders.map((folder) => ({
+                id: folder.id,
+                object: folder.object,
+                name: folder.name,
+                parent_folder_id: folder.parent_folder_id
+            })),
+            hasMore: providerResponse.hasMore,
+            ...(providerResponse.cursor != null && { next_cursor: providerResponse.cursor })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/granola/actions/list-notes.ts
+++ b/integrations/granola/actions/list-notes.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z
+    .object({
+        created_before: z.string().optional().describe('Return notes created before this date. Accepts ISO 8601 date or date-time strings.'),
+        created_after: z.string().optional().describe('Return notes created after this date. Accepts ISO 8601 date or date-time strings.'),
+        updated_after: z
+            .string()
+            .optional()
+            .describe(
+                'Return notes updated after this date. Accepts ISO 8601 date or date-time strings. This filter is precise and will return an empty list if no notes match.'
+            ),
+        folder_id: z
+            .string()
+            .regex(/^fol_[a-zA-Z0-9]{14}$/)
+            .optional()
+            .describe('Return notes in this folder and any of its child folders. Use the list folders endpoint to discover folder IDs.'),
+        cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
+        page_size: z.number().min(1).max(30).optional().describe('Maximum number of notes to return per page. Defaults to 10, capped at 30.')
+    })
+    .describe('Input for listing Granola meeting notes.');
+
+const ProviderUserSchema = z.object({
+    name: z.string().nullable(),
+    email: z.string()
+});
+
+const ProviderNoteSchema = z.object({
+    id: z.string(),
+    object: z.literal('note'),
+    title: z.string().nullable(),
+    owner: ProviderUserSchema,
+    created_at: z.string(),
+    updated_at: z.string()
+});
+
+const ProviderListOutputSchema = z.object({
+    notes: z.array(ProviderNoteSchema),
+    hasMore: z.boolean(),
+    cursor: z.string().nullable()
+});
+
+const NoteSchema = z.object({
+    id: z.string().describe('The ID of the note.'),
+    object: z.literal('note').describe('The object type of the note.'),
+    title: z.string().optional().describe('The title of the note, if present.'),
+    owner: z
+        .object({
+            name: z.string().optional().describe('The name of the note owner, if known.'),
+            email: z.string().describe('The email of the note owner.')
+        })
+        .describe('The owner of the note.'),
+    created_at: z.string().describe('The creation time of the note in ISO 8601 format.'),
+    updated_at: z.string().describe('The last update time of the note in ISO 8601 format.')
+});
+
+const OutputSchema = z
+    .object({
+        notes: z.array(NoteSchema).describe('The list of notes visible to the API key.'),
+        hasMore: z.boolean().describe('Whether another page of notes is available.'),
+        next_cursor: z.string().optional().describe('The opaque cursor for the next page, or omitted when this is the final page.')
+    })
+    .describe('Output from listing Granola meeting notes.');
+
+/**
+ * @tags: [read]
+ * @tagReason: Lists meeting notes visible to the API key. This is a read-only provider operation.
+ * @pitfalls: Returned notes are lightweight summaries that omit summaries, transcripts, attendees, and folder membership; use get-note for full details. folder_id filters recursively to the specified folder and all descendants. updated_after returns an empty list when no notes match.
+ */
+const action = createAction({
+    description: 'List meeting notes visible to the API key, with date and folder filtering.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://docs.granola.ai/api-reference/list-notes.md
+            endpoint: '/v1/notes',
+            params: {
+                ...(input.created_before !== undefined && { created_before: input.created_before }),
+                ...(input.created_after !== undefined && { created_after: input.created_after }),
+                ...(input.updated_after !== undefined && { updated_after: input.updated_after }),
+                ...(input.folder_id !== undefined && { folder_id: input.folder_id }),
+                ...(input.cursor !== undefined && { cursor: input.cursor }),
+                ...(input.page_size !== undefined && { page_size: input.page_size })
+            },
+            retries: 3
+        });
+
+        const providerResponse = ProviderListOutputSchema.parse(response.data);
+
+        return {
+            notes: providerResponse.notes.map((note) => ({
+                id: note.id,
+                object: note.object,
+                ...(note.title != null && { title: note.title }),
+                owner: {
+                    ...(note.owner.name != null && { name: note.owner.name }),
+                    email: note.owner.email
+                },
+                created_at: note.created_at,
+                updated_at: note.updated_at
+            })),
+            hasMore: providerResponse.hasMore,
+            ...(providerResponse.cursor != null && { next_cursor: providerResponse.cursor })
+        };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/granola/actions/list-notes.ts
+++ b/integrations/granola/actions/list-notes.ts
@@ -17,7 +17,7 @@ const InputSchema = z
             .optional()
             .describe('Return notes in this folder and any of its child folders. Use the list folders endpoint to discover folder IDs.'),
         cursor: z.string().optional().describe('Pagination cursor from the previous response. Omit for the first page.'),
-        page_size: z.number().min(1).max(30).optional().describe('Maximum number of notes to return per page. Defaults to 10, capped at 30.')
+        page_size: z.number().int().min(1).max(30).optional().describe('Maximum number of notes to return per page. Defaults to 10, capped at 30.')
     })
     .describe('Input for listing Granola meeting notes.');
 

--- a/integrations/granola/syncs/folders.ts
+++ b/integrations/granola/syncs/folders.ts
@@ -5,14 +5,16 @@ const ProviderFolderSchema = z.object({
     id: z.string(),
     object: z.string(),
     name: z.string(),
-    parent_folder_id: z.string().nullable()
+    parent_folder_id: z.string().nullable(),
+    space_id: z.string().optional()
 });
 
 const FolderSchema = z
     .object({
         id: z.string().describe('Unique identifier for the folder'),
         name: z.string().describe('Name of the folder'),
-        parent_folder_id: z.string().nullable().describe('ID of the parent folder, or null when this folder is top-level')
+        parent_folder_id: z.string().nullable().describe('ID of the parent folder, or null when this folder is top-level'),
+        space_id: z.string().optional().describe('ID of the space this folder belongs to')
     })
     .describe('A folder for organizing meeting notes in Granola');
 
@@ -33,6 +35,7 @@ const sync = createSync({
     exec: async (nango) => {
         const rawCheckpoint = await nango.getCheckpoint();
         let cursor: string | undefined;
+        const isFreshSync = rawCheckpoint === null;
 
         if (rawCheckpoint !== null) {
             const parsedCheckpoint = CheckpointSchema.safeParse(rawCheckpoint);
@@ -44,7 +47,12 @@ const sync = createSync({
             cursor = parsedCheckpoint.data.cursor || undefined;
         }
 
-        await nango.trackDeletesStart('Folder');
+        // Only (re)start the deletion window on a fresh sync. When resuming from a saved
+        // cursor, the earlier pages were already saved under the still-open window from the
+        // interrupted run; starting a new window here would make trackDeletesEnd delete them.
+        if (isFreshSync) {
+            await nango.trackDeletesStart('Folder');
+        }
 
         let processedAnyPage = false;
 
@@ -77,7 +85,8 @@ const sync = createSync({
             const mapped = folders.map((folder) => ({
                 id: folder.id,
                 name: folder.name,
-                parent_folder_id: folder.parent_folder_id
+                parent_folder_id: folder.parent_folder_id,
+                ...(folder.space_id != null && { space_id: folder.space_id })
             }));
 
             if (mapped.length > 0) {

--- a/integrations/granola/syncs/folders.ts
+++ b/integrations/granola/syncs/folders.ts
@@ -1,0 +1,99 @@
+import { createSync, type ProxyConfiguration } from 'nango';
+import { z } from 'zod';
+
+const ProviderFolderSchema = z.object({
+    id: z.string(),
+    object: z.string(),
+    name: z.string(),
+    parent_folder_id: z.string().nullable()
+});
+
+const FolderSchema = z
+    .object({
+        id: z.string().describe('Unique identifier for the folder'),
+        name: z.string().describe('Name of the folder'),
+        parent_folder_id: z.string().nullable().describe('ID of the parent folder, or null when this folder is top-level')
+    })
+    .describe('A folder for organizing meeting notes in Granola');
+
+const CheckpointSchema = z.object({
+    cursor: z.string()
+});
+
+const sync = createSync({
+    description: 'Sync folders (id, name, parent hierarchy)',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    checkpoint: CheckpointSchema,
+    models: {
+        Folder: FolderSchema
+    },
+
+    exec: async (nango) => {
+        const rawCheckpoint = await nango.getCheckpoint();
+        let cursor: string | undefined;
+
+        if (rawCheckpoint !== null) {
+            const parsedCheckpoint = CheckpointSchema.safeParse(rawCheckpoint);
+
+            if (!parsedCheckpoint.success) {
+                throw new Error(`Invalid checkpoint: ${parsedCheckpoint.error.message}`);
+            }
+
+            cursor = parsedCheckpoint.data.cursor || undefined;
+        }
+
+        await nango.trackDeletesStart('Folder');
+
+        let processedAnyPage = false;
+
+        const proxyConfig: ProxyConfiguration = {
+            // https://docs.granola.ai/api-reference/list-folders.md
+            endpoint: '/v1/folders',
+            params: {
+                ...(cursor !== undefined && { cursor }),
+                page_size: 30
+            },
+            paginate: {
+                type: 'cursor',
+                cursor_name_in_request: 'cursor',
+                cursor_path_in_response: 'cursor',
+                response_path: 'folders',
+                limit_name_in_request: 'page_size',
+                limit: 30,
+                on_page: async ({ nextPageParam }) => {
+                    cursor = typeof nextPageParam === 'string' ? nextPageParam : undefined;
+                }
+            },
+            retries: 3
+        };
+
+        for await (const page of nango.paginate(proxyConfig)) {
+            processedAnyPage = true;
+
+            const folders = z.array(ProviderFolderSchema).parse(page);
+
+            const mapped = folders.map((folder) => ({
+                id: folder.id,
+                name: folder.name,
+                parent_folder_id: folder.parent_folder_id
+            }));
+
+            if (mapped.length > 0) {
+                await nango.batchSave(mapped, 'Folder');
+            }
+
+            await nango.saveCheckpoint({ cursor: cursor ?? '' });
+        }
+
+        if (processedAnyPage) {
+            await nango.clearCheckpoint();
+        }
+
+        await nango.trackDeletesEnd('Folder');
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/granola/syncs/notes.ts
+++ b/integrations/granola/syncs/notes.ts
@@ -53,7 +53,7 @@ const ProviderNoteSchema = z.object({
     calendar_event: ProviderCalendarEventSchema.nullable(),
     attendees: z.array(ProviderUserSchema),
     folder_membership: z.array(ProviderFolderSchema),
-    space_membership: z.array(ProviderSpaceSchema),
+    space_membership: z.array(ProviderSpaceSchema).default([]),
     summary_text: z.string(),
     summary_markdown: z.string().nullable(),
     private_notes_text: z.string().nullable(),

--- a/integrations/granola/syncs/notes.ts
+++ b/integrations/granola/syncs/notes.ts
@@ -1,0 +1,253 @@
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+const ProviderUserSchema = z.object({
+    name: z.string().nullable(),
+    email: z.string()
+});
+
+const ProviderNoteSummarySchema = z.object({
+    id: z.string(),
+    object: z.literal('note'),
+    title: z.string().nullable(),
+    owner: ProviderUserSchema,
+    created_at: z.string(),
+    updated_at: z.string()
+});
+
+const ProviderCalendarEventSchema = z.object({
+    event_title: z.string().nullable(),
+    invitees: z.array(
+        z.object({
+            email: z.string()
+        })
+    ),
+    organiser: z.string().nullable(),
+    calendar_event_id: z.string().nullable(),
+    scheduled_start_time: z.string().nullable(),
+    scheduled_end_time: z.string().nullable()
+});
+
+const ProviderFolderSchema = z.object({
+    id: z.string(),
+    object: z.literal('folder'),
+    name: z.string(),
+    parent_folder_id: z.string().nullable()
+});
+
+const ProviderNoteSchema = z.object({
+    id: z.string(),
+    object: z.literal('note'),
+    title: z.string().nullable(),
+    owner: ProviderUserSchema,
+    created_at: z.string(),
+    updated_at: z.string(),
+    web_url: z.string(),
+    calendar_event: ProviderCalendarEventSchema.nullable(),
+    attendees: z.array(ProviderUserSchema),
+    folder_membership: z.array(ProviderFolderSchema),
+    summary_text: z.string(),
+    summary_markdown: z.string().nullable(),
+    private_notes_text: z.string().nullable(),
+    private_notes_markdown: z.string().nullable(),
+    transcript: z.array(z.unknown()).nullable()
+});
+
+const CalendarEventSchema = z
+    .object({
+        event_title: z.string().optional().describe('The title of the calendar event'),
+        invitees: z
+            .array(
+                z
+                    .object({
+                        email: z.string().describe('The email of the calendar invitee')
+                    })
+                    .describe('A calendar invitee')
+            )
+            .describe('The invitees of the calendar event'),
+        organiser: z.string().optional().describe('The email of the organiser'),
+        calendar_event_id: z.string().optional().describe('The ID of the calendar event'),
+        scheduled_start_time: z.string().optional().describe('The scheduled start time of the calendar event'),
+        scheduled_end_time: z.string().optional().describe('The scheduled end time of the calendar event')
+    })
+    .describe('Calendar event associated with the note');
+
+const UserSchema = z
+    .object({
+        name: z.string().optional().describe('The name of the user'),
+        email: z.string().describe('The email of the user')
+    })
+    .describe('A user');
+
+const FolderSchema = z
+    .object({
+        id: z.string().describe('The ID of the folder'),
+        object: z.string().describe('The object type of the folder'),
+        name: z.string().describe('The name of the folder'),
+        parent_folder_id: z.string().optional().describe('The ID of the parent folder, or omitted if top-level')
+    })
+    .describe('A folder');
+
+const NoteSchema = z
+    .object({
+        id: z.string().describe('The unique ID of the note'),
+        object: z.string().describe('The object type of the note'),
+        title: z.string().optional().describe('The title of the note'),
+        owner: UserSchema.describe('The owner of the note'),
+        created_at: z.string().describe('The creation time of the note'),
+        updated_at: z.string().describe('The last update time of the note'),
+        web_url: z.string().describe('The URL to view the note in the Granola web app'),
+        calendar_event: CalendarEventSchema.optional().describe('Calendar event associated with the note'),
+        attendees: z.array(UserSchema).describe('The attendees of the meeting'),
+        folder_membership: z.array(FolderSchema).describe('The folders the note belongs to'),
+        summary_text: z.string().describe('The summary text of the note'),
+        summary_markdown: z.string().optional().describe('The summary of the note in markdown format'),
+        private_notes_text: z.string().optional().describe('The private notes text of the note owner'),
+        private_notes_markdown: z.string().optional().describe('The private notes markdown of the note owner')
+    })
+    .describe('A Granola meeting note');
+
+const LegacyCheckpointSchema = z.object({
+    updated_after: z.string()
+});
+
+const CheckpointSchema = z.object({
+    updated_after: z.string(),
+    cursor: z.string(),
+    max_updated_at: z.string()
+});
+
+const sync = createSync({
+    description: 'Sync meeting notes (metadata, summary, attendees, folder/space membership - not the transcript)',
+    version: '1.0.0',
+    frequency: 'every hour',
+    autoStart: true,
+    checkpoint: CheckpointSchema,
+    models: {
+        Note: NoteSchema
+    },
+
+    exec: async (nango) => {
+        const rawCheckpoint = await nango.getCheckpoint();
+        let requestUpdatedAfter: string | undefined;
+        let cursor: string | undefined;
+        let maxUpdatedAt: string | undefined;
+
+        if (rawCheckpoint !== undefined && rawCheckpoint !== null) {
+            const parsedCheckpoint = z.union([CheckpointSchema, LegacyCheckpointSchema]).safeParse(rawCheckpoint);
+
+            if (!parsedCheckpoint.success) {
+                throw new Error(`Invalid checkpoint: ${parsedCheckpoint.error.message}`);
+            }
+
+            requestUpdatedAfter = parsedCheckpoint.data.updated_after || undefined;
+            cursor = 'cursor' in parsedCheckpoint.data ? parsedCheckpoint.data.cursor || undefined : undefined;
+            maxUpdatedAt = 'max_updated_at' in parsedCheckpoint.data ? parsedCheckpoint.data.max_updated_at || requestUpdatedAfter : requestUpdatedAfter;
+        }
+
+        for await (const summaries of nango.paginate({
+            // https://docs.granola.ai/api-reference/list-notes.md
+            endpoint: '/v1/notes',
+            params: {
+                ...(requestUpdatedAfter !== undefined && { updated_after: requestUpdatedAfter }),
+                ...(cursor !== undefined && { cursor }),
+                page_size: 30
+            },
+            paginate: {
+                type: 'cursor',
+                cursor_name_in_request: 'cursor',
+                cursor_path_in_response: 'cursor',
+                response_path: 'notes',
+                limit_name_in_request: 'page_size',
+                limit: 30,
+                on_page: async ({ nextPageParam }) => {
+                    cursor = typeof nextPageParam === 'string' ? nextPageParam : undefined;
+                }
+            },
+            retries: 3
+        })) {
+            const parsedSummaries = z.array(ProviderNoteSummarySchema).parse(summaries);
+            const notes = [];
+
+            for (const summary of parsedSummaries) {
+                const noteId = summary.id;
+
+                // https://docs.granola.ai/api-reference/get-note.md
+                const noteResponse = await nango.get({
+                    endpoint: `/v1/notes/${encodeURIComponent(noteId)}`,
+                    retries: 3
+                });
+
+                const parsedNote = ProviderNoteSchema.safeParse(noteResponse.data);
+
+                if (!parsedNote.success) {
+                    throw new Error(`Invalid note detail: ${parsedNote.error.message}`);
+                }
+
+                const note = parsedNote.data;
+
+                notes.push({
+                    id: note.id,
+                    object: note.object,
+                    ...(note.title != null && { title: note.title }),
+                    owner: {
+                        ...(note.owner.name != null && { name: note.owner.name }),
+                        email: note.owner.email
+                    },
+                    created_at: note.created_at,
+                    updated_at: note.updated_at,
+                    web_url: note.web_url,
+                    ...(note.calendar_event != null && {
+                        calendar_event: {
+                            ...(note.calendar_event.event_title != null && { event_title: note.calendar_event.event_title }),
+                            invitees: note.calendar_event.invitees.map((invitee) => ({ email: invitee.email })),
+                            ...(note.calendar_event.organiser != null && { organiser: note.calendar_event.organiser }),
+                            ...(note.calendar_event.calendar_event_id != null && { calendar_event_id: note.calendar_event.calendar_event_id }),
+                            ...(note.calendar_event.scheduled_start_time != null && { scheduled_start_time: note.calendar_event.scheduled_start_time }),
+                            ...(note.calendar_event.scheduled_end_time != null && { scheduled_end_time: note.calendar_event.scheduled_end_time })
+                        }
+                    }),
+                    attendees: note.attendees.map((attendee) => ({
+                        ...(attendee.name != null && { name: attendee.name }),
+                        email: attendee.email
+                    })),
+                    folder_membership: note.folder_membership.map((folder) => ({
+                        id: folder.id,
+                        object: folder.object,
+                        name: folder.name,
+                        ...(folder.parent_folder_id != null && { parent_folder_id: folder.parent_folder_id })
+                    })),
+                    summary_text: note.summary_text,
+                    ...(note.summary_markdown != null && { summary_markdown: note.summary_markdown }),
+                    ...(note.private_notes_text != null && { private_notes_text: note.private_notes_text }),
+                    ...(note.private_notes_markdown != null && { private_notes_markdown: note.private_notes_markdown })
+                });
+
+                if (maxUpdatedAt === undefined || note.updated_at > maxUpdatedAt) {
+                    maxUpdatedAt = note.updated_at;
+                }
+            }
+
+            if (notes.length > 0) {
+                await nango.batchSave(notes, 'Note');
+            }
+
+            if (cursor !== undefined) {
+                await nango.saveCheckpoint({
+                    updated_after: requestUpdatedAfter ?? '',
+                    cursor,
+                    max_updated_at: maxUpdatedAt ?? ''
+                });
+            } else if (maxUpdatedAt !== undefined) {
+                await nango.saveCheckpoint({
+                    updated_after: maxUpdatedAt,
+                    cursor: '',
+                    max_updated_at: ''
+                });
+            }
+        }
+    }
+});
+
+export type NangoSyncLocal = Parameters<(typeof sync)['exec']>[0];
+export default sync;

--- a/integrations/granola/syncs/notes.ts
+++ b/integrations/granola/syncs/notes.ts
@@ -32,7 +32,14 @@ const ProviderFolderSchema = z.object({
     id: z.string(),
     object: z.literal('folder'),
     name: z.string(),
-    parent_folder_id: z.string().nullable()
+    parent_folder_id: z.string().nullable(),
+    space_id: z.string().optional()
+});
+
+const ProviderSpaceSchema = z.object({
+    id: z.string(),
+    object: z.literal('space'),
+    name: z.string()
 });
 
 const ProviderNoteSchema = z.object({
@@ -46,6 +53,7 @@ const ProviderNoteSchema = z.object({
     calendar_event: ProviderCalendarEventSchema.nullable(),
     attendees: z.array(ProviderUserSchema),
     folder_membership: z.array(ProviderFolderSchema),
+    space_membership: z.array(ProviderSpaceSchema),
     summary_text: z.string(),
     summary_markdown: z.string().nullable(),
     private_notes_text: z.string().nullable(),
@@ -84,9 +92,18 @@ const FolderSchema = z
         id: z.string().describe('The ID of the folder'),
         object: z.string().describe('The object type of the folder'),
         name: z.string().describe('The name of the folder'),
-        parent_folder_id: z.string().optional().describe('The ID of the parent folder, or omitted if top-level')
+        parent_folder_id: z.string().optional().describe('The ID of the parent folder, or omitted if top-level'),
+        space_id: z.string().optional().describe('The ID of the space this folder belongs to')
     })
     .describe('A folder');
+
+const SpaceSchema = z
+    .object({
+        id: z.string().describe('The ID of the space'),
+        object: z.string().describe('The object type of the space'),
+        name: z.string().describe('The name of the space')
+    })
+    .describe('A Granola space (team workspace)');
 
 const NoteSchema = z
     .object({
@@ -100,6 +117,7 @@ const NoteSchema = z
         calendar_event: CalendarEventSchema.optional().describe('Calendar event associated with the note'),
         attendees: z.array(UserSchema).describe('The attendees of the meeting'),
         folder_membership: z.array(FolderSchema).describe('The folders the note belongs to'),
+        space_membership: z.array(SpaceSchema).describe('The spaces the note belongs to'),
         summary_text: z.string().describe('The summary text of the note'),
         summary_markdown: z.string().optional().describe('The summary of the note in markdown format'),
         private_notes_text: z.string().optional().describe('The private notes text of the note owner'),
@@ -215,7 +233,13 @@ const sync = createSync({
                         id: folder.id,
                         object: folder.object,
                         name: folder.name,
-                        ...(folder.parent_folder_id != null && { parent_folder_id: folder.parent_folder_id })
+                        ...(folder.parent_folder_id != null && { parent_folder_id: folder.parent_folder_id }),
+                        ...(folder.space_id != null && { space_id: folder.space_id })
+                    })),
+                    space_membership: note.space_membership.map((space) => ({
+                        id: space.id,
+                        object: space.object,
+                        name: space.name
                     })),
                     summary_text: note.summary_text,
                     ...(note.summary_markdown != null && { summary_markdown: note.summary_markdown }),

--- a/integrations/granola/tests/folders.test.json
+++ b/integrations/granola/tests/folders.test.json
@@ -1,0 +1,75 @@
+{
+  "nango": {
+    "batchSave": {
+      "Folder": [
+        {
+          "id": "fol_omr6ASuOy2xE9L",
+          "name": "Customer calls",
+          "parent_folder_id": null
+        },
+        {
+          "id": "fol_bYRRm9Q6dQ2wSK",
+          "name": "Team meetings",
+          "parent_folder_id": null
+        }
+      ]
+    },
+    "batchDelete": {
+      "Folder": []
+    }
+  },
+  "api": {
+    "get": {
+      "/v1/folders": {
+        "response": {
+          "folders": [
+            {
+              "object": "folder",
+              "id": "fol_omr6ASuOy2xE9L",
+              "name": "Customer calls",
+              "parent_folder_id": null,
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            },
+            {
+              "object": "folder",
+              "id": "fol_bYRRm9Q6dQ2wSK",
+              "name": "Team meetings",
+              "parent_folder_id": null,
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            }
+          ],
+          "hasMore": false,
+          "cursor": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 15:15:51 GMT",
+          "content-type": "application/json",
+          "content-length": "294",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1994",
+          "x-ratelimit-reset": "1788275806",
+          "server": "awselb/2.0",
+          "etag": "W/\"126-vi5pBk1bhEQOzMCDBhF2f1vT3Vc\""
+        },
+        "hash": "d194c81dfaa7d422d2a1a804767437af9524f180",
+        "request": {
+          "params": {
+            "page_size": "30"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/granola/tests/folders.test.json
+++ b/integrations/granola/tests/folders.test.json
@@ -5,12 +5,14 @@
         {
           "id": "fol_omr6ASuOy2xE9L",
           "name": "Customer calls",
-          "parent_folder_id": null
+          "parent_folder_id": null,
+          "space_id": "spa_IdfiRQ2DkJGmPR"
         },
         {
           "id": "fol_bYRRm9Q6dQ2wSK",
           "name": "Team meetings",
-          "parent_folder_id": null
+          "parent_folder_id": null,
+          "space_id": "spa_IdfiRQ2DkJGmPR"
         }
       ]
     },

--- a/integrations/granola/tests/get-note.test.json
+++ b/integrations/granola/tests/get-note.test.json
@@ -40,7 +40,15 @@
         "id": "fol_omr6ASuOy2xE9L",
         "object": "folder",
         "name": "Customer calls",
-        "parent_folder_id": null
+        "parent_folder_id": null,
+        "space_id": "spa_IdfiRQ2DkJGmPR"
+      }
+    ],
+    "space_membership": [
+      {
+        "id": "spa_IdfiRQ2DkJGmPR",
+        "object": "space",
+        "name": "NangoDeveloperApp team"
       }
     ],
     "summary_text": "Product Walkthrough\nSam demoed Granola’s core notepad and transcript features\nNotepad works like a regular text editor: type notes during the meeting\nTranscript visible via green dancing bars at the bottom of the screen\nEnhanced Notes\nAt meeting end, Granola auto-detects and generates enhanced notes\nNotes combine transcript capture with anything typed in the notepad\nManual flow: stop button, then “Enhanced Notes” button\nNote-Taker’s Notes\n73\n31\nPause on",

--- a/integrations/granola/tests/get-note.test.json
+++ b/integrations/granola/tests/get-note.test.json
@@ -1,0 +1,138 @@
+{
+  "input": {
+    "note_id": "not_IBuThyr2eJgage"
+  },
+  "output": {
+    "id": "not_IBuThyr2eJgage",
+    "object": "note",
+    "title": "Demo meeting",
+    "owner": {
+      "name": "Nango Developer",
+      "email": "api@nango.dev"
+    },
+    "created_at": "2026-08-31T11:15:53.536Z",
+    "updated_at": "2026-08-31T11:47:39.191Z",
+    "web_url": "https://notes.granola.ai/d/556129f4-7855-4799-9a0c-619b75ef88e7",
+    "calendar_event": {
+      "event_title": "Demo meeting",
+      "invitees": [
+        {
+          "email": "samstephenson@granola.ai"
+        }
+      ],
+      "organiser": null,
+      "calendar_event_id": "demo_meeting_d92bf0a5-7e61-4d44-8602-b6985f5f29c8",
+      "scheduled_start_time": "2026-08-31T11:15:53.536Z",
+      "scheduled_end_time": "2026-09-07T11:45:53.536Z"
+    },
+    "attendees": [
+      {
+        "name": "Nango Developer",
+        "email": "api@nango.dev"
+      },
+      {
+        "name": "Sam Stephenson",
+        "email": "samstephenson@granola.ai"
+      }
+    ],
+    "folder_membership": [
+      {
+        "id": "fol_omr6ASuOy2xE9L",
+        "object": "folder",
+        "name": "Customer calls",
+        "parent_folder_id": null
+      }
+    ],
+    "summary_text": "Product Walkthrough\nSam demoed Granola’s core notepad and transcript features\nNotepad works like a regular text editor: type notes during the meeting\nTranscript visible via green dancing bars at the bottom of the screen\nEnhanced Notes\nAt meeting end, Granola auto-detects and generates enhanced notes\nNotes combine transcript capture with anything typed in the notepad\nManual flow: stop button, then “Enhanced Notes” button\nNote-Taker’s Notes\n73\n31\nPause on",
+    "summary_markdown": "# Product Walkthrough\n\n- Sam demoed Granola’s core notepad and transcript features\n- Notepad works like a regular text editor: type notes during the meeting\n- Transcript visible via green dancing bars at the bottom of the screen\n\n# Enhanced Notes\n\n- At meeting end, Granola auto-detects and generates enhanced notes\n- Notes combine transcript capture with anything typed in the notepad\n- Manual flow: stop button, then “Enhanced Notes” button\n\n# Note-Taker’s Notes\n\n- 73\n- 31\n- Pause on\n\n---\n\nChat with meeting transcript: [https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8](https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8)",
+    "private_notes_text": null,
+    "private_notes_markdown": null,
+    "transcript": null
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/v1/notes/not_IBuThyr2eJgage": {
+        "response": {
+          "id": "not_IBuThyr2eJgage",
+          "object": "note",
+          "title": "Demo meeting",
+          "web_url": "https://notes.granola.ai/d/556129f4-7855-4799-9a0c-619b75ef88e7",
+          "owner": {
+            "name": "Nango Developer",
+            "email": "api@nango.dev"
+          },
+          "created_at": "2026-08-31T11:15:53.536Z",
+          "updated_at": "2026-08-31T11:47:39.191Z",
+          "calendar_event": {
+            "event_title": "Demo meeting",
+            "invitees": [
+              {
+                "email": "samstephenson@granola.ai"
+              }
+            ],
+            "organiser": null,
+            "calendar_event_id": "demo_meeting_d92bf0a5-7e61-4d44-8602-b6985f5f29c8",
+            "scheduled_start_time": "2026-08-31T11:15:53.536Z",
+            "scheduled_end_time": "2026-09-07T11:45:53.536Z"
+          },
+          "attendees": [
+            {
+              "name": "Nango Developer",
+              "email": "api@nango.dev"
+            },
+            {
+              "email": "samstephenson@granola.ai",
+              "name": "Sam Stephenson"
+            }
+          ],
+          "folder_membership": [
+            {
+              "object": "folder",
+              "id": "fol_omr6ASuOy2xE9L",
+              "name": "Customer calls",
+              "parent_folder_id": null,
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            }
+          ],
+          "space_membership": [
+            {
+              "object": "space",
+              "id": "spa_IdfiRQ2DkJGmPR",
+              "name": "NangoDeveloperApp team"
+            }
+          ],
+          "transcript": null,
+          "summary_text": "Product Walkthrough\nSam demoed Granola’s core notepad and transcript features\nNotepad works like a regular text editor: type notes during the meeting\nTranscript visible via green dancing bars at the bottom of the screen\nEnhanced Notes\nAt meeting end, Granola auto-detects and generates enhanced notes\nNotes combine transcript capture with anything typed in the notepad\nManual flow: stop button, then “Enhanced Notes” button\nNote-Taker’s Notes\n73\n31\nPause on",
+          "summary_markdown": "# Product Walkthrough\n\n- Sam demoed Granola’s core notepad and transcript features\n- Notepad works like a regular text editor: type notes during the meeting\n- Transcript visible via green dancing bars at the bottom of the screen\n\n# Enhanced Notes\n\n- At meeting end, Granola auto-detects and generates enhanced notes\n- Notes combine transcript capture with anything typed in the notepad\n- Manual flow: stop button, then “Enhanced Notes” button\n\n# Note-Taker’s Notes\n\n- 73\n- 31\n- Pause on\n\n---\n\nChat with meeting transcript: [https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8](https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8)",
+          "private_notes_text": null,
+          "private_notes_markdown": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 14:58:39 GMT",
+          "content-type": "application/json",
+          "content-length": "2209",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1988",
+          "x-ratelimit-reset": "1788274764",
+          "server": "awselb/2.0",
+          "etag": "W/\"8a1-47C1H+KyR9/L97HH+U3sEjXCvFM\""
+        },
+        "hash": "7d68039e23d1b12344ba7ea7e81db4c2145a6434",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/granola/tests/get-transcript.test.json
+++ b/integrations/granola/tests/get-transcript.test.json
@@ -1,0 +1,353 @@
+{
+  "input": {
+    "note_id": "not_IBuThyr2eJgage"
+  },
+  "output": {
+    "transcript": [
+      {
+        "text": "Hey, my name is Sam and in the next two minutes I'm going to show you how to use Granola to transcribe your meetings and turn your short scrappy notes into something much more beautiful and useful.",
+        "start_time": "2026-08-31T11:16:04.143Z",
+        "end_time": "2026-08-31T11:16:11.903Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "This is Granola on the right. It looks and behaves a lot like a regular text editor, but it does a few extra clever things which I want to show you now.",
+        "start_time": "2026-08-31T11:16:13.103Z",
+        "end_time": "2026-08-31T11:16:20.143Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "At the bottom of your screen, you should see some green dancing bars. Click those green dancing bars now.",
+        "start_time": "2026-08-31T11:16:21.743Z",
+        "end_time": "2026-08-31T11:16:26.063Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "In there, you should see my voice coming in. This is the transcript and it runs in real time anytime you're having a meeting with Granola.",
+        "start_time": "2026-08-31T11:16:27.663Z",
+        "end_time": "2026-08-31T11:16:34.223Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "Okay, you can close the transcript. And now I want you to try taking one or two lines of notes in the notepad. Just write something short like Granola AI, for example. So the way to think about the notepad is that Granola is transcribing in the background anyway. So you can relax about writing every little detail. Instead, just write the things that really matter to you or things that are in your head that wouldn't have made it into the transcript.",
+        "start_time": "2026-08-31T11:16:35.503Z",
+        "end_time": "2026-08-31T11:16:58.543Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "At the end of the meeting, Granola will take any notes you write as guidance and turn those into much more fleshed out, much more useful notes that you can share with your team or have as a record going forward.",
+        "start_time": "2026-08-31T11:16:59.823Z",
+        "end_time": "2026-08-31T11:17:09.983Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "Great, that's the basics. I'm going to stick around and I'm going to show you one or two more things if you like, but feel free to end the meeting at this point. Just click the red X and you'll see Granola flesh out your notes. Yeah, with that, I'm going to share my screen and I'm going to show you one or two extra things.",
+        "start_time": "2026-08-31T11:17:11.903Z",
+        "end_time": "2026-08-31T11:17:26.543Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "Okay, so you should be looking at my notepad, which should look somewhat similar to yours on the right side of your screen.",
+        "start_time": "2026-08-31T11:17:30.143Z",
+        "end_time": "2026-08-31T11:17:35.263Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "You can see that I took some notes here about kind of specific things that were mentioned in the video that I thought were interesting. This is a great way to use Granola, just writing short scrappy notes about the stuff that stands out to you. One extra thing I want to show you that you could do in this notepad is as well as writing specific one-off things like this. I can also instruct Granola to capture notes on kind of broader topics or headings. And you can do that with this notation here. So if I do a little hashtag and a space and I'm going to say features of Granola, I'll do another one that's like steps to use Granola.",
+        "start_time": "2026-08-31T11:17:36.223Z",
+        "end_time": "2026-08-31T11:18:12.863Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "This notation will be familiar if you use markdown. It's the same notation as a heading in markdown. And the idea is you're instructing Granola to turn this into a heading and collect notes underneath that, which you'll see now. I'm going to hit the enhanced note button and we'll see Granola do its thing.",
+        "start_time": "2026-08-31T11:18:13.823Z",
+        "end_time": "2026-08-31T11:18:28.143Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "Great. And you can see, so now Granola has written some notes for me. This is a mix of the specific things that I wrote, stuff that I didn't write, but the Granola thought was worth putting in. And it's used those headings that I wrote earlier to group stuff underneath, as well as a few extras that it's sort of useful.",
+        "start_time": "2026-08-31T11:18:34.303Z",
+        "end_time": "2026-08-31T11:18:48.703Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "If you go back, you can see the specific stuff I wrote, the headings I wrote.",
+        "start_time": "2026-08-31T11:18:49.983Z",
+        "end_time": "2026-08-31T11:18:53.023Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "And then the output from Granola.",
+        "start_time": "2026-08-31T11:18:54.703Z",
+        "end_time": "2026-08-31T11:18:56.223Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "What's it?",
+        "start_time": "2026-08-31T11:18:57.103Z",
+        "end_time": "2026-08-31T11:18:57.583Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "Okay, the final thing. This is like automatic template that gets applied after every meeting. But if you want something more specific out of your notes, we have a bunch of other templates here. You can see like these are the default ones, but we also have a bunch more in this menu here.",
+        "start_time": "2026-08-31T11:18:58.783Z",
+        "end_time": "2026-08-31T11:19:14.703Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "The idea here is you predefine a structure for the notes that you want. So I have this user interview one which breaks down notes into like the user's goal and their pain points and current solutions blah blah blah. I'll apply this and let's see what happens.",
+        "start_time": "2026-08-31T11:19:15.663Z",
+        "end_time": "2026-08-31T11:19:28.383Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      },
+      {
+        "text": "So you can see like Granola's kind of taking that template as instructions and produce the set of notes in that structure. I find this especially useful for situations like recruiting is a good one where I want consistent notes for every candidate I'm talking to so I can make comparisons easily. All right, that's it. I think that's enough. I will let you go exploring from here on out and I hope that Granola is just super useful for you over the coming weeks. Thank you very much.",
+        "start_time": "2026-08-31T11:19:34.143Z",
+        "end_time": "2026-08-31T11:19:59.423Z",
+        "speaker": {
+          "source": "speaker",
+          "attribution": "them"
+        }
+      }
+    ],
+    "hasMore": false
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/v1/notes/not_IBuThyr2eJgage/transcript": {
+        "response": {
+          "transcript": [
+            {
+              "text": "Hey, my name is Sam and in the next two minutes I'm going to show you how to use Granola to transcribe your meetings and turn your short scrappy notes into something much more beautiful and useful.",
+              "start_time": "2026-08-31T11:16:04.143Z",
+              "end_time": "2026-08-31T11:16:11.903Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "This is Granola on the right. It looks and behaves a lot like a regular text editor, but it does a few extra clever things which I want to show you now.",
+              "start_time": "2026-08-31T11:16:13.103Z",
+              "end_time": "2026-08-31T11:16:20.143Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "At the bottom of your screen, you should see some green dancing bars. Click those green dancing bars now.",
+              "start_time": "2026-08-31T11:16:21.743Z",
+              "end_time": "2026-08-31T11:16:26.063Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "In there, you should see my voice coming in. This is the transcript and it runs in real time anytime you're having a meeting with Granola.",
+              "start_time": "2026-08-31T11:16:27.663Z",
+              "end_time": "2026-08-31T11:16:34.223Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "Okay, you can close the transcript. And now I want you to try taking one or two lines of notes in the notepad. Just write something short like Granola AI, for example. So the way to think about the notepad is that Granola is transcribing in the background anyway. So you can relax about writing every little detail. Instead, just write the things that really matter to you or things that are in your head that wouldn't have made it into the transcript.",
+              "start_time": "2026-08-31T11:16:35.503Z",
+              "end_time": "2026-08-31T11:16:58.543Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "At the end of the meeting, Granola will take any notes you write as guidance and turn those into much more fleshed out, much more useful notes that you can share with your team or have as a record going forward.",
+              "start_time": "2026-08-31T11:16:59.823Z",
+              "end_time": "2026-08-31T11:17:09.983Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "Great, that's the basics. I'm going to stick around and I'm going to show you one or two more things if you like, but feel free to end the meeting at this point. Just click the red X and you'll see Granola flesh out your notes. Yeah, with that, I'm going to share my screen and I'm going to show you one or two extra things.",
+              "start_time": "2026-08-31T11:17:11.903Z",
+              "end_time": "2026-08-31T11:17:26.543Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "Okay, so you should be looking at my notepad, which should look somewhat similar to yours on the right side of your screen.",
+              "start_time": "2026-08-31T11:17:30.143Z",
+              "end_time": "2026-08-31T11:17:35.263Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "You can see that I took some notes here about kind of specific things that were mentioned in the video that I thought were interesting. This is a great way to use Granola, just writing short scrappy notes about the stuff that stands out to you. One extra thing I want to show you that you could do in this notepad is as well as writing specific one-off things like this. I can also instruct Granola to capture notes on kind of broader topics or headings. And you can do that with this notation here. So if I do a little hashtag and a space and I'm going to say features of Granola, I'll do another one that's like steps to use Granola.",
+              "start_time": "2026-08-31T11:17:36.223Z",
+              "end_time": "2026-08-31T11:18:12.863Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "This notation will be familiar if you use markdown. It's the same notation as a heading in markdown. And the idea is you're instructing Granola to turn this into a heading and collect notes underneath that, which you'll see now. I'm going to hit the enhanced note button and we'll see Granola do its thing.",
+              "start_time": "2026-08-31T11:18:13.823Z",
+              "end_time": "2026-08-31T11:18:28.143Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "Great. And you can see, so now Granola has written some notes for me. This is a mix of the specific things that I wrote, stuff that I didn't write, but the Granola thought was worth putting in. And it's used those headings that I wrote earlier to group stuff underneath, as well as a few extras that it's sort of useful.",
+              "start_time": "2026-08-31T11:18:34.303Z",
+              "end_time": "2026-08-31T11:18:48.703Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "If you go back, you can see the specific stuff I wrote, the headings I wrote.",
+              "start_time": "2026-08-31T11:18:49.983Z",
+              "end_time": "2026-08-31T11:18:53.023Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "And then the output from Granola.",
+              "start_time": "2026-08-31T11:18:54.703Z",
+              "end_time": "2026-08-31T11:18:56.223Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "What's it?",
+              "start_time": "2026-08-31T11:18:57.103Z",
+              "end_time": "2026-08-31T11:18:57.583Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "Okay, the final thing. This is like automatic template that gets applied after every meeting. But if you want something more specific out of your notes, we have a bunch of other templates here. You can see like these are the default ones, but we also have a bunch more in this menu here.",
+              "start_time": "2026-08-31T11:18:58.783Z",
+              "end_time": "2026-08-31T11:19:14.703Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "The idea here is you predefine a structure for the notes that you want. So I have this user interview one which breaks down notes into like the user's goal and their pain points and current solutions blah blah blah. I'll apply this and let's see what happens.",
+              "start_time": "2026-08-31T11:19:15.663Z",
+              "end_time": "2026-08-31T11:19:28.383Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            },
+            {
+              "text": "So you can see like Granola's kind of taking that template as instructions and produce the set of notes in that structure. I find this especially useful for situations like recruiting is a good one where I want consistent notes for every candidate I'm talking to so I can make comparisons easily. All right, that's it. I think that's enough. I will let you go exploring from here on out and I hope that Granola is just super useful for you over the coming weeks. Thank you very much.",
+              "start_time": "2026-08-31T11:19:34.143Z",
+              "end_time": "2026-08-31T11:19:59.423Z",
+              "speaker": {
+                "source": "speaker",
+                "attribution": "them"
+              }
+            }
+          ],
+          "hasMore": false,
+          "cursor": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 14:59:53 GMT",
+          "content-type": "application/json",
+          "content-length": "6572",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1992",
+          "x-ratelimit-reset": "1788274831",
+          "server": "awselb/2.0",
+          "etag": "W/\"19ac-LQwtwJzk2ahfdozN5FzB/FX/Fb8\""
+        },
+        "hash": "b43e2141cfcb87980e1a20a1aea7b930ce1250b9",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/granola/tests/granola-folders.test.ts
+++ b/integrations/granola/tests/granola-folders.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, vi, expect, it, describe } from 'vitest';
+
+import createSync from '../syncs/folders.js';
+
+describe('granola folders tests', () => {
+    const models = 'Folder'.split(',');
+
+    const createTestContext = () => {
+        const nangoMock = new global.vitest.NangoSyncMock({
+            dirname: __dirname,
+            name: 'folders',
+            Model: 'Folder'
+        });
+
+        return {
+            nangoMock,
+            batchSaveSpy: vi.spyOn(nangoMock, 'batchSave')
+        };
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('should get, map correctly the data and batchSave the result', async () => {
+        const { nangoMock, batchSaveSpy } = createTestContext();
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const expectedBatchSaveData = await nangoMock.getBatchSaveData(model);
+
+            const spiedData = batchSaveSpy.mock.calls.flatMap((call) => {
+                if (call[1] === model) {
+                    return call[0];
+                }
+
+                return [];
+            });
+
+            // Normalize spy-captured args into plain JSON so they compare cleanly
+            // with fixture data loaded from `*.test.json`.
+            // Removes things like prototypes, undefined values and other non-serializable data.
+            const spied = JSON.parse(JSON.stringify(spiedData));
+
+            expect(spied).toStrictEqual(expectedBatchSaveData);
+        }
+    });
+
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        const { nangoMock } = createTestContext();
+        const batchDeleteSpy = vi.spyOn(nangoMock, 'batchDelete');
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                const spiedData = batchDeleteSpy.mock.calls.flatMap((call) => {
+                    if (call[1] === model) {
+                        return call[0];
+                    }
+
+                    return [];
+                });
+
+                // Normalize spy-captured args into plain JSON so they compare cleanly
+                // with fixture data loaded from `*.test.json`.
+                // Removes things like prototypes, undefined values and other non-serializable data.
+                const spied = JSON.parse(JSON.stringify(spiedData));
+
+                expect(spied).toStrictEqual(batchDeleteData);
+            }
+        }
+    });
+});

--- a/integrations/granola/tests/granola-get-note.test.ts
+++ b/integrations/granola/tests/granola-get-note.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/get-note.js';
+
+describe('granola get-note tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'get-note',
+        Model: 'ActionOutput_granola_getnote'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/granola/tests/granola-get-transcript.test.ts
+++ b/integrations/granola/tests/granola-get-transcript.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/get-transcript.js';
+
+describe('granola get-transcript tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'get-transcript',
+        Model: 'ActionOutput_granola_gettranscript'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/granola/tests/granola-list-folders.test.ts
+++ b/integrations/granola/tests/granola-list-folders.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/list-folders.js';
+
+describe('granola list-folders tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'list-folders',
+        Model: 'ActionOutput_granola_listfolders'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/granola/tests/granola-list-notes.test.ts
+++ b/integrations/granola/tests/granola-list-notes.test.ts
@@ -1,0 +1,19 @@
+import { vi, expect, it, describe } from 'vitest';
+
+import createAction from '../actions/list-notes.js';
+
+describe('granola list-notes tests', () => {
+    const nangoMock = new global.vitest.NangoActionMock({
+        dirname: __dirname,
+        name: 'list-notes',
+        Model: 'ActionOutput_granola_listnotes'
+    });
+
+    it('should output the action output that is expected', async () => {
+        const input = await nangoMock.getInput();
+        const response = await createAction.exec(nangoMock, input);
+        const output = await nangoMock.getOutput();
+
+        expect(response).toEqual(output);
+    });
+});

--- a/integrations/granola/tests/granola-notes.test.ts
+++ b/integrations/granola/tests/granola-notes.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, vi, expect, it, describe } from 'vitest';
+
+import createSync from '../syncs/notes.js';
+
+describe('granola notes tests', () => {
+    const models = 'Note'.split(',');
+
+    const createTestContext = () => {
+        const nangoMock = new global.vitest.NangoSyncMock({
+            dirname: __dirname,
+            name: 'notes',
+            Model: 'Note'
+        });
+
+        return {
+            nangoMock,
+            batchSaveSpy: vi.spyOn(nangoMock, 'batchSave')
+        };
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('should get, map correctly the data and batchSave the result', async () => {
+        const { nangoMock, batchSaveSpy } = createTestContext();
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const expectedBatchSaveData = await nangoMock.getBatchSaveData(model);
+
+            const spiedData = batchSaveSpy.mock.calls.flatMap((call) => {
+                if (call[1] === model) {
+                    return call[0];
+                }
+
+                return [];
+            });
+
+            // Normalize spy-captured args into plain JSON so they compare cleanly
+            // with fixture data loaded from `*.test.json`.
+            // Removes things like prototypes, undefined values and other non-serializable data.
+            const spied = JSON.parse(JSON.stringify(spiedData));
+
+            expect(spied).toStrictEqual(expectedBatchSaveData);
+        }
+    });
+
+    it('should get, map correctly the data and batchDelete the result', async () => {
+        const { nangoMock } = createTestContext();
+        const batchDeleteSpy = vi.spyOn(nangoMock, 'batchDelete');
+
+        await createSync.exec(nangoMock);
+
+        for (const model of models) {
+            const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+            if (batchDeleteData && batchDeleteData.length > 0) {
+                const spiedData = batchDeleteSpy.mock.calls.flatMap((call) => {
+                    if (call[1] === model) {
+                        return call[0];
+                    }
+
+                    return [];
+                });
+
+                // Normalize spy-captured args into plain JSON so they compare cleanly
+                // with fixture data loaded from `*.test.json`.
+                // Removes things like prototypes, undefined values and other non-serializable data.
+                const spied = JSON.parse(JSON.stringify(spiedData));
+
+                expect(spied).toStrictEqual(batchDeleteData);
+            }
+        }
+    });
+});

--- a/integrations/granola/tests/list-folders.test.json
+++ b/integrations/granola/tests/list-folders.test.json
@@ -1,0 +1,71 @@
+{
+  "input": {},
+  "output": {
+    "folders": [
+      {
+        "id": "fol_omr6ASuOy2xE9L",
+        "object": "folder",
+        "name": "Customer calls",
+        "parent_folder_id": null
+      },
+      {
+        "id": "fol_bYRRm9Q6dQ2wSK",
+        "object": "folder",
+        "name": "Team meetings",
+        "parent_folder_id": null
+      }
+    ],
+    "hasMore": false
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/v1/folders": {
+        "response": {
+          "folders": [
+            {
+              "object": "folder",
+              "id": "fol_omr6ASuOy2xE9L",
+              "name": "Customer calls",
+              "parent_folder_id": null,
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            },
+            {
+              "object": "folder",
+              "id": "fol_bYRRm9Q6dQ2wSK",
+              "name": "Team meetings",
+              "parent_folder_id": null,
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            }
+          ],
+          "hasMore": false,
+          "cursor": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 14:57:40 GMT",
+          "content-type": "application/json",
+          "content-length": "294",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1992",
+          "x-ratelimit-reset": "1788274700",
+          "server": "awselb/2.0",
+          "etag": "W/\"126-vi5pBk1bhEQOzMCDBhF2f1vT3Vc\""
+        },
+        "hash": "de021585761488b78ce9b77188f09d8f2fff3cae",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/granola/tests/list-folders.test.json
+++ b/integrations/granola/tests/list-folders.test.json
@@ -6,13 +6,15 @@
         "id": "fol_omr6ASuOy2xE9L",
         "object": "folder",
         "name": "Customer calls",
-        "parent_folder_id": null
+        "parent_folder_id": null,
+        "space_id": "spa_IdfiRQ2DkJGmPR"
       },
       {
         "id": "fol_bYRRm9Q6dQ2wSK",
         "object": "folder",
         "name": "Team meetings",
-        "parent_folder_id": null
+        "parent_folder_id": null,
+        "space_id": "spa_IdfiRQ2DkJGmPR"
       }
     ],
     "hasMore": false

--- a/integrations/granola/tests/list-notes.test.json
+++ b/integrations/granola/tests/list-notes.test.json
@@ -1,0 +1,67 @@
+{
+  "input": {},
+  "output": {
+    "notes": [
+      {
+        "id": "not_IBuThyr2eJgage",
+        "object": "note",
+        "title": "Demo meeting",
+        "owner": {
+          "name": "Nango Developer",
+          "email": "api@nango.dev"
+        },
+        "created_at": "2026-08-31T11:15:53.536Z",
+        "updated_at": "2026-08-31T11:47:39.191Z"
+      }
+    ],
+    "hasMore": false
+  },
+  "nango": {},
+  "api": {
+    "get": {
+      "/v1/notes": {
+        "response": {
+          "notes": [
+            {
+              "id": "not_IBuThyr2eJgage",
+              "object": "note",
+              "title": "Demo meeting",
+              "owner": {
+                "name": "Nango Developer",
+                "email": "api@nango.dev"
+              },
+              "created_at": "2026-08-31T11:15:53.536Z",
+              "updated_at": "2026-08-31T11:47:39.191Z"
+            }
+          ],
+          "hasMore": false,
+          "cursor": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 15:05:52 GMT",
+          "content-type": "application/json",
+          "content-length": "247",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1992",
+          "x-ratelimit-reset": "1788275202",
+          "server": "awselb/2.0",
+          "etag": "W/\"f7-Db7ejH7iW008qIbCY3i5F+6zH/w\""
+        },
+        "hash": "9655332a2b11312b14561777ccbba837023345a7",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/granola/tests/notes.test.json
+++ b/integrations/granola/tests/notes.test.json
@@ -38,7 +38,15 @@
             {
               "id": "fol_omr6ASuOy2xE9L",
               "object": "folder",
-              "name": "Customer calls"
+              "name": "Customer calls",
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            }
+          ],
+          "space_membership": [
+            {
+              "id": "spa_IdfiRQ2DkJGmPR",
+              "object": "space",
+              "name": "NangoDeveloperApp team"
             }
           ],
           "summary_text": "Product Walkthrough\nSam demoed Granola’s core notepad and transcript features\nNotepad works like a regular text editor: type notes during the meeting\nTranscript visible via green dancing bars at the bottom of the screen\nEnhanced Notes\nAt meeting end, Granola auto-detects and generates enhanced notes\nNotes combine transcript capture with anything typed in the notepad\nManual flow: stop button, then “Enhanced Notes” button\nNote-Taker’s Notes\n73\n31\nPause on",

--- a/integrations/granola/tests/notes.test.json
+++ b/integrations/granola/tests/notes.test.json
@@ -1,0 +1,185 @@
+{
+  "nango": {
+    "batchSave": {
+      "Note": [
+        {
+          "id": "not_IBuThyr2eJgage",
+          "object": "note",
+          "title": "Demo meeting",
+          "owner": {
+            "name": "Nango Developer",
+            "email": "api@nango.dev"
+          },
+          "created_at": "2026-08-31T11:15:53.536Z",
+          "updated_at": "2026-08-31T11:47:39.191Z",
+          "web_url": "https://notes.granola.ai/d/556129f4-7855-4799-9a0c-619b75ef88e7",
+          "calendar_event": {
+            "event_title": "Demo meeting",
+            "invitees": [
+              {
+                "email": "samstephenson@granola.ai"
+              }
+            ],
+            "calendar_event_id": "demo_meeting_d92bf0a5-7e61-4d44-8602-b6985f5f29c8",
+            "scheduled_start_time": "2026-08-31T11:15:53.536Z",
+            "scheduled_end_time": "2026-09-07T11:45:53.536Z"
+          },
+          "attendees": [
+            {
+              "name": "Nango Developer",
+              "email": "api@nango.dev"
+            },
+            {
+              "name": "Sam Stephenson",
+              "email": "samstephenson@granola.ai"
+            }
+          ],
+          "folder_membership": [
+            {
+              "id": "fol_omr6ASuOy2xE9L",
+              "object": "folder",
+              "name": "Customer calls"
+            }
+          ],
+          "summary_text": "Product Walkthrough\nSam demoed Granola’s core notepad and transcript features\nNotepad works like a regular text editor: type notes during the meeting\nTranscript visible via green dancing bars at the bottom of the screen\nEnhanced Notes\nAt meeting end, Granola auto-detects and generates enhanced notes\nNotes combine transcript capture with anything typed in the notepad\nManual flow: stop button, then “Enhanced Notes” button\nNote-Taker’s Notes\n73\n31\nPause on",
+          "summary_markdown": "# Product Walkthrough\n\n- Sam demoed Granola’s core notepad and transcript features\n- Notepad works like a regular text editor: type notes during the meeting\n- Transcript visible via green dancing bars at the bottom of the screen\n\n# Enhanced Notes\n\n- At meeting end, Granola auto-detects and generates enhanced notes\n- Notes combine transcript capture with anything typed in the notepad\n- Manual flow: stop button, then “Enhanced Notes” button\n\n# Note-Taker’s Notes\n\n- 73\n- 31\n- Pause on\n\n---\n\nChat with meeting transcript: [https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8](https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8)"
+        }
+      ]
+    },
+    "batchDelete": {
+      "Note": []
+    }
+  },
+  "api": {
+    "get": {
+      "/v1/notes": {
+        "response": {
+          "notes": [
+            {
+              "id": "not_IBuThyr2eJgage",
+              "object": "note",
+              "title": "Demo meeting",
+              "owner": {
+                "name": "Nango Developer",
+                "email": "api@nango.dev"
+              },
+              "created_at": "2026-08-31T11:15:53.536Z",
+              "updated_at": "2026-08-31T11:47:39.191Z"
+            }
+          ],
+          "hasMore": false,
+          "cursor": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 15:16:10 GMT",
+          "content-type": "application/json",
+          "content-length": "247",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1987",
+          "x-ratelimit-reset": "1788275806",
+          "server": "awselb/2.0",
+          "etag": "W/\"f7-Db7ejH7iW008qIbCY3i5F+6zH/w\""
+        },
+        "hash": "fc1d3d49a58502911d3161ad2523cda5900520f4",
+        "request": {
+          "params": {
+            "page_size": "30"
+          }
+        }
+      },
+      "/v1/notes/not_IBuThyr2eJgage": {
+        "response": {
+          "id": "not_IBuThyr2eJgage",
+          "object": "note",
+          "title": "Demo meeting",
+          "web_url": "https://notes.granola.ai/d/556129f4-7855-4799-9a0c-619b75ef88e7",
+          "owner": {
+            "name": "Nango Developer",
+            "email": "api@nango.dev"
+          },
+          "created_at": "2026-08-31T11:15:53.536Z",
+          "updated_at": "2026-08-31T11:47:39.191Z",
+          "calendar_event": {
+            "event_title": "Demo meeting",
+            "invitees": [
+              {
+                "email": "samstephenson@granola.ai"
+              }
+            ],
+            "organiser": null,
+            "calendar_event_id": "demo_meeting_d92bf0a5-7e61-4d44-8602-b6985f5f29c8",
+            "scheduled_start_time": "2026-08-31T11:15:53.536Z",
+            "scheduled_end_time": "2026-09-07T11:45:53.536Z"
+          },
+          "attendees": [
+            {
+              "name": "Nango Developer",
+              "email": "api@nango.dev"
+            },
+            {
+              "email": "samstephenson@granola.ai",
+              "name": "Sam Stephenson"
+            }
+          ],
+          "folder_membership": [
+            {
+              "object": "folder",
+              "id": "fol_omr6ASuOy2xE9L",
+              "name": "Customer calls",
+              "parent_folder_id": null,
+              "space_id": "spa_IdfiRQ2DkJGmPR"
+            }
+          ],
+          "space_membership": [
+            {
+              "object": "space",
+              "id": "spa_IdfiRQ2DkJGmPR",
+              "name": "NangoDeveloperApp team"
+            }
+          ],
+          "transcript": null,
+          "summary_text": "Product Walkthrough\nSam demoed Granola’s core notepad and transcript features\nNotepad works like a regular text editor: type notes during the meeting\nTranscript visible via green dancing bars at the bottom of the screen\nEnhanced Notes\nAt meeting end, Granola auto-detects and generates enhanced notes\nNotes combine transcript capture with anything typed in the notepad\nManual flow: stop button, then “Enhanced Notes” button\nNote-Taker’s Notes\n73\n31\nPause on",
+          "summary_markdown": "# Product Walkthrough\n\n- Sam demoed Granola’s core notepad and transcript features\n- Notepad works like a regular text editor: type notes during the meeting\n- Transcript visible via green dancing bars at the bottom of the screen\n\n# Enhanced Notes\n\n- At meeting end, Granola auto-detects and generates enhanced notes\n- Notes combine transcript capture with anything typed in the notepad\n- Manual flow: stop button, then “Enhanced Notes” button\n\n# Note-Taker’s Notes\n\n- 73\n- 31\n- Pause on\n\n---\n\nChat with meeting transcript: [https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8](https://notes.granola.ai/t/ec37bdb4-aaee-44c6-a6d5-921b7bb7a4a8)",
+          "private_notes_text": null,
+          "private_notes_markdown": null
+        },
+        "status": 200,
+        "headers": {
+          "date": "Tue, 01 Sep 2026 15:16:11 GMT",
+          "content-type": "application/json",
+          "content-length": "2209",
+          "connection": "keep-alive",
+          "x-xss-protection": "0",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-frame-options": "SAMEORIGIN",
+          "x-dns-prefetch-control": "off",
+          "referrer-policy": "strict-origin",
+          "strict-transport-security": "max-age=5184000; includeSubDomains",
+          "content-security-policy-report-only": "default-src 'self' https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/;child-src 'self';connect-src 'self' https://*.google-analytics.com https://*.sentry.io https://app.nango.dev https://api.nango.dev wss://api.nango.dev/ https://connect.nango.dev https://connect.nango.dev/ https://*.posthog.com https://*.stripe.com https://*.plain.com wss://*.plain.com https://raw.githubusercontent.com;font-src 'self' data: https://*.googleapis.com https://*.gstatic.com https://*.cdn-plain.com;frame-src 'self' https://accounts.google.com https://app.nango.dev https://api.nango.dev https://connect.nango.dev https://connect.nango.dev/ https://www.youtube.com https://*.stripe.com;img-src 'self' data: blob: https://app.nango.dev https://api.nango.dev https://*.google-analytics.com https://*.googleapis.com https://*.posthog.com https://img.logo.dev https://*.ytimg.com https://*.plain.com;manifest-src 'self';media-src 'self';object-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline' https://app.nango.dev https://api.nango.dev https://*.stripe.com https://*.google-analytics.com https://*.googleapis.com https://apis.google.com https://*.posthog.com https://www.youtube.com https://*.cdn-plain.com;style-src blob: 'self' 'unsafe-inline' https://*.googleapis.com https://app.nango.dev https://api.nango.dev;worker-src blob: 'self' https://app.nango.dev https://api.nango.dev https://*.googleapis.com https://*.posthog.com;base-uri 'self';form-action 'self';frame-ancestors 'self';script-src-attr 'none';upgrade-insecure-requests",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Authorization, Etag, Content-Type, Content-Length, X-Nango-Signature, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset",
+          "x-ratelimit-limit": "2000",
+          "x-ratelimit-remaining": "1986",
+          "x-ratelimit-reset": "1788275806",
+          "server": "awselb/2.0",
+          "etag": "W/\"8a1-47C1H+KyR9/L97HH+U3sEjXCvFM\""
+        },
+        "hash": "7d68039e23d1b12344ba7ea7e81db4c2145a6434",
+        "request": {}
+      }
+    }
+  }
+}

--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -2842,6 +2842,14 @@ import './gorgias/actions/update-view.js';
 import './grammarly/syncs/users.js';
 import './grammarly/actions/delete-user.js';
 
+// -- Integration: granola
+import './granola/syncs/folders.js';
+import './granola/syncs/notes.js';
+import './granola/actions/get-note.js';
+import './granola/actions/get-transcript.js';
+import './granola/actions/list-folders.js';
+import './granola/actions/list-notes.js';
+
 // -- Integration: greenhouse-basic
 import './greenhouse-basic/syncs/applications.js';
 import './greenhouse-basic/syncs/candidates.js';


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)

-   [ ] I added tests, otherwise the reason is:
-   [ ] External API requests have `retries`
-   [ ] Pagination is used where appropriate
-   [ ] The built in `nango.paginate` call is used instead of a `while (true)` loop
-   [ ] Third party requests are NOT parallelized (this can cause issues with rate limits)
-   [ ] If a sync requires metadata the `nango.yaml` has `auto_start: false`
-   [ ] If the sync is a `full` sync then `track_deletes: true` is set
-   [ ] I followed the best practices and guidelines from the [Writing Integration Scripts](/NangoHQ/integration-templates/blob/main/guides/WRITING_SCRIPTS.md) doc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Granola integration that exposes meeting notes and folders through Nango, so users can fetch notes, transcripts, and folder listings and keep notes synced.

**New Features**
- Adds `get-note`, `get-transcript`, `list-folders`, and `list-notes` actions.
- Adds hourly syncs for notes and folders.
- Registers the integration in the generated config and index.

**Bug Fixes**
- Folders sync starts the deletion tracking window only on a fresh sync, so resuming from a saved cursor no longer deletes already-saved folders.
- Notes sync and `get-note` tolerate missing `space_membership` and map `space_id` from `folder_membership`.
- `list-folders`, `list-notes`, and `get-transcript` validate `page_size` as a bounded integer before sending requests.

<sup>Written for commit 7f9a8ccd9895376b67aff89fcc9707fb1e9ba8cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

