### PR TITLE
feat(clerk): add identity administration actions

### DIFF
--- a/integrations/clerk/actions/assign-organization-role-permission.ts
+++ b/integrations/clerk/actions/assign-organization-role-permission.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_role_id: z.string(), permission_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        key: z.string(),
+        description: z.string().nullable().optional(),
+        permissions: z.array(z.object({ id: z.string(), key: z.string().optional(), name: z.string().optional() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Assign a permission to a Clerk organization role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/AssignPermissionToOrganizationRole
+            endpoint: `/v1/organization_roles/${encodeURIComponent(input.organization_role_id)}/permissions/${encodeURIComponent(input.permission_id)}`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-email-address.ts
+++ b/integrations/clerk/actions/create-email-address.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    user_id: z.string(),
+    email_address: z.string(),
+    verified: z.boolean().optional(),
+    primary: z.boolean().optional(),
+    notify_primary_email_address_changed: z.boolean().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        verification: z.object({ status: z.string().optional(), strategy: z.string().optional() }).passthrough().nullable().optional(),
+        linked_to: z.array(z.object({ id: z.string(), type: z.string() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a Clerk email address.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Email-Addresses#operation/CreateEmailAddress
+            endpoint: '/v1/email_addresses',
+            data: {
+                user_id: input.user_id,
+                email_address: input.email_address,
+                ...(input.verified !== undefined && { verified: input.verified }),
+                ...(input.primary !== undefined && { primary: input.primary }),
+                ...(input.notify_primary_email_address_changed !== undefined && {
+                    notify_primary_email_address_changed: input.notify_primary_email_address_changed
+                })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-organization-domain.ts
+++ b/integrations/clerk/actions/create-organization-domain.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const EnrollmentModeSchema = z.enum(['manual_invitation', 'automatic_invitation', 'automatic_suggestion', 'enterprise_sso']);
+const InputSchema = z.object({ organization_id: z.string(), name: z.string(), enrollment_mode: EnrollmentModeSchema, verified: z.boolean().optional() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization_id: z.string().optional(),
+        name: z.string(),
+        enrollment_mode: EnrollmentModeSchema.optional(),
+        affiliation_verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verified: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a verified domain for a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Domains#operation/CreateOrganizationDomain
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/domains`,
+            data: { name: input.name, enrollment_mode: input.enrollment_mode, ...(input.verified !== undefined && { verified: input.verified }) },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-organization-invitation.ts
+++ b/integrations/clerk/actions/create-organization-invitation.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    organization_id: z.string(),
+    email_address: z.string().email(),
+    role: z.string(),
+    inviter_user_id: z.string().optional(),
+    redirect_url: z.string().url().optional(),
+    expires_in_days: z.number().int().positive().optional(),
+    notify: z.boolean().optional(),
+    public_metadata: z.record(z.string(), z.unknown()).optional(),
+    private_metadata: z.record(z.string(), z.unknown()).optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        organization_id: z.string().optional(),
+        role: z.string().optional(),
+        status: z.enum(['pending', 'accepted', 'revoked', 'expired']).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create an invitation for a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Invitations#operation/CreateOrganizationInvitation
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/invitations`,
+            data: {
+                email_address: input.email_address,
+                role: input.role,
+                ...(input.inviter_user_id !== undefined && { inviter_user_id: input.inviter_user_id }),
+                ...(input.redirect_url !== undefined && { redirect_url: input.redirect_url }),
+                ...(input.expires_in_days !== undefined && { expires_in_days: input.expires_in_days }),
+                ...(input.notify !== undefined && { notify: input.notify }),
+                ...(input.public_metadata !== undefined && { public_metadata: input.public_metadata }),
+                ...(input.private_metadata !== undefined && { private_metadata: input.private_metadata })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-organization-membership.ts
+++ b/integrations/clerk/actions/create-organization-membership.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    organization_id: z.string(),
+    user_id: z.string(),
+    role: z.string(),
+    public_metadata: z.record(z.string(), z.unknown()).optional(),
+    private_metadata: z.record(z.string(), z.unknown()).optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization: z.object({ id: z.string() }).passthrough().optional(),
+        public_user_data: z.object({ user_id: z.string() }).passthrough().optional(),
+        role: z.string().optional(),
+        permissions: z.array(z.string()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a membership in a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Memberships#operation/CreateOrganizationMembership
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/memberships`,
+            data: {
+                user_id: input.user_id,
+                role: input.role,
+                ...(input.public_metadata !== undefined && { public_metadata: input.public_metadata }),
+                ...(input.private_metadata !== undefined && { private_metadata: input.private_metadata })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-organization-role.ts
+++ b/integrations/clerk/actions/create-organization-role.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    name: z.string(),
+    key: z.string(),
+    description: z.string().optional(),
+    permissions: z.array(z.string()).optional(),
+    include_in_initial_role_set: z.boolean().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        key: z.string(),
+        description: z.string().nullable().optional(),
+        permissions: z.array(z.object({ id: z.string(), key: z.string().optional(), name: z.string().optional() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a Clerk organization role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/CreateOrganizationRole
+            endpoint: '/v1/organization_roles',
+            data: {
+                name: input.name,
+                key: input.key,
+                ...(input.description !== undefined && { description: input.description }),
+                ...(input.permissions !== undefined && { permissions: input.permissions }),
+                ...(input.include_in_initial_role_set !== undefined && { include_in_initial_role_set: input.include_in_initial_role_set })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-organization.ts
+++ b/integrations/clerk/actions/create-organization.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+const InputSchema = z.object({
+    name: z.string().min(1),
+    slug: z.string().optional(),
+    created_by: z.string().optional(),
+    max_allowed_memberships: z.number().int().min(0).optional(),
+    public_metadata: z.record(z.string(), z.unknown()).optional(),
+    private_metadata: z.record(z.string(), z.unknown()).optional()
+});
+const OrganizationSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        slug: z.string(),
+        image_url: z.string().optional(),
+        has_image: z.boolean().optional(),
+        members_count: z.number().optional(),
+        max_allowed_memberships: z.number().optional(),
+        admin_delete_enabled: z.boolean().optional(),
+        public_metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+        private_metadata: z.record(z.string(), z.unknown()).optional(),
+        created_by: z.string().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = OrganizationSchema;
+const action = createAction({
+    description: 'Create an organization in Clerk.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/CreateOrganization
+            endpoint: '/v1/organizations',
+            data: {
+                name: input.name,
+                ...(input.slug !== undefined && { slug: input.slug }),
+                ...(input.created_by !== undefined && { created_by: input.created_by }),
+                ...(input.max_allowed_memberships !== undefined && { max_allowed_memberships: input.max_allowed_memberships }),
+                ...(input.public_metadata !== undefined && { public_metadata: input.public_metadata }),
+                ...(input.private_metadata !== undefined && { private_metadata: input.private_metadata })
+            },
+            retries: 3
+        });
+        return OrganizationSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-phone-number.ts
+++ b/integrations/clerk/actions/create-phone-number.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    user_id: z.string(),
+    phone_number: z.string(),
+    verified: z.boolean().optional(),
+    primary: z.boolean().optional(),
+    reserved_for_second_factor: z.boolean().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        phone_number: z.string(),
+        reserved_for_second_factor: z.boolean().optional(),
+        verification: z.object({ status: z.string().optional(), strategy: z.string().optional() }).passthrough().nullable().optional(),
+        linked_to: z.array(z.object({ id: z.string(), type: z.string() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a Clerk phone number.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Phone-Numbers#operation/CreatePhoneNumber
+            endpoint: '/v1/phone_numbers',
+            data: {
+                user_id: input.user_id,
+                phone_number: input.phone_number,
+                ...(input.verified !== undefined && { verified: input.verified }),
+                ...(input.primary !== undefined && { primary: input.primary }),
+                ...(input.reserved_for_second_factor !== undefined && { reserved_for_second_factor: input.reserved_for_second_factor })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/create-user.ts
+++ b/integrations/clerk/actions/create-user.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    external_id: z.string().optional(),
+    email_address: z.array(z.string().email()).max(100).optional(),
+    phone_number: z.array(z.string()).max(100).optional(),
+    username: z.string().optional(),
+    password: z.string().min(8).optional(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    locale: z.string().optional().describe('BCP-47 locale. Example: "en-US"'),
+    skip_password_checks: z.boolean().optional(),
+    skip_password_requirement: z.boolean().optional(),
+    banned: z.boolean().optional(),
+    locked: z.boolean().optional(),
+    public_metadata: z.record(z.string(), z.unknown()).optional(),
+    private_metadata: z.record(z.string(), z.unknown()).optional(),
+    unsafe_metadata: z.record(z.string(), z.unknown()).optional()
+});
+const UserSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        username: z.string().nullable().optional(),
+        first_name: z.string().nullable().optional(),
+        last_name: z.string().nullable().optional(),
+        image_url: z.string().optional(),
+        primary_email_address_id: z.string().nullable().optional(),
+        primary_phone_number_id: z.string().nullable().optional(),
+        external_id: z.string().nullable().optional(),
+        banned: z.boolean().optional(),
+        locked: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional(),
+        locale: z.string().nullable().optional()
+    })
+    .passthrough();
+const OutputSchema = UserSchema;
+
+const action = createAction({
+    description: 'Create a user in Clerk.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser
+            endpoint: '/v1/users',
+            data: {
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.email_address !== undefined && { email_address: input.email_address }),
+                ...(input.phone_number !== undefined && { phone_number: input.phone_number }),
+                ...(input.username !== undefined && { username: input.username }),
+                ...(input.password !== undefined && { password: input.password }),
+                ...(input.first_name !== undefined && { first_name: input.first_name }),
+                ...(input.last_name !== undefined && { last_name: input.last_name }),
+                ...(input.locale !== undefined && { locale: input.locale }),
+                ...(input.skip_password_checks !== undefined && { skip_password_checks: input.skip_password_checks }),
+                ...(input.skip_password_requirement !== undefined && { skip_password_requirement: input.skip_password_requirement }),
+                ...(input.banned !== undefined && { banned: input.banned }),
+                ...(input.locked !== undefined && { locked: input.locked }),
+                ...(input.public_metadata !== undefined && { public_metadata: input.public_metadata }),
+                ...(input.private_metadata !== undefined && { private_metadata: input.private_metadata }),
+                ...(input.unsafe_metadata !== undefined && { unsafe_metadata: input.unsafe_metadata })
+            },
+            retries: 3
+        });
+        return UserSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-email-address.ts
+++ b/integrations/clerk/actions/delete-email-address.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ email_address_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a Clerk email address.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://clerk.com/docs/reference/backend-api/tag/Email-Addresses#operation/DeleteEmailAddress
+            endpoint: `/v1/email_addresses/${encodeURIComponent(input.email_address_id)}`,
+            retries: 3
+        });
+        return { id: input.email_address_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-organization-domain.ts
+++ b/integrations/clerk/actions/delete-organization-domain.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), domain_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a verified domain from a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Domains#operation/DeleteOrganizationDomain
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/domains/${encodeURIComponent(input.domain_id)}`,
+            retries: 3
+        });
+        return { id: input.domain_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-organization-membership.ts
+++ b/integrations/clerk/actions/delete-organization-membership.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), user_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a membership from a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Memberships#operation/DeleteOrganizationMembership
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/memberships/${encodeURIComponent(input.user_id)}`,
+            retries: 3
+        });
+        return { id: input.user_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-organization-role.ts
+++ b/integrations/clerk/actions/delete-organization-role.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_role_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a Clerk organization role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/DeleteOrganizationRole
+            endpoint: `/v1/organization_roles/${encodeURIComponent(input.organization_role_id)}`,
+            retries: 3
+        });
+        return { id: input.organization_role_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-organization.ts
+++ b/integrations/clerk/actions/delete-organization.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+const InputSchema = z.object({ organization_id: z.string().min(1) });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/DeleteOrganization
+        await nango.delete({ endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}`, retries: 3 });
+        return { id: input.organization_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-phone-number.ts
+++ b/integrations/clerk/actions/delete-phone-number.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ phone_number_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a Clerk phone number.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://clerk.com/docs/reference/backend-api/tag/Phone-Numbers#operation/DeletePhoneNumber
+            endpoint: `/v1/phone_numbers/${encodeURIComponent(input.phone_number_id)}`,
+            retries: 3
+        });
+        return { id: input.phone_number_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/delete-user.ts
+++ b/integrations/clerk/actions/delete-user.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+const InputSchema = z.object({ user_id: z.string().min(1) });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a Clerk user.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://clerk.com/docs/reference/backend-api/tag/Users#operation/DeleteUser
+        await nango.delete({ endpoint: `/v1/users/${encodeURIComponent(input.user_id)}`, retries: 3 });
+        return { id: input.user_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-email-address.ts
+++ b/integrations/clerk/actions/get-email-address.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ email_address_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        verification: z.object({ status: z.string().optional(), strategy: z.string().optional() }).passthrough().nullable().optional(),
+        linked_to: z.array(z.object({ id: z.string(), type: z.string() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a Clerk email address.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Email-Addresses#operation/GetEmailAddress
+            endpoint: `/v1/email_addresses/${encodeURIComponent(input.email_address_id)}`,
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-organization-invitation.ts
+++ b/integrations/clerk/actions/get-organization-invitation.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), invitation_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        organization_id: z.string().optional(),
+        role: z.string().optional(),
+        status: z.enum(['pending', 'accepted', 'revoked', 'expired']).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a Clerk organization invitation.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Invitations#operation/GetOrganizationInvitation
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/invitations/${encodeURIComponent(input.invitation_id)}`,
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-organization-role.ts
+++ b/integrations/clerk/actions/get-organization-role.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_role_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        key: z.string(),
+        description: z.string().nullable().optional(),
+        permissions: z.array(z.object({ id: z.string(), key: z.string().optional(), name: z.string().optional() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a Clerk organization role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/GetOrganizationRole
+            endpoint: `/v1/organization_roles/${encodeURIComponent(input.organization_role_id)}`,
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-organization.ts
+++ b/integrations/clerk/actions/get-organization.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+const InputSchema = z.object({ organization_id: z.string().min(1), include_members_count: z.boolean().optional() });
+const OrganizationSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        slug: z.string(),
+        image_url: z.string().optional(),
+        has_image: z.boolean().optional(),
+        members_count: z.number().optional(),
+        max_allowed_memberships: z.number().optional(),
+        admin_delete_enabled: z.boolean().optional(),
+        public_metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+        private_metadata: z.record(z.string(), z.unknown()).optional(),
+        created_by: z.string().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = OrganizationSchema;
+const action = createAction({
+    description: 'Retrieve a Clerk organization by ID.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/GetOrganization
+        const response = await nango.get({
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}`,
+            params: { ...(input.include_members_count !== undefined && { include_members_count: String(input.include_members_count) }) },
+            retries: 3
+        });
+        return OrganizationSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-phone-number.ts
+++ b/integrations/clerk/actions/get-phone-number.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ phone_number_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        phone_number: z.string(),
+        reserved_for_second_factor: z.boolean().optional(),
+        verification: z.object({ status: z.string().optional(), strategy: z.string().optional() }).passthrough().nullable().optional(),
+        linked_to: z.array(z.object({ id: z.string(), type: z.string() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a Clerk phone number.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Phone-Numbers#operation/GetPhoneNumber
+            endpoint: `/v1/phone_numbers/${encodeURIComponent(input.phone_number_id)}`,
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-session.ts
+++ b/integrations/clerk/actions/get-session.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ session_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        client_id: z.string().optional(),
+        user_id: z.string(),
+        status: z.enum(['abandoned', 'active', 'ended', 'expired', 'removed', 'replaced', 'revoked']).optional(),
+        last_active_at: z.number().optional(),
+        expire_at: z.number().optional(),
+        abandon_at: z.number().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a Clerk session.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Sessions#operation/GetSession
+            endpoint: `/v1/sessions/${encodeURIComponent(input.session_id)}`,
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/get-user.ts
+++ b/integrations/clerk/actions/get-user.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ user_id: z.string().min(1).describe('Clerk user ID. Example: "user_2abc123"') });
+const UserSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        username: z.string().nullable().optional(),
+        first_name: z.string().nullable().optional(),
+        last_name: z.string().nullable().optional(),
+        image_url: z.string().optional(),
+        primary_email_address_id: z.string().nullable().optional(),
+        primary_phone_number_id: z.string().nullable().optional(),
+        external_id: z.string().nullable().optional(),
+        banned: z.boolean().optional(),
+        locked: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional(),
+        locale: z.string().nullable().optional()
+    })
+    .passthrough();
+const OutputSchema = UserSchema;
+
+const action = createAction({
+    description: 'Retrieve a Clerk user by ID.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        // https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUser
+        const response = await nango.get({ endpoint: `/v1/users/${encodeURIComponent(input.user_id)}`, retries: 3 });
+        return UserSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-organization-domains.ts
+++ b/integrations/clerk/actions/list-organization-domains.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const EnrollmentModeSchema = z.enum(['manual_invitation', 'automatic_invitation', 'automatic_suggestion', 'enterprise_sso']);
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    limit: z.number().int().min(1).max(500).optional(),
+    organization_id: z.string(),
+    verified: z.boolean().optional(),
+    enrollment_mode: EnrollmentModeSchema.optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization_id: z.string().optional(),
+        name: z.string(),
+        enrollment_mode: EnrollmentModeSchema.optional(),
+        affiliation_verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verified: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({ data: z.array(ResourceSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional(), total: z.number() });
+const action = createAction({
+    description: 'List verified domains for a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Domains#operation/ListOrganizationDomains
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/domains`,
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.verified !== undefined && { verified: String(input.verified) }),
+                ...(input.enrollment_mode !== undefined && { enrollment_mode: input.enrollment_mode })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-organization-invitations.ts
+++ b/integrations/clerk/actions/list-organization-invitations.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    limit: z.number().int().min(1).max(500).optional(),
+    organization_id: z.string(),
+    status: z.enum(['pending', 'accepted', 'revoked', 'expired']).optional(),
+    email_address: z.string().optional(),
+    order_by: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        organization_id: z.string().optional(),
+        role: z.string().optional(),
+        status: z.enum(['pending', 'accepted', 'revoked', 'expired']).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({ data: z.array(ResourceSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional(), total: z.number() });
+const action = createAction({
+    description: 'List invitations for a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Invitations#operation/ListOrganizationInvitations
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/invitations`,
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.status !== undefined && { status: input.status }),
+                ...(input.email_address !== undefined && { email_address: input.email_address }),
+                ...(input.order_by !== undefined && { order_by: input.order_by })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-organization-memberships.ts
+++ b/integrations/clerk/actions/list-organization-memberships.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    limit: z.number().int().min(1).max(500).optional(),
+    organization_id: z.string(),
+    user_id: z.array(z.string()).optional(),
+    email_address: z.array(z.string()).optional(),
+    phone_number: z.array(z.string()).optional(),
+    username: z.array(z.string()).optional(),
+    web3_wallet: z.array(z.string()).optional(),
+    role: z.array(z.string()).optional(),
+    query: z.string().optional(),
+    email_address_query: z.string().optional(),
+    phone_number_query: z.string().optional(),
+    username_query: z.string().optional(),
+    name_query: z.string().optional(),
+    last_active_at_before: z.number().int().optional(),
+    last_active_at_after: z.number().int().optional(),
+    created_at_before: z.number().int().optional(),
+    created_at_after: z.number().int().optional(),
+    order_by: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization: z.object({ id: z.string() }).passthrough().optional(),
+        public_user_data: z.object({ user_id: z.string() }).passthrough().optional(),
+        role: z.string().optional(),
+        permissions: z.array(z.string()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({ data: z.array(ResourceSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional(), total: z.number() });
+const action = createAction({
+    description: 'List memberships for a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Memberships#operation/ListOrganizationMemberships
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/memberships`,
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.user_id !== undefined && { user_id: input.user_id }),
+                ...(input.email_address !== undefined && { email_address: input.email_address }),
+                ...(input.phone_number !== undefined && { phone_number: input.phone_number }),
+                ...(input.username !== undefined && { username: input.username }),
+                ...(input.web3_wallet !== undefined && { web3_wallet: input.web3_wallet }),
+                ...(input.role !== undefined && { role: input.role }),
+                ...(input.query !== undefined && { query: input.query }),
+                ...(input.email_address_query !== undefined && { email_address_query: input.email_address_query }),
+                ...(input.phone_number_query !== undefined && { phone_number_query: input.phone_number_query }),
+                ...(input.username_query !== undefined && { username_query: input.username_query }),
+                ...(input.name_query !== undefined && { name_query: input.name_query }),
+                ...(input.last_active_at_before !== undefined && { last_active_at_before: String(input.last_active_at_before) }),
+                ...(input.last_active_at_after !== undefined && { last_active_at_after: String(input.last_active_at_after) }),
+                ...(input.created_at_before !== undefined && { created_at_before: String(input.created_at_before) }),
+                ...(input.created_at_after !== undefined && { created_at_after: String(input.created_at_after) }),
+                ...(input.order_by !== undefined && { order_by: input.order_by })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-organization-roles.ts
+++ b/integrations/clerk/actions/list-organization-roles.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    limit: z.number().int().min(1).max(500).optional(),
+    query: z.string().optional(),
+    order_by: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        key: z.string(),
+        description: z.string().nullable().optional(),
+        permissions: z.array(z.object({ id: z.string(), key: z.string().optional(), name: z.string().optional() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({ data: z.array(ResourceSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional(), total: z.number() });
+const action = createAction({
+    description: 'List Clerk organization roles.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/ListOrganizationRoles
+            endpoint: '/v1/organization_roles',
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.query !== undefined && { query: input.query }),
+                ...(input.order_by !== undefined && { order_by: input.order_by })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-organizations.ts
+++ b/integrations/clerk/actions/list-organizations.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+const InputSchema = z.object({
+    cursor: z.string().optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+    query: z.string().optional(),
+    order_by: z.string().optional().describe('Sort by name, created_at, or members_count, prefixed with + or -.'),
+    organization_id: z.array(z.string()).max(100).optional(),
+    include_members_count: z.boolean().optional()
+});
+const OrganizationSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        slug: z.string(),
+        image_url: z.string().optional(),
+        has_image: z.boolean().optional(),
+        members_count: z.number().optional(),
+        max_allowed_memberships: z.number().optional(),
+        admin_delete_enabled: z.boolean().optional(),
+        public_metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+        private_metadata: z.record(z.string(), z.unknown()).optional(),
+        created_by: z.string().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({ data: z.array(OrganizationSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(OrganizationSchema), next_cursor: z.string().optional(), total: z.number() });
+const action = createAction({
+    description: 'List organizations from Clerk.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/GetOrganizationList
+            endpoint: '/v1/organizations',
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.query !== undefined && { query: input.query }),
+                ...(input.order_by !== undefined && { order_by: input.order_by }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.include_members_count !== undefined && { include_members_count: String(input.include_members_count) })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-sessions.ts
+++ b/integrations/clerk/actions/list-sessions.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    limit: z.number().int().min(1).max(500).optional(),
+    client_id: z.string().optional(),
+    user_id: z.string().optional(),
+    status: z.enum(['abandoned', 'active', 'ended', 'expired', 'removed', 'replaced', 'revoked']).optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        client_id: z.string().optional(),
+        user_id: z.string(),
+        status: z.enum(['abandoned', 'active', 'ended', 'expired', 'removed', 'replaced', 'revoked']).optional(),
+        last_active_at: z.number().optional(),
+        expire_at: z.number().optional(),
+        abandon_at: z.number().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({ data: z.array(ResourceSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional(), total: z.number() });
+const action = createAction({
+    description: 'List Clerk sessions.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Sessions#operation/GetSessionList
+            endpoint: '/v1/sessions',
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.client_id !== undefined && { client_id: input.client_id }),
+                ...(input.user_id !== undefined && { user_id: input.user_id }),
+                ...(input.status !== undefined && { status: input.status })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/list-users.ts
+++ b/integrations/clerk/actions/list-users.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    limit: z.number().int().min(1).max(500).optional().describe('Maximum number of users to return. Maximum 500.'),
+    query: z.string().optional().describe('Search across names, identifiers, email addresses, phone numbers, and usernames.'),
+    email_address: z.array(z.string()).max(100).optional().describe('Filter by email addresses.'),
+    user_id: z.array(z.string()).max(100).optional().describe('Filter by Clerk user IDs.'),
+    external_id: z.array(z.string()).max(100).optional().describe('Filter by external user IDs.'),
+    organization_id: z.array(z.string()).max(100).optional().describe('Filter by organization IDs.'),
+    order_by: z.string().optional().describe('Sort field prefixed with + for ascending or - for descending. Example: "-created_at"')
+});
+
+const UserSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        username: z.string().nullable().optional(),
+        first_name: z.string().nullable().optional(),
+        last_name: z.string().nullable().optional(),
+        image_url: z.string().optional(),
+        primary_email_address_id: z.string().nullable().optional(),
+        primary_phone_number_id: z.string().nullable().optional(),
+        external_id: z.string().nullable().optional(),
+        banned: z.boolean().optional(),
+        locked: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional(),
+        locale: z.string().nullable().optional()
+    })
+    .passthrough();
+
+const ProviderResponseSchema = z.object({ data: z.array(UserSchema), total_count: z.number() });
+const OutputSchema = z.object({ items: z.array(UserSchema), next_cursor: z.string().optional(), total: z.number() });
+
+const action = createAction({
+    description: 'List users from Clerk.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const offset = input.cursor === undefined ? 0 : Number.parseInt(input.cursor, 10);
+        if (!Number.isInteger(offset) || offset < 0) {
+            throw new nango.ActionError({ type: 'invalid_cursor', message: 'Cursor must be a non-negative integer.' });
+        }
+        const response = await nango.get({
+            // https://clerk.com/docs/reference/backend-api/tag/Users#operation/GetUserList
+            endpoint: '/v1/users',
+            params: {
+                offset: String(offset),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.query !== undefined && { query: input.query }),
+                ...(input.email_address !== undefined && { email_address: input.email_address }),
+                ...(input.user_id !== undefined && { user_id: input.user_id }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.order_by !== undefined && { order_by: input.order_by })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextOffset = offset + provider.data.length;
+        return { items: provider.data, ...(nextOffset < provider.total_count && { next_cursor: String(nextOffset) }), total: provider.total_count };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/remove-organization-role-permission.ts
+++ b/integrations/clerk/actions/remove-organization-role-permission.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_role_id: z.string(), permission_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Remove a permission from a Clerk organization role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/RemovePermissionFromOrganizationRole
+            endpoint: `/v1/organization_roles/${encodeURIComponent(input.organization_role_id)}/permissions/${encodeURIComponent(input.permission_id)}`,
+            retries: 3
+        });
+        return { id: input.permission_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/revoke-organization-invitation.ts
+++ b/integrations/clerk/actions/revoke-organization-invitation.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), invitation_id: z.string(), requesting_user_id: z.string().optional() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        organization_id: z.string().optional(),
+        role: z.string().optional(),
+        status: z.enum(['pending', 'accepted', 'revoked', 'expired']).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Revoke a Clerk organization invitation.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Invitations#operation/RevokeOrganizationInvitation
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/invitations/${encodeURIComponent(input.invitation_id)}/revoke`,
+            data: { ...(input.requesting_user_id !== undefined && { requesting_user_id: input.requesting_user_id }) },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/revoke-session.ts
+++ b/integrations/clerk/actions/revoke-session.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ session_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        client_id: z.string().optional(),
+        user_id: z.string(),
+        status: z.enum(['abandoned', 'active', 'ended', 'expired', 'removed', 'replaced', 'revoked']).optional(),
+        last_active_at: z.number().optional(),
+        expire_at: z.number().optional(),
+        abandon_at: z.number().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Revoke a Clerk session.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Sessions#operation/RevokeSession
+            endpoint: `/v1/sessions/${encodeURIComponent(input.session_id)}/revoke`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-email-address.ts
+++ b/integrations/clerk/actions/update-email-address.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    email_address_id: z.string(),
+    verified: z.boolean().optional(),
+    primary: z.boolean().optional(),
+    notify_primary_email_address_changed: z.boolean().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        email_address: z.string(),
+        verification: z.object({ status: z.string().optional(), strategy: z.string().optional() }).passthrough().nullable().optional(),
+        linked_to: z.array(z.object({ id: z.string(), type: z.string() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update a Clerk email address.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Email-Addresses#operation/UpdateEmailAddress
+            endpoint: `/v1/email_addresses/${encodeURIComponent(input.email_address_id)}`,
+            data: {
+                ...(input.verified !== undefined && { verified: input.verified }),
+                ...(input.primary !== undefined && { primary: input.primary }),
+                ...(input.notify_primary_email_address_changed !== undefined && {
+                    notify_primary_email_address_changed: input.notify_primary_email_address_changed
+                })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-organization-domain.ts
+++ b/integrations/clerk/actions/update-organization-domain.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const EnrollmentModeSchema = z.enum(['manual_invitation', 'automatic_invitation', 'automatic_suggestion', 'enterprise_sso']);
+const InputSchema = z.object({
+    organization_id: z.string(),
+    domain_id: z.string(),
+    enrollment_mode: EnrollmentModeSchema.optional(),
+    verified: z.boolean().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization_id: z.string().optional(),
+        name: z.string(),
+        enrollment_mode: EnrollmentModeSchema.optional(),
+        affiliation_verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verified: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update a verified domain for a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Domains#operation/UpdateOrganizationDomain
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/domains/${encodeURIComponent(input.domain_id)}`,
+            data: {
+                ...(input.enrollment_mode !== undefined && { enrollment_mode: input.enrollment_mode }),
+                ...(input.verified !== undefined && { verified: input.verified })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-organization-membership-metadata.ts
+++ b/integrations/clerk/actions/update-organization-membership-metadata.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    organization_id: z.string(),
+    user_id: z.string(),
+    public_metadata: z.record(z.string(), z.unknown()).optional(),
+    private_metadata: z.record(z.string(), z.unknown()).optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization: z.object({ id: z.string() }).passthrough().optional(),
+        public_user_data: z.object({ user_id: z.string() }).passthrough().optional(),
+        role: z.string().optional(),
+        permissions: z.array(z.string()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update metadata for a Clerk organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Memberships#operation/UpdateOrganizationMembershipMetadata
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/memberships/${encodeURIComponent(input.user_id)}/metadata`,
+            data: {
+                ...(input.public_metadata !== undefined && { public_metadata: input.public_metadata }),
+                ...(input.private_metadata !== undefined && { private_metadata: input.private_metadata })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-organization-membership.ts
+++ b/integrations/clerk/actions/update-organization-membership.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), user_id: z.string(), role: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization: z.object({ id: z.string() }).passthrough().optional(),
+        public_user_data: z.object({ user_id: z.string() }).passthrough().optional(),
+        role: z.string().optional(),
+        permissions: z.array(z.string()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update a Clerk organization membership role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Memberships#operation/UpdateOrganizationMembership
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/memberships/${encodeURIComponent(input.user_id)}`,
+            data: { role: input.role },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-organization-role.ts
+++ b/integrations/clerk/actions/update-organization-role.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    organization_role_id: z.string(),
+    name: z.string().optional(),
+    key: z.string().optional(),
+    description: z.string().optional(),
+    permissions: z.array(z.string()).optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        key: z.string(),
+        description: z.string().nullable().optional(),
+        permissions: z.array(z.object({ id: z.string(), key: z.string().optional(), name: z.string().optional() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update a Clerk organization role.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Roles#operation/UpdateOrganizationRole
+            endpoint: `/v1/organization_roles/${encodeURIComponent(input.organization_role_id)}`,
+            data: {
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.key !== undefined && { key: input.key }),
+                ...(input.description !== undefined && { description: input.description }),
+                ...(input.permissions !== undefined && { permissions: input.permissions })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-organization.ts
+++ b/integrations/clerk/actions/update-organization.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+const InputSchema = z.object({
+    organization_id: z.string().min(1),
+    name: z.string().min(1).optional(),
+    slug: z.string().optional(),
+    admin_delete_enabled: z.boolean().optional(),
+    max_allowed_memberships: z.number().int().min(0).optional()
+});
+const OrganizationSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        name: z.string(),
+        slug: z.string(),
+        image_url: z.string().optional(),
+        has_image: z.boolean().optional(),
+        members_count: z.number().optional(),
+        max_allowed_memberships: z.number().optional(),
+        admin_delete_enabled: z.boolean().optional(),
+        public_metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+        private_metadata: z.record(z.string(), z.unknown()).optional(),
+        created_by: z.string().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = OrganizationSchema;
+const action = createAction({
+    description: 'Update a Clerk organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/UpdateOrganization
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}`,
+            data: {
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.slug !== undefined && { slug: input.slug }),
+                ...(input.admin_delete_enabled !== undefined && { admin_delete_enabled: input.admin_delete_enabled }),
+                ...(input.max_allowed_memberships !== undefined && { max_allowed_memberships: input.max_allowed_memberships })
+            },
+            retries: 3
+        });
+        return OrganizationSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-phone-number.ts
+++ b/integrations/clerk/actions/update-phone-number.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    phone_number_id: z.string(),
+    verified: z.boolean().optional(),
+    primary: z.boolean().optional(),
+    reserved_for_second_factor: z.boolean().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        phone_number: z.string(),
+        reserved_for_second_factor: z.boolean().optional(),
+        verification: z.object({ status: z.string().optional(), strategy: z.string().optional() }).passthrough().nullable().optional(),
+        linked_to: z.array(z.object({ id: z.string(), type: z.string() }).passthrough()).optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update a Clerk phone number.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Phone-Numbers#operation/UpdatePhoneNumber
+            endpoint: `/v1/phone_numbers/${encodeURIComponent(input.phone_number_id)}`,
+            data: {
+                ...(input.verified !== undefined && { verified: input.verified }),
+                ...(input.primary !== undefined && { primary: input.primary }),
+                ...(input.reserved_for_second_factor !== undefined && { reserved_for_second_factor: input.reserved_for_second_factor })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/update-user.ts
+++ b/integrations/clerk/actions/update-user.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    user_id: z.string().min(1),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    username: z.string().optional(),
+    password: z.string().min(8).optional(),
+    skip_password_checks: z.boolean().optional(),
+    sign_out_of_other_sessions: z.boolean().optional(),
+    external_id: z.string().optional(),
+    locale: z.string().optional()
+});
+const UserSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        username: z.string().nullable().optional(),
+        first_name: z.string().nullable().optional(),
+        last_name: z.string().nullable().optional(),
+        image_url: z.string().optional(),
+        primary_email_address_id: z.string().nullable().optional(),
+        primary_phone_number_id: z.string().nullable().optional(),
+        external_id: z.string().nullable().optional(),
+        banned: z.boolean().optional(),
+        locked: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional(),
+        locale: z.string().nullable().optional()
+    })
+    .passthrough();
+const OutputSchema = UserSchema;
+
+const action = createAction({
+    description: 'Update a Clerk user.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://clerk.com/docs/reference/backend-api/tag/Users#operation/UpdateUser
+            endpoint: `/v1/users/${encodeURIComponent(input.user_id)}`,
+            data: {
+                ...(input.first_name !== undefined && { first_name: input.first_name }),
+                ...(input.last_name !== undefined && { last_name: input.last_name }),
+                ...(input.username !== undefined && { username: input.username }),
+                ...(input.password !== undefined && { password: input.password }),
+                ...(input.skip_password_checks !== undefined && { skip_password_checks: input.skip_password_checks }),
+                ...(input.sign_out_of_other_sessions !== undefined && { sign_out_of_other_sessions: input.sign_out_of_other_sessions }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.locale !== undefined && { locale: input.locale })
+            },
+            retries: 3
+        });
+        return UserSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/actions/verify-organization-domain.ts
+++ b/integrations/clerk/actions/verify-organization-domain.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), domain_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        object: z.string().optional(),
+        organization_id: z.string().optional(),
+        name: z.string(),
+        enrollment_mode: z.string().optional(),
+        affiliation_verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verification: z.object({ attempts: z.number().optional(), status: z.string().optional() }).passthrough().optional(),
+        verified: z.boolean().optional(),
+        created_at: z.number().optional(),
+        updated_at: z.number().optional()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Verify ownership of a Clerk organization domain.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://clerk.com/docs/reference/backend-api/tag/Organization-Domains#operation/VerifyOrganizationDomainOwnership
+            endpoint: `/v1/organizations/${encodeURIComponent(input.organization_id)}/domains/${encodeURIComponent(input.domain_id)}/verify_ownership`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/clerk/tests/clerk-actions.test.ts
+++ b/integrations/clerk/tests/clerk-actions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import createOrganization from '../actions/create-organization.js';
+import createUser from '../actions/create-user.js';
+import deleteOrganization from '../actions/delete-organization.js';
+import deleteUser from '../actions/delete-user.js';
+import getOrganization from '../actions/get-organization.js';
+import getUser from '../actions/get-user.js';
+import listOrganizations from '../actions/list-organizations.js';
+import listUsers from '../actions/list-users.js';
+import updateOrganization from '../actions/update-organization.js';
+import updateUser from '../actions/update-user.js';
+
+const user = { id: 'user_123', object: 'user', first_name: 'Ada', last_name: 'Lovelace' };
+const organization = { id: 'org_123', object: 'organization', name: 'Analytical Engines', slug: 'analytical-engines' };
+
+function mockNango(data: unknown = {}) {
+    return {
+        get: vi.fn().mockResolvedValue({ data }),
+        post: vi.fn().mockResolvedValue({ data }),
+        patch: vi.fn().mockResolvedValue({ data }),
+        delete: vi.fn().mockResolvedValue({ data }),
+        ActionError: class extends Error {
+            constructor(public payload: unknown) {
+                super('Action error');
+            }
+        }
+    } as any;
+}
+
+describe('Clerk actions', () => {
+    it('lists users with offset cursor pagination', async () => {
+        const nango = mockNango({ data: [user], total_count: 2 });
+        await expect(listUsers.exec(nango, { cursor: '0', limit: 1, query: 'ada' })).resolves.toEqual({ items: [user], next_cursor: '1', total: 2 });
+        expect(nango.get).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/v1/users', params: expect.objectContaining({ offset: '0', limit: '1', query: 'ada' }), retries: 3 })
+        );
+    });
+
+    it('gets and creates users', async () => {
+        const getNango = mockNango(user);
+        await expect(getUser.exec(getNango, { user_id: 'user/123' })).resolves.toMatchObject(user);
+        expect(getNango.get).toHaveBeenCalledWith({ endpoint: '/v1/users/user%2F123', retries: 3 });
+        const createNango = mockNango(user);
+        await createUser.exec(createNango, { email_address: ['ada@example.com'], first_name: 'Ada' });
+        expect(createNango.post).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/v1/users', data: { email_address: ['ada@example.com'], first_name: 'Ada' }, retries: 3 })
+        );
+    });
+
+    it('updates and deletes users', async () => {
+        const updateNango = mockNango(user);
+        await updateUser.exec(updateNango, { user_id: 'user_123', first_name: 'Augusta' });
+        expect(updateNango.patch).toHaveBeenCalledWith(expect.objectContaining({ endpoint: '/v1/users/user_123', data: { first_name: 'Augusta' } }));
+        const deleteNango = mockNango();
+        await expect(deleteUser.exec(deleteNango, { user_id: 'user_123' })).resolves.toEqual({ id: 'user_123', success: true });
+    });
+
+    it('lists organizations with offset cursor pagination', async () => {
+        const nango = mockNango({ data: [organization], total_count: 2 });
+        await expect(listOrganizations.exec(nango, { cursor: '0', limit: 1 })).resolves.toEqual({ items: [organization], next_cursor: '1', total: 2 });
+        expect(nango.get).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/v1/organizations', params: expect.objectContaining({ offset: '0', limit: '1' }), retries: 3 })
+        );
+    });
+
+    it('gets and creates organizations', async () => {
+        const getNango = mockNango(organization);
+        await getOrganization.exec(getNango, { organization_id: 'org_123' });
+        expect(getNango.get).toHaveBeenCalledWith({ endpoint: '/v1/organizations/org_123', params: {}, retries: 3 });
+        const createNango = mockNango(organization);
+        await createOrganization.exec(createNango, { name: 'Analytical Engines', slug: 'analytical-engines' });
+        expect(createNango.post).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/v1/organizations', data: { name: 'Analytical Engines', slug: 'analytical-engines' } })
+        );
+    });
+
+    it('updates and deletes organizations', async () => {
+        const updateNango = mockNango(organization);
+        await updateOrganization.exec(updateNango, { organization_id: 'org_123', name: 'New Name' });
+        expect(updateNango.patch).toHaveBeenCalledWith(expect.objectContaining({ endpoint: '/v1/organizations/org_123', data: { name: 'New Name' } }));
+        const deleteNango = mockNango();
+        await expect(deleteOrganization.exec(deleteNango, { organization_id: 'org_123' })).resolves.toEqual({ id: 'org_123', success: true });
+    });
+});

--- a/integrations/clerk/tests/clerk-priority-actions.test.ts
+++ b/integrations/clerk/tests/clerk-priority-actions.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import assignOrganizationRolePermission from '../actions/assign-organization-role-permission.js';
+import createEmailAddress from '../actions/create-email-address.js';
+import createOrganizationDomain from '../actions/create-organization-domain.js';
+import createOrganizationInvitation from '../actions/create-organization-invitation.js';
+import createOrganizationMembership from '../actions/create-organization-membership.js';
+import createOrganizationRole from '../actions/create-organization-role.js';
+import createPhoneNumber from '../actions/create-phone-number.js';
+import deleteEmailAddress from '../actions/delete-email-address.js';
+import deleteOrganizationDomain from '../actions/delete-organization-domain.js';
+import deleteOrganizationMembership from '../actions/delete-organization-membership.js';
+import deleteOrganizationRole from '../actions/delete-organization-role.js';
+import deletePhoneNumber from '../actions/delete-phone-number.js';
+import getEmailAddress from '../actions/get-email-address.js';
+import getOrganizationInvitation from '../actions/get-organization-invitation.js';
+import getOrganizationRole from '../actions/get-organization-role.js';
+import getPhoneNumber from '../actions/get-phone-number.js';
+import getSession from '../actions/get-session.js';
+import listOrganizationDomains from '../actions/list-organization-domains.js';
+import listOrganizationInvitations from '../actions/list-organization-invitations.js';
+import listOrganizationMemberships from '../actions/list-organization-memberships.js';
+import listOrganizationRoles from '../actions/list-organization-roles.js';
+import listSessions from '../actions/list-sessions.js';
+import removeOrganizationRolePermission from '../actions/remove-organization-role-permission.js';
+import revokeOrganizationInvitation from '../actions/revoke-organization-invitation.js';
+import revokeSession from '../actions/revoke-session.js';
+import updateEmailAddress from '../actions/update-email-address.js';
+import updateOrganizationDomain from '../actions/update-organization-domain.js';
+import updateOrganizationMembershipMetadata from '../actions/update-organization-membership-metadata.js';
+import updateOrganizationMembership from '../actions/update-organization-membership.js';
+import updateOrganizationRole from '../actions/update-organization-role.js';
+import updatePhoneNumber from '../actions/update-phone-number.js';
+import verifyOrganizationDomain from '../actions/verify-organization-domain.js';
+
+function mockNango(data: unknown = {}) {
+    return {
+        get: vi.fn().mockResolvedValue({ data }),
+        post: vi.fn().mockResolvedValue({ data }),
+        patch: vi.fn().mockResolvedValue({ data }),
+        delete: vi.fn().mockResolvedValue({ data }),
+        ActionError: class extends Error {
+            constructor(public payload: unknown) {
+                super('Action error');
+            }
+        }
+    } as any;
+}
+
+const membership = { id: 'orgmem_123', object: 'organization_membership', role: 'org:member' };
+const invitation = { id: 'orginv_123', object: 'organization_invitation', email_address: 'ada@example.com', status: 'pending' };
+const domain = { id: 'orgdmn_123', object: 'organization_domain', name: 'example.com', verified: false };
+const session = { id: 'sess_123', object: 'session', user_id: 'user_123', status: 'active' };
+const emailAddress = { id: 'idn_123', object: 'email_address', email_address: 'ada@example.com' };
+const phoneNumber = { id: 'idn_456', object: 'phone_number', phone_number: '+15555550100' };
+const role = { id: 'role_123', object: 'role', name: 'Editor', key: 'org:editor' };
+
+describe('Clerk priority actions', () => {
+    it('manages organization memberships', async () => {
+        const listNango = mockNango({ data: [membership], total_count: 2 });
+        await expect(listOrganizationMemberships.exec(listNango, { organization_id: 'org/123', cursor: '0', limit: 1 })).resolves.toEqual({
+            items: [membership],
+            next_cursor: '1',
+            total: 2
+        });
+        expect(listNango.get).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/v1/organizations/org%2F123/memberships', params: expect.objectContaining({ offset: '0', limit: '1' }) })
+        );
+
+        const createNango = mockNango(membership);
+        await createOrganizationMembership.exec(createNango, { organization_id: 'org_123', user_id: 'user_123', role: 'org:member' });
+        expect(createNango.post).toHaveBeenCalledWith(expect.objectContaining({ data: { user_id: 'user_123', role: 'org:member' }, retries: 3 }));
+
+        const updateNango = mockNango(membership);
+        await updateOrganizationMembership.exec(updateNango, { organization_id: 'org_123', user_id: 'user_123', role: 'org:admin' });
+        await updateOrganizationMembershipMetadata.exec(updateNango, {
+            organization_id: 'org_123',
+            user_id: 'user_123',
+            public_metadata: { team: 'engineering' }
+        });
+        expect(updateNango.patch).toHaveBeenCalledTimes(2);
+
+        const deleteNango = mockNango();
+        await expect(deleteOrganizationMembership.exec(deleteNango, { organization_id: 'org_123', user_id: 'user_123' })).resolves.toEqual({
+            id: 'user_123',
+            success: true
+        });
+    });
+
+    it('manages organization invitations', async () => {
+        const listNango = mockNango({ data: [invitation], total_count: 1 });
+        await expect(listOrganizationInvitations.exec(listNango, { organization_id: 'org_123' })).resolves.toEqual({ items: [invitation], total: 1 });
+
+        const nango = mockNango(invitation);
+        await createOrganizationInvitation.exec(nango, { organization_id: 'org_123', email_address: 'ada@example.com', role: 'org:member', notify: true });
+        await getOrganizationInvitation.exec(nango, { organization_id: 'org_123', invitation_id: 'orginv_123' });
+        await revokeOrganizationInvitation.exec(nango, { organization_id: 'org_123', invitation_id: 'orginv_123' });
+        expect(nango.post).toHaveBeenLastCalledWith(
+            expect.objectContaining({ endpoint: '/v1/organizations/org_123/invitations/orginv_123/revoke', data: {}, retries: 3 })
+        );
+    });
+
+    it('manages organization domains', async () => {
+        const listNango = mockNango({ data: [domain], total_count: 1 });
+        await listOrganizationDomains.exec(listNango, { organization_id: 'org_123', verified: false });
+        expect(listNango.get).toHaveBeenCalledWith(expect.objectContaining({ params: expect.objectContaining({ verified: 'false' }) }));
+
+        const nango = mockNango(domain);
+        await createOrganizationDomain.exec(nango, { organization_id: 'org_123', name: 'example.com', enrollment_mode: 'automatic_invitation' });
+        await updateOrganizationDomain.exec(nango, { organization_id: 'org_123', domain_id: 'orgdmn_123', verified: true });
+        await verifyOrganizationDomain.exec(nango, { organization_id: 'org_123', domain_id: 'orgdmn_123' });
+
+        const deleteNango = mockNango();
+        await expect(deleteOrganizationDomain.exec(deleteNango, { organization_id: 'org_123', domain_id: 'orgdmn_123' })).resolves.toEqual({
+            id: 'orgdmn_123',
+            success: true
+        });
+    });
+
+    it('lists, gets, and revokes sessions', async () => {
+        const listNango = mockNango({ data: [session], total_count: 1 });
+        await expect(listSessions.exec(listNango, { user_id: 'user_123', status: 'active' })).resolves.toEqual({ items: [session], total: 1 });
+        const nango = mockNango(session);
+        await getSession.exec(nango, { session_id: 'sess/123' });
+        await revokeSession.exec(nango, { session_id: 'sess/123' });
+        expect(nango.post).toHaveBeenCalledWith(expect.objectContaining({ endpoint: '/v1/sessions/sess%2F123/revoke', data: {} }));
+    });
+
+    it('manages email addresses', async () => {
+        const nango = mockNango(emailAddress);
+        await createEmailAddress.exec(nango, { user_id: 'user_123', email_address: 'ada@example.com', primary: true });
+        await getEmailAddress.exec(nango, { email_address_id: 'idn/123' });
+        await updateEmailAddress.exec(nango, { email_address_id: 'idn_123', verified: true });
+        const deleteNango = mockNango();
+        await expect(deleteEmailAddress.exec(deleteNango, { email_address_id: 'idn_123' })).resolves.toEqual({ id: 'idn_123', success: true });
+        expect(nango.get).toHaveBeenCalledWith(expect.objectContaining({ endpoint: '/v1/email_addresses/idn%2F123' }));
+    });
+
+    it('manages phone numbers', async () => {
+        const nango = mockNango(phoneNumber);
+        await createPhoneNumber.exec(nango, { user_id: 'user_123', phone_number: '+15555550100', reserved_for_second_factor: true });
+        await getPhoneNumber.exec(nango, { phone_number_id: 'idn/456' });
+        await updatePhoneNumber.exec(nango, { phone_number_id: 'idn_456', primary: true });
+        const deleteNango = mockNango();
+        await expect(deletePhoneNumber.exec(deleteNango, { phone_number_id: 'idn_456' })).resolves.toEqual({ id: 'idn_456', success: true });
+        expect(nango.get).toHaveBeenCalledWith(expect.objectContaining({ endpoint: '/v1/phone_numbers/idn%2F456' }));
+    });
+
+    it('manages organization roles and permissions', async () => {
+        const listNango = mockNango({ data: [role], total_count: 1 });
+        await expect(listOrganizationRoles.exec(listNango, {})).resolves.toEqual({ items: [role], total: 1 });
+
+        const nango = mockNango(role);
+        await createOrganizationRole.exec(nango, { name: 'Editor', key: 'org:editor', permissions: ['org:posts:manage'] });
+        await getOrganizationRole.exec(nango, { organization_role_id: 'role_123' });
+        await updateOrganizationRole.exec(nango, { organization_role_id: 'role_123', name: 'Publisher' });
+        await assignOrganizationRolePermission.exec(nango, { organization_role_id: 'role_123', permission_id: 'perm_123' });
+
+        const deleteNango = mockNango();
+        await expect(removeOrganizationRolePermission.exec(deleteNango, { organization_role_id: 'role_123', permission_id: 'perm_123' })).resolves.toEqual({
+            id: 'perm_123',
+            success: true
+        });
+        await expect(deleteOrganizationRole.exec(deleteNango, { organization_role_id: 'role_123' })).resolves.toEqual({ id: 'role_123', success: true });
+    });
+});

--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -1210,16 +1210,48 @@ import './checkr-partner-staging/syncs/account.js';
 import './clari-copilot/syncs/calls.js';
 
 // -- Integration: clerk
+import './clerk/actions/assign-organization-role-permission.js';
+import './clerk/actions/create-email-address.js';
+import './clerk/actions/create-organization-domain.js';
+import './clerk/actions/create-organization-invitation.js';
+import './clerk/actions/create-organization-membership.js';
+import './clerk/actions/create-organization-role.js';
 import './clerk/actions/create-organization.js';
+import './clerk/actions/create-phone-number.js';
 import './clerk/actions/create-user.js';
+import './clerk/actions/delete-email-address.js';
+import './clerk/actions/delete-organization-domain.js';
+import './clerk/actions/delete-organization-membership.js';
+import './clerk/actions/delete-organization-role.js';
 import './clerk/actions/delete-organization.js';
+import './clerk/actions/delete-phone-number.js';
 import './clerk/actions/delete-user.js';
+import './clerk/actions/get-email-address.js';
+import './clerk/actions/get-organization-invitation.js';
+import './clerk/actions/get-organization-role.js';
 import './clerk/actions/get-organization.js';
+import './clerk/actions/get-phone-number.js';
+import './clerk/actions/get-session.js';
 import './clerk/actions/get-user.js';
+import './clerk/actions/list-organization-domains.js';
+import './clerk/actions/list-organization-invitations.js';
+import './clerk/actions/list-organization-memberships.js';
+import './clerk/actions/list-organization-roles.js';
 import './clerk/actions/list-organizations.js';
+import './clerk/actions/list-sessions.js';
 import './clerk/actions/list-users.js';
+import './clerk/actions/remove-organization-role-permission.js';
+import './clerk/actions/revoke-organization-invitation.js';
+import './clerk/actions/revoke-session.js';
+import './clerk/actions/update-email-address.js';
+import './clerk/actions/update-organization-domain.js';
+import './clerk/actions/update-organization-membership-metadata.js';
+import './clerk/actions/update-organization-membership.js';
+import './clerk/actions/update-organization-role.js';
 import './clerk/actions/update-organization.js';
+import './clerk/actions/update-phone-number.js';
 import './clerk/actions/update-user.js';
+import './clerk/actions/verify-organization-domain.js';
 
 // -- Integration: clicksend
 import './clicksend/syncs/sms-history.js';

--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -1209,6 +1209,18 @@ import './checkr-partner-staging/syncs/account.js';
 // -- Integration: clari-copilot
 import './clari-copilot/syncs/calls.js';
 
+// -- Integration: clerk
+import './clerk/actions/create-organization.js';
+import './clerk/actions/create-user.js';
+import './clerk/actions/delete-organization.js';
+import './clerk/actions/delete-user.js';
+import './clerk/actions/get-organization.js';
+import './clerk/actions/get-user.js';
+import './clerk/actions/list-organizations.js';
+import './clerk/actions/list-users.js';
+import './clerk/actions/update-organization.js';
+import './clerk/actions/update-user.js';
+
 // -- Integration: clicksend
 import './clicksend/syncs/sms-history.js';
 import './clicksend/actions/fetch-account.js';


### PR DESCRIPTION
Adds a Clerk integration with 42 typed actions covering users, organizations, sessions, email and phone identities, invitations, memberships, roles and permissions, and organization domains.

The actions follow Clerk Backend API v1 request and response shapes, encode path parameters, expose offset pagination through cursors, and use the standard Nango retry and scope conventions. Generated Nango artifacts and focused tests are included.

Examples include `list-users`, `revoke-session`, `create-organization-membership`, and `assign-organization-role-permission`.

Tested with `npx vitest run clerk` (13 tests), `npm run lint -- --quiet`, and `npm run compile:integrations`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Clerk integration with 42 typed actions for managing users, organizations, sessions, identities, invitations, memberships, roles, and domains.

All actions follow Clerk Backend API v1 request and response shapes, encode path parameters, and use standard Nango retry and scope conventions. List actions expose offset pagination through cursors, and the PR includes generated Nango artifacts and 13 focused tests.

**Validation and pagination fixes**
- Rejects malformed pagination cursors, and list-users and list-sessions parse plain arrays instead of wrapped responses.
- Enforces required inputs: non-empty IDs, a valid email, an identifier for new users, a mutable field for role updates, and client_id or user_id for session lists.
- Allows null verification fields, supports clearing nullable user fields with explicit null, and adds missing filters to list-users.

<sup>Written for commit afaa835b1a77cf5cb1d26fd470e55381ad2b1980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

