### PR TITLE
feat(workos): add directory and identity actions

### DIFF
--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -6706,18 +6706,46 @@ import './workday-refresh-token/actions/list-workers.js';
 import './workday-refresh-token/actions/submit-time-off-request.js';
 
 // -- Integration: workos
+import './workos/actions/create-connection.js';
+import './workos/actions/create-invitation.js';
+import './workos/actions/create-organization-domain.js';
+import './workos/actions/create-organization-membership.js';
 import './workos/actions/create-organization.js';
 import './workos/actions/create-user.js';
+import './workos/actions/deactivate-organization-membership.js';
+import './workos/actions/delete-connection.js';
+import './workos/actions/delete-directory.js';
+import './workos/actions/delete-organization-domain.js';
+import './workos/actions/delete-organization-membership.js';
 import './workos/actions/delete-organization.js';
 import './workos/actions/delete-user.js';
+import './workos/actions/get-connection.js';
+import './workos/actions/get-directory-group.js';
+import './workos/actions/get-directory-user.js';
+import './workos/actions/get-directory.js';
+import './workos/actions/get-invitation.js';
+import './workos/actions/get-organization-domain.js';
+import './workos/actions/get-organization-membership.js';
 import './workos/actions/get-organization.js';
 import './workos/actions/get-user.js';
+import './workos/actions/list-connections.js';
+import './workos/actions/list-directories.js';
 import './workos/actions/list-directory-groups.js';
 import './workos/actions/list-directory-users.js';
+import './workos/actions/list-events.js';
+import './workos/actions/list-invitations.js';
+import './workos/actions/list-organization-membership-groups.js';
+import './workos/actions/list-organization-memberships.js';
 import './workos/actions/list-organizations.js';
 import './workos/actions/list-users.js';
+import './workos/actions/reactivate-organization-membership.js';
+import './workos/actions/resend-invitation.js';
+import './workos/actions/revoke-invitation.js';
+import './workos/actions/update-connection.js';
+import './workos/actions/update-organization-membership.js';
 import './workos/actions/update-organization.js';
 import './workos/actions/update-user.js';
+import './workos/actions/verify-organization-domain.js';
 
 // -- Integration: xero
 import './xero/syncs/accounts.js';

--- a/integrations/index.ts
+++ b/integrations/index.ts
@@ -6705,6 +6705,20 @@ import './workday-refresh-token/actions/list-worker-time-off.js';
 import './workday-refresh-token/actions/list-workers.js';
 import './workday-refresh-token/actions/submit-time-off-request.js';
 
+// -- Integration: workos
+import './workos/actions/create-organization.js';
+import './workos/actions/create-user.js';
+import './workos/actions/delete-organization.js';
+import './workos/actions/delete-user.js';
+import './workos/actions/get-organization.js';
+import './workos/actions/get-user.js';
+import './workos/actions/list-directory-groups.js';
+import './workos/actions/list-directory-users.js';
+import './workos/actions/list-organizations.js';
+import './workos/actions/list-users.js';
+import './workos/actions/update-organization.js';
+import './workos/actions/update-user.js';
+
 // -- Integration: xero
 import './xero/syncs/accounts.js';
 import './xero/syncs/bank-transactions.js';

--- a/integrations/workos/actions/create-connection.ts
+++ b/integrations/workos/actions/create-connection.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const KeyPairSchema = z.object({ key: z.string(), cert: z.string() });
+const AttributeMapsSchema = z.object({
+    standard_attributes: z
+        .object({
+            idp_id: z.string().optional(),
+            email: z.string().optional(),
+            first_name: z.string().optional(),
+            last_name: z.string().optional(),
+            groups: z.string().nullable().optional(),
+            name: z.string().nullable().optional()
+        })
+        .optional(),
+    custom_attributes: z.record(z.string(), z.string()).optional()
+});
+const SamlOptionsSchema = z.object({
+    idp_metadata_url: z.string().url().optional(),
+    acs_url: z.string().url().optional(),
+    sp_entity_id: z.string().optional(),
+    idp_entity_id: z.string().optional(),
+    idp_sso_url: z.string().url().optional(),
+    idp_signing_certs: z.array(z.string()).optional(),
+    sp_signing_key_pair: KeyPairSchema.optional(),
+    sp_encryption_key_pairs: z.array(KeyPairSchema).optional()
+});
+const OidcOptionsSchema = z.object({
+    discovery_endpoint: z.string().url(),
+    client_id: z.string(),
+    client_secret: z.string().optional(),
+    redirect_uri: z.string().url().optional(),
+    pkce: z.boolean().optional(),
+    token_authentication_method: z.enum(['client_secret_post', 'client_secret_basic', 'private_key_jwt']).optional(),
+    jwt_signing_key_pair: KeyPairSchema.optional(),
+    id_token_signature_algorithm: z
+        .enum(['ES256', 'ES384', 'ES512', 'EdDSA', 'HS256', 'HS384', 'HS512', 'PS256', 'PS384', 'PS512', 'RS256', 'RS384', 'RS512'])
+        .optional(),
+    fetch_user_info: z.boolean().optional()
+});
+const InputSchema = z
+    .object({
+        organization_id: z.string(),
+        name: z.string().optional(),
+        external_id: z
+            .string()
+            .max(128)
+            .refine((value) => Array.from(value).every((character) => character.charCodeAt(0) <= 127), 'External ID must contain only ASCII characters.')
+            .optional(),
+        connection_type: z.string().optional(),
+        attribute_maps: AttributeMapsSchema.optional(),
+        saml_options: SamlOptionsSchema.optional(),
+        oidc_options: OidcOptionsSchema.optional()
+    })
+    .refine((input) => Number(input.saml_options !== undefined) + Number(input.oidc_options !== undefined) === 1, {
+        message: 'Exactly one of saml_options or oidc_options is required.'
+    });
+const ResourceSchema = z
+    .object({
+        object: z.literal('connection'),
+        id: z.string(),
+        organization_id: z.string().optional(),
+        connection_type: z.string(),
+        name: z.string(),
+        state: z.enum(['requires_type', 'draft', 'active', 'validating', 'inactive', 'deleting']),
+        status: z.enum(['linked', 'unlinked']),
+        domains: z.array(z.object({ id: z.string(), object: z.literal('connection_domain'), domain: z.string() }).passthrough()),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+
+const action = createAction({
+    description: 'Create a WorkOS SSO connection.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/sso/connection
+            endpoint: '/connections',
+            data: {
+                organization_id: input.organization_id,
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.connection_type !== undefined && { connection_type: input.connection_type }),
+                ...(input.attribute_maps !== undefined && { attribute_maps: input.attribute_maps }),
+                ...(input.saml_options !== undefined && { saml_options: input.saml_options }),
+                ...(input.oidc_options !== undefined && { oidc_options: input.oidc_options })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/create-invitation.ts
+++ b/integrations/workos/actions/create-invitation.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    email: z.string().email(),
+    organization_id: z.string().optional(),
+    role_slug: z.string().optional(),
+    expires_in_days: z.number().int().min(1).max(30).optional(),
+    inviter_user_id: z.string().optional(),
+    locale: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        object: z.literal('invitation'),
+        id: z.string(),
+        email: z.string(),
+        state: z.enum(['pending', 'accepted', 'expired', 'revoked']),
+        accepted_at: z.string().nullable(),
+        revoked_at: z.string().nullable(),
+        expires_at: z.string(),
+        organization_id: z.string().nullable(),
+        inviter_user_id: z.string().nullable(),
+        accepted_user_id: z.string().nullable(),
+        role_slug: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        token: z.string(),
+        accept_invitation_url: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a WorkOS user invitation.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/user-management/invitation
+            endpoint: '/user_management/invitations',
+            data: {
+                email: input.email,
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.role_slug !== undefined && { role_slug: input.role_slug }),
+                ...(input.expires_in_days !== undefined && { expires_in_days: input.expires_in_days }),
+                ...(input.inviter_user_id !== undefined && { inviter_user_id: input.inviter_user_id }),
+                ...(input.locale !== undefined && { locale: input.locale })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/create-organization-domain.ts
+++ b/integrations/workos/actions/create-organization-domain.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string(), domain: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_domain'),
+        id: z.string(),
+        organization_id: z.string(),
+        domain: z.string(),
+        state: z.enum(['failed', 'legacy_verified', 'pending', 'unverified', 'verified']).optional(),
+        verification_prefix: z.string().optional(),
+        verification_token: z.string().optional(),
+        verification_strategy: z.enum(['dns', 'manual']).optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a WorkOS organization domain.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/organization-domain
+            endpoint: '/organization_domains',
+            data: { organization_id: input.organization_id, domain: input.domain },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/create-organization-membership.ts
+++ b/integrations/workos/actions/create-organization-membership.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z
+    .object({ user_id: z.string(), organization_id: z.string(), role_slug: z.string().optional(), role_slugs: z.array(z.string()).min(1).optional() })
+    .refine((input) => input.role_slug === undefined || input.role_slugs === undefined, { message: 'role_slug and role_slugs are mutually exclusive.' });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_membership'),
+        id: z.string(),
+        user_id: z.string(),
+        organization_id: z.string(),
+        status: z.enum(['active', 'inactive', 'pending']),
+        directory_managed: z.boolean(),
+        organization_name: z.string().optional(),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        role: z.object({ slug: z.string() }).passthrough().optional(),
+        roles: z.array(z.object({ slug: z.string() }).passthrough()).optional(),
+        user: z.object({ id: z.string() }).passthrough().optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Create a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: '/user_management/organization_memberships',
+            data: {
+                user_id: input.user_id,
+                organization_id: input.organization_id,
+                ...(input.role_slug !== undefined && { role_slug: input.role_slug }),
+                ...(input.role_slugs !== undefined && { role_slugs: input.role_slugs })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/create-organization.ts
+++ b/integrations/workos/actions/create-organization.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const DomainDataSchema = z.object({ domain: z.string(), state: z.enum(['verified', 'pending']) });
+const InputSchema = z.object({
+    name: z.string().min(1).describe('Descriptive organization name.'),
+    domain_data: z.array(DomainDataSchema).optional(),
+    external_id: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.string()).optional()
+});
+const OrganizationSchema = z
+    .object({
+        object: z.literal('organization'),
+        id: z.string(),
+        name: z.string(),
+        allow_profiles_outside_organization: z.boolean(),
+        domains: z.array(z.record(z.string(), z.unknown())),
+        stripe_customer_id: z.string().nullable().optional(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Create an organization in WorkOS.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OrganizationSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OrganizationSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/organization
+            endpoint: '/organizations',
+            data: {
+                name: input.name,
+                ...(input.domain_data !== undefined && { domain_data: input.domain_data }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.metadata !== undefined && { metadata: input.metadata })
+            },
+            retries: 3
+        });
+        return OrganizationSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/create-user.ts
+++ b/integrations/workos/actions/create-user.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const PasswordHashTypeSchema = z.enum(['bcrypt', 'firebase-scrypt', 'ssha', 'scrypt', 'argon2']);
+const InputSchema = z.object({
+    email: z.string().email().describe('Email address for the user.'),
+    password: z.string().optional().describe('Plaintext password for the user.'),
+    password_hash: z.string().optional().describe('Pre-hashed password. Use with password_hash_type.'),
+    password_hash_type: PasswordHashTypeSchema.optional(),
+    name: z.string().optional(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    email_verified: z.boolean().optional(),
+    external_id: z.string().optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+    ip_address: z.string().optional(),
+    user_agent: z.string().optional(),
+    signals_id: z.string().optional()
+});
+const UserSchema = z
+    .object({
+        object: z.literal('user'),
+        id: z.string(),
+        email: z.string(),
+        email_verified: z.boolean(),
+        profile_picture_url: z.string().nullable(),
+        name: z.string().nullable(),
+        first_name: z.string().nullable(),
+        last_name: z.string().nullable(),
+        last_sign_in_at: z.string().nullable(),
+        locale: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional(),
+        radar_auth_attempt_id: z.string().optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Create a user in WorkOS User Management.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: UserSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof UserSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/user-management/user
+            endpoint: '/user_management/users',
+            data: {
+                email: input.email,
+                ...(input.password !== undefined && { password: input.password }),
+                ...(input.password_hash !== undefined && { password_hash: input.password_hash }),
+                ...(input.password_hash_type !== undefined && { password_hash_type: input.password_hash_type }),
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.first_name !== undefined && { first_name: input.first_name }),
+                ...(input.last_name !== undefined && { last_name: input.last_name }),
+                ...(input.email_verified !== undefined && { email_verified: input.email_verified }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.metadata !== undefined && { metadata: input.metadata }),
+                ...(input.ip_address !== undefined && { ip_address: input.ip_address }),
+                ...(input.user_agent !== undefined && { user_agent: input.user_agent }),
+                ...(input.signals_id !== undefined && { signals_id: input.signals_id })
+            },
+            retries: 3
+        });
+        return UserSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/deactivate-organization-membership.ts
+++ b/integrations/workos/actions/deactivate-organization-membership.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ membership_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_membership'),
+        id: z.string(),
+        user_id: z.string(),
+        organization_id: z.string(),
+        status: z.enum(['active', 'inactive', 'pending']),
+        directory_managed: z.boolean(),
+        organization_name: z.string().optional(),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        role: z.object({ slug: z.string() }).passthrough().optional(),
+        roles: z.array(z.object({ slug: z.string() }).passthrough()).optional(),
+        user: z.object({ id: z.string() }).passthrough().optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Deactivate a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.put({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: `/user_management/organization_memberships/${encodeURIComponent(input.membership_id)}/deactivate`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/delete-connection.ts
+++ b/integrations/workos/actions/delete-connection.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ connection_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a WorkOS SSO connection.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://workos.com/docs/reference/sso/connection
+            endpoint: `/connections/${encodeURIComponent(input.connection_id)}`,
+            retries: 3
+        });
+        return { id: input.connection_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/delete-directory.ts
+++ b/integrations/workos/actions/delete-directory.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ directory_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a WorkOS directory.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://workos.com/docs/reference/directory-sync/directory
+            endpoint: `/directories/${encodeURIComponent(input.directory_id)}`,
+            retries: 3
+        });
+        return { id: input.directory_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/delete-organization-domain.ts
+++ b/integrations/workos/actions/delete-organization-domain.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_domain_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a WorkOS organization domain.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://workos.com/docs/reference/organization-domain
+            endpoint: `/organization_domains/${encodeURIComponent(input.organization_domain_id)}`,
+            retries: 3
+        });
+        return { id: input.organization_domain_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/delete-organization-membership.ts
+++ b/integrations/workos/actions/delete-organization-membership.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ membership_id: z.string() });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+const action = createAction({
+    description: 'Delete a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: `/user_management/organization_memberships/${encodeURIComponent(input.membership_id)}`,
+            retries: 3
+        });
+        return { id: input.membership_id, success: true };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/delete-organization.ts
+++ b/integrations/workos/actions/delete-organization.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string().min(1).describe('WorkOS organization ID. Example: "org_01H..."') });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+
+const action = createAction({
+    description: 'Permanently delete a WorkOS organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://workos.com/docs/reference/organization
+            endpoint: `/organizations/${encodeURIComponent(input.organization_id)}`,
+            retries: 3
+        });
+        return { id: input.organization_id, success: true };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/delete-user.ts
+++ b/integrations/workos/actions/delete-user.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ user_id: z.string().min(1).describe('WorkOS user ID. Example: "user_01H..."') });
+const OutputSchema = z.object({ id: z.string(), success: z.boolean() });
+
+const action = createAction({
+    description: 'Permanently delete a WorkOS user.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        await nango.delete({
+            // https://workos.com/docs/reference/user-management/user
+            endpoint: `/user_management/users/${encodeURIComponent(input.user_id)}`,
+            retries: 3
+        });
+        return { id: input.user_id, success: true };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-connection.ts
+++ b/integrations/workos/actions/get-connection.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ connection_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('connection'),
+        id: z.string(),
+        organization_id: z.string().optional(),
+        connection_type: z.string(),
+        name: z.string(),
+        state: z.enum(['requires_type', 'draft', 'active', 'validating', 'inactive', 'deleting']),
+        status: z.enum(['linked', 'unlinked']),
+        domains: z.array(z.object({ id: z.string(), object: z.literal('connection_domain'), domain: z.string() }).passthrough()),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS SSO connection.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/sso/connection
+            endpoint: `/connections/${encodeURIComponent(input.connection_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-directory-group.ts
+++ b/integrations/workos/actions/get-directory-group.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ group_id: z.string() });
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        idp_id: z.string(),
+        directory_id: z.string(),
+        organization_id: z.string().nullable(),
+        name: z.string(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        raw_attributes: z.record(z.string(), z.unknown())
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS directory group.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/directory-sync/group
+            endpoint: `/directory_groups/${encodeURIComponent(input.group_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-directory-user.ts
+++ b/integrations/workos/actions/get-directory-user.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ directory_user_id: z.string() });
+const GroupSchema = z
+    .object({
+        id: z.string(),
+        idp_id: z.string(),
+        directory_id: z.string(),
+        organization_id: z.string().nullable(),
+        name: z.string(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        raw_attributes: z.record(z.string(), z.unknown())
+    })
+    .passthrough();
+const ResourceSchema = z
+    .object({
+        object: z.literal('directory_user'),
+        id: z.string(),
+        directory_id: z.string(),
+        organization_id: z.string().nullable(),
+        idp_id: z.string(),
+        first_name: z.string().nullable(),
+        last_name: z.string().nullable(),
+        email: z.string().nullable(),
+        state: z.enum(['active', 'inactive']),
+        role: z.record(z.string(), z.unknown()).optional(),
+        roles: z.array(z.record(z.string(), z.unknown())).optional(),
+        raw_attributes: z.record(z.string(), z.unknown()),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        groups: z.array(GroupSchema),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS directory user and their groups.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/directory-sync/user
+            endpoint: `/directory_users/${encodeURIComponent(input.directory_user_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-directory.ts
+++ b/integrations/workos/actions/get-directory.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ directory_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('directory'),
+        id: z.string(),
+        domain: z.string(),
+        external_key: z.string(),
+        name: z.string(),
+        organization_id: z.string().nullable().optional(),
+        state: z.string(),
+        type: z.string(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS directory.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/directory-sync/directory
+            endpoint: `/directories/${encodeURIComponent(input.directory_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-invitation.ts
+++ b/integrations/workos/actions/get-invitation.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ invitation_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('invitation'),
+        id: z.string(),
+        email: z.string(),
+        state: z.enum(['pending', 'accepted', 'expired', 'revoked']),
+        accepted_at: z.string().nullable(),
+        revoked_at: z.string().nullable(),
+        expires_at: z.string(),
+        organization_id: z.string().nullable(),
+        inviter_user_id: z.string().nullable(),
+        accepted_user_id: z.string().nullable(),
+        role_slug: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        token: z.string(),
+        accept_invitation_url: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS user invitation.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/invitation
+            endpoint: `/user_management/invitations/${encodeURIComponent(input.invitation_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-organization-domain.ts
+++ b/integrations/workos/actions/get-organization-domain.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_domain_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_domain'),
+        id: z.string(),
+        organization_id: z.string(),
+        domain: z.string(),
+        state: z.enum(['failed', 'legacy_verified', 'pending', 'unverified', 'verified']).optional(),
+        verification_prefix: z.string().optional(),
+        verification_token: z.string().optional(),
+        verification_strategy: z.enum(['dns', 'manual']).optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS organization domain.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/organization-domain
+            endpoint: `/organization_domains/${encodeURIComponent(input.organization_domain_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-organization-membership.ts
+++ b/integrations/workos/actions/get-organization-membership.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ membership_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_membership'),
+        id: z.string(),
+        user_id: z.string(),
+        organization_id: z.string(),
+        status: z.enum(['active', 'inactive', 'pending']),
+        directory_managed: z.boolean(),
+        organization_name: z.string().optional(),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        role: z.object({ slug: z.string() }).passthrough().optional(),
+        roles: z.array(z.object({ slug: z.string() }).passthrough()).optional(),
+        user: z.object({ id: z.string() }).passthrough().optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Get a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: `/user_management/organization_memberships/${encodeURIComponent(input.membership_id)}`,
+
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-organization.ts
+++ b/integrations/workos/actions/get-organization.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_id: z.string().min(1).describe('WorkOS organization ID. Example: "org_01H..."') });
+const DomainSchema = z.object({
+    object: z.literal('organization_domain'),
+    id: z.string(),
+    domain: z.string(),
+    organization_id: z.string(),
+    state: z.string(),
+    verification_token: z.string().optional(),
+    verification_strategy: z.string(),
+    verification_prefix: z.string().optional(),
+    created_at: z.string(),
+    updated_at: z.string()
+});
+const OrganizationSchema = z
+    .object({
+        object: z.literal('organization'),
+        id: z.string(),
+        name: z.string(),
+        allow_profiles_outside_organization: z.boolean(),
+        domains: z.array(DomainSchema),
+        stripe_customer_id: z.string().nullable().optional(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Retrieve a WorkOS organization by ID.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OrganizationSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OrganizationSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/organization
+            endpoint: `/organizations/${encodeURIComponent(input.organization_id)}`,
+            retries: 3
+        });
+        return OrganizationSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/get-user.ts
+++ b/integrations/workos/actions/get-user.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ user_id: z.string().min(1).describe('WorkOS user ID. Example: "user_01H..."') });
+const UserSchema = z
+    .object({
+        object: z.literal('user'),
+        id: z.string(),
+        email: z.string(),
+        email_verified: z.boolean(),
+        profile_picture_url: z.string().nullable(),
+        name: z.string().nullable(),
+        first_name: z.string().nullable(),
+        last_name: z.string().nullable(),
+        last_sign_in_at: z.string().nullable(),
+        locale: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Retrieve a WorkOS user by ID.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: UserSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof UserSchema>> => {
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/user
+            endpoint: `/user_management/users/${encodeURIComponent(input.user_id)}`,
+            retries: 3
+        });
+        return UserSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-connections.ts
+++ b/integrations/workos/actions/list-connections.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    connection_type: z.string().optional(),
+    domain: z.string().optional(),
+    organization_id: z.string().optional(),
+    search: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        object: z.literal('connection'),
+        id: z.string(),
+        organization_id: z.string().optional(),
+        connection_type: z.string(),
+        name: z.string(),
+        state: z.enum(['requires_type', 'draft', 'active', 'validating', 'inactive', 'deleting']),
+        status: z.enum(['linked', 'unlinked']),
+        domains: z.array(z.object({ id: z.string(), object: z.literal('connection_domain'), domain: z.string() }).passthrough()),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(ResourceSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional() });
+const action = createAction({
+    description: 'List WorkOS SSO connections.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/sso/connection
+            endpoint: '/connections',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.connection_type !== undefined && { connection_type: input.connection_type }),
+                ...(input.domain !== undefined && { domain: input.domain }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.search !== undefined && { search: input.search })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-directories.ts
+++ b/integrations/workos/actions/list-directories.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    organization_id: z.string().optional(),
+    search: z.string().optional(),
+    domain: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        object: z.literal('directory'),
+        id: z.string(),
+        domain: z.string(),
+        external_key: z.string(),
+        name: z.string(),
+        organization_id: z.string().nullable().optional(),
+        state: z.string(),
+        type: z.string(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(ResourceSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional() });
+const action = createAction({
+    description: 'List WorkOS directories.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/directory-sync/directory
+            endpoint: '/directories',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.search !== undefined && { search: input.search }),
+                ...(input.domain !== undefined && { domain: input.domain })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-directory-groups.ts
+++ b/integrations/workos/actions/list-directory-groups.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    directory: z.string().optional().describe('Filter groups by directory ID.'),
+    user: z.string().optional().describe('Filter groups by directory user ID.')
+});
+const DirectoryGroupSchema = z
+    .object({
+        id: z.string(),
+        idp_id: z.string(),
+        directory_id: z.string(),
+        organization_id: z.string().nullable(),
+        name: z.string(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        raw_attributes: z.record(z.string(), z.unknown())
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(DirectoryGroupSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(DirectoryGroupSchema), next_cursor: z.string().optional() });
+
+const action = createAction({
+    description: 'List directory groups from WorkOS Directory Sync.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/directory-sync/group
+            endpoint: '/directory_groups',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.directory !== undefined && { directory: input.directory }),
+                ...(input.user !== undefined && { user: input.user })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-directory-users.ts
+++ b/integrations/workos/actions/list-directory-users.ts
@@ -7,7 +7,9 @@ const InputSchema = z.object({
     limit: z.number().int().min(1).max(100).optional(),
     order: z.enum(['asc', 'desc']).optional(),
     directory: z.string().optional().describe('Filter users by directory ID.'),
-    group: z.string().optional().describe('Filter users by directory group ID.')
+    group: z.string().optional().describe('Filter users by directory group ID.'),
+    idp_id: z.string().optional().describe('Filter users by the identity provider user ID.'),
+    email: z.string().email().optional().describe('Filter users by email address.')
 });
 const DirectoryGroupSchema = z
     .object({
@@ -64,7 +66,9 @@ const action = createAction({
                 ...(input.limit !== undefined && { limit: String(input.limit) }),
                 ...(input.order !== undefined && { order: input.order }),
                 ...(input.directory !== undefined && { directory: input.directory }),
-                ...(input.group !== undefined && { group: input.group })
+                ...(input.group !== undefined && { group: input.group }),
+                ...(input.idp_id !== undefined && { idp_id: input.idp_id }),
+                ...(input.email !== undefined && { email: input.email })
             },
             retries: 3
         });

--- a/integrations/workos/actions/list-directory-users.ts
+++ b/integrations/workos/actions/list-directory-users.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    directory: z.string().optional().describe('Filter users by directory ID.'),
+    group: z.string().optional().describe('Filter users by directory group ID.')
+});
+const DirectoryGroupSchema = z
+    .object({
+        id: z.string(),
+        idp_id: z.string(),
+        directory_id: z.string(),
+        organization_id: z.string().nullable(),
+        name: z.string(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        raw_attributes: z.record(z.string(), z.unknown())
+    })
+    .passthrough();
+const DirectoryUserSchema = z
+    .object({
+        object: z.literal('directory_user'),
+        id: z.string(),
+        directory_id: z.string(),
+        organization_id: z.string().nullable(),
+        idp_id: z.string(),
+        first_name: z.string().nullable(),
+        last_name: z.string().nullable(),
+        email: z.string().nullable(),
+        state: z.enum(['active', 'inactive']),
+        role: z.record(z.string(), z.unknown()).optional(),
+        roles: z.array(z.record(z.string(), z.unknown())).optional(),
+        raw_attributes: z.record(z.string(), z.unknown()),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        groups: z.array(DirectoryGroupSchema),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(DirectoryUserSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(DirectoryUserSchema), next_cursor: z.string().optional() });
+
+const action = createAction({
+    description: 'List directory users from WorkOS Directory Sync.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/directory-sync/user
+            endpoint: '/directory_users',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.directory !== undefined && { directory: input.directory }),
+                ...(input.group !== undefined && { group: input.group })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-events.ts
+++ b/integrations/workos/actions/list-events.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    events: z.array(z.string()).min(1),
+    range_start: z.string().optional(),
+    range_end: z.string().optional(),
+    organization_id: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        id: z.string(),
+        event: z.string(),
+        created_at: z.string(),
+        data: z.record(z.string(), z.unknown()),
+        context: z.record(z.string(), z.unknown()).optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(ResourceSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional() });
+const action = createAction({
+    description: 'List WorkOS events.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/events/list
+            endpoint: '/events',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                events: input.events,
+                ...(input.range_start !== undefined && { range_start: input.range_start }),
+                ...(input.range_end !== undefined && { range_end: input.range_end }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-invitations.ts
+++ b/integrations/workos/actions/list-invitations.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    organization_id: z.string().optional(),
+    email: z.string().email().optional()
+});
+const ResourceSchema = z
+    .object({
+        object: z.literal('invitation'),
+        id: z.string(),
+        email: z.string(),
+        state: z.enum(['pending', 'accepted', 'expired', 'revoked']),
+        accepted_at: z.string().nullable(),
+        revoked_at: z.string().nullable(),
+        expires_at: z.string(),
+        organization_id: z.string().nullable(),
+        inviter_user_id: z.string().nullable(),
+        accepted_user_id: z.string().nullable(),
+        role_slug: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        token: z.string(),
+        accept_invitation_url: z.string()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(ResourceSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional() });
+const action = createAction({
+    description: 'List WorkOS user invitations.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/invitation
+            endpoint: '/user_management/invitations',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.email !== undefined && { email: input.email })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-organization-membership-groups.ts
+++ b/integrations/workos/actions/list-organization-membership-groups.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    membership_id: z.string()
+});
+const ResourceSchema = z.object({ id: z.string(), name: z.string(), organization_id: z.string().optional() }).passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(ResourceSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional() });
+const action = createAction({
+    description: 'List groups assigned to a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: `/user_management/organization_memberships/${encodeURIComponent(input.membership_id)}/groups`,
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-organization-memberships.ts
+++ b/integrations/workos/actions/list-organization-memberships.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional(),
+    order: z.enum(['asc', 'desc']).optional(),
+    organization_id: z.string().optional(),
+    user_id: z.string().optional(),
+    statuses: z.array(z.enum(['active', 'inactive', 'pending'])).optional()
+});
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_membership'),
+        id: z.string(),
+        user_id: z.string(),
+        organization_id: z.string(),
+        status: z.enum(['active', 'inactive', 'pending']),
+        directory_managed: z.boolean(),
+        organization_name: z.string().optional(),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        role: z.object({ slug: z.string() }).passthrough().optional(),
+        roles: z.array(z.object({ slug: z.string() }).passthrough()).optional(),
+        user: z.object({ id: z.string() }).passthrough().optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(ResourceSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(ResourceSchema), next_cursor: z.string().optional() });
+const action = createAction({
+    description: 'List WorkOS organization memberships.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: '/user_management/organization_memberships',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id }),
+                ...(input.user_id !== undefined && { user_id: input.user_id }),
+                ...(input.statuses !== undefined && { statuses: input.statuses.join(',') })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-organizations.ts
+++ b/integrations/workos/actions/list-organizations.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional().describe('Maximum number of organizations to return.'),
+    order: z.enum(['asc', 'desc']).optional(),
+    domains: z.array(z.string()).optional().describe('Return organizations matching any of these domains.')
+});
+const OrganizationSchema = z
+    .object({
+        object: z.literal('organization'),
+        id: z.string(),
+        name: z.string(),
+        allow_profiles_outside_organization: z.boolean(),
+        domains: z.array(z.record(z.string(), z.unknown())),
+        stripe_customer_id: z.string().nullable().optional(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(OrganizationSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(OrganizationSchema), next_cursor: z.string().optional() });
+
+const action = createAction({
+    description: 'List organizations from WorkOS.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/organization
+            endpoint: '/organizations',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.domains !== undefined && { domains: input.domains })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/list-users.ts
+++ b/integrations/workos/actions/list-users.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    cursor: z.string().optional().describe('Pagination cursor returned by a previous request. Omit for the first page.'),
+    cursor_direction: z.enum(['after', 'before']).optional().describe('Direction for the cursor. Defaults to after.'),
+    limit: z.number().int().min(1).max(100).optional().describe('Maximum number of users to return.'),
+    order: z.enum(['asc', 'desc']).optional(),
+    email: z.string().email().optional().describe('Filter users by email address.'),
+    organization_id: z.string().optional().describe('Filter users by organization ID.')
+});
+const UserSchema = z
+    .object({
+        object: z.literal('user'),
+        id: z.string(),
+        email: z.string(),
+        email_verified: z.boolean(),
+        profile_picture_url: z.string().nullable(),
+        name: z.string().nullable(),
+        first_name: z.string().nullable(),
+        last_name: z.string().nullable(),
+        last_sign_in_at: z.string().nullable(),
+        locale: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+const ProviderResponseSchema = z.object({
+    object: z.literal('list').optional(),
+    data: z.array(UserSchema),
+    list_metadata: z.object({ after: z.string().nullable().optional(), before: z.string().nullable().optional() })
+});
+const OutputSchema = z.object({ items: z.array(UserSchema), next_cursor: z.string().optional() });
+
+const action = createAction({
+    description: 'List users from WorkOS User Management.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const cursorDirection = input.cursor_direction ?? 'after';
+        const response = await nango.get({
+            // https://workos.com/docs/reference/user-management/user
+            endpoint: '/user_management/users',
+            params: {
+                ...(input.cursor !== undefined && { [cursorDirection]: input.cursor }),
+                ...(input.limit !== undefined && { limit: String(input.limit) }),
+                ...(input.order !== undefined && { order: input.order }),
+                ...(input.email !== undefined && { email: input.email }),
+                ...(input.organization_id !== undefined && { organization_id: input.organization_id })
+            },
+            retries: 3
+        });
+        const provider = ProviderResponseSchema.parse(response.data);
+        const nextCursor = cursorDirection === 'before' ? provider.list_metadata.before : provider.list_metadata.after;
+        return { items: provider.data, ...(nextCursor != null && { next_cursor: nextCursor }) };
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/reactivate-organization-membership.ts
+++ b/integrations/workos/actions/reactivate-organization-membership.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ membership_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_membership'),
+        id: z.string(),
+        user_id: z.string(),
+        organization_id: z.string(),
+        status: z.enum(['active', 'inactive', 'pending']),
+        directory_managed: z.boolean(),
+        organization_name: z.string().optional(),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        role: z.object({ slug: z.string() }).passthrough().optional(),
+        roles: z.array(z.object({ slug: z.string() }).passthrough()).optional(),
+        user: z.object({ id: z.string() }).passthrough().optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Reactivate a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.put({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: `/user_management/organization_memberships/${encodeURIComponent(input.membership_id)}/reactivate`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/resend-invitation.ts
+++ b/integrations/workos/actions/resend-invitation.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ invitation_id: z.string(), locale: z.string().optional() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('invitation'),
+        id: z.string(),
+        email: z.string(),
+        state: z.enum(['pending', 'accepted', 'expired', 'revoked']),
+        accepted_at: z.string().nullable(),
+        revoked_at: z.string().nullable(),
+        expires_at: z.string(),
+        organization_id: z.string().nullable(),
+        inviter_user_id: z.string().nullable(),
+        accepted_user_id: z.string().nullable(),
+        role_slug: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        token: z.string(),
+        accept_invitation_url: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Resend a WorkOS user invitation.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/user-management/invitation
+            endpoint: `/user_management/invitations/${encodeURIComponent(input.invitation_id)}/resend`,
+            data: { ...(input.locale !== undefined && { locale: input.locale }) },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/revoke-invitation.ts
+++ b/integrations/workos/actions/revoke-invitation.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ invitation_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('invitation'),
+        id: z.string(),
+        email: z.string(),
+        state: z.enum(['pending', 'accepted', 'expired', 'revoked']),
+        accepted_at: z.string().nullable(),
+        revoked_at: z.string().nullable(),
+        expires_at: z.string(),
+        organization_id: z.string().nullable(),
+        inviter_user_id: z.string().nullable(),
+        accepted_user_id: z.string().nullable(),
+        role_slug: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        token: z.string(),
+        accept_invitation_url: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Revoke a WorkOS user invitation.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/user-management/invitation
+            endpoint: `/user_management/invitations/${encodeURIComponent(input.invitation_id)}/revoke`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/update-connection.ts
+++ b/integrations/workos/actions/update-connection.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    connection_id: z.string(),
+    name: z.string().optional(),
+    external_id: z.string().max(128).nullable().optional(),
+    connection_type: z.string().optional()
+});
+const ResourceSchema = z
+    .object({
+        object: z.literal('connection'),
+        id: z.string(),
+        organization_id: z.string().optional(),
+        connection_type: z.string(),
+        name: z.string(),
+        state: z.enum(['requires_type', 'draft', 'active', 'validating', 'inactive', 'deleting']),
+        status: z.enum(['linked', 'unlinked']),
+        domains: z.array(z.object({ id: z.string(), object: z.literal('connection_domain'), domain: z.string() }).passthrough()),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update a WorkOS SSO connection.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.patch({
+            // https://workos.com/docs/reference/sso/connection
+            endpoint: `/connections/${encodeURIComponent(input.connection_id)}`,
+            data: {
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.connection_type !== undefined && { connection_type: input.connection_type })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/update-organization-membership.ts
+++ b/integrations/workos/actions/update-organization-membership.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z
+    .object({ membership_id: z.string(), role_slug: z.string().optional(), role_slugs: z.array(z.string()).min(1).optional() })
+    .refine((input) => input.role_slug === undefined || input.role_slugs === undefined, { message: 'role_slug and role_slugs are mutually exclusive.' });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_membership'),
+        id: z.string(),
+        user_id: z.string(),
+        organization_id: z.string(),
+        status: z.enum(['active', 'inactive', 'pending']),
+        directory_managed: z.boolean(),
+        organization_name: z.string().optional(),
+        custom_attributes: z.record(z.string(), z.unknown()).optional(),
+        role: z.object({ slug: z.string() }).passthrough().optional(),
+        roles: z.array(z.object({ slug: z.string() }).passthrough()).optional(),
+        user: z.object({ id: z.string() }).passthrough().optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Update roles for a WorkOS organization membership.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.put({
+            // https://workos.com/docs/reference/user-management/organization-membership
+            endpoint: `/user_management/organization_memberships/${encodeURIComponent(input.membership_id)}`,
+            data: {
+                ...(input.role_slug !== undefined && { role_slug: input.role_slug }),
+                ...(input.role_slugs !== undefined && { role_slugs: input.role_slugs })
+            },
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/update-organization.ts
+++ b/integrations/workos/actions/update-organization.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const DomainDataSchema = z.object({ domain: z.string(), state: z.enum(['verified', 'pending']) });
+const InputSchema = z.object({
+    organization_id: z.string().min(1).describe('WorkOS organization ID. Example: "org_01H..."'),
+    name: z.string().optional(),
+    domain_data: z.array(DomainDataSchema).optional(),
+    stripe_customer_id: z.string().nullable().optional(),
+    external_id: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.string()).optional()
+});
+const OrganizationSchema = z
+    .object({
+        object: z.literal('organization'),
+        id: z.string(),
+        name: z.string(),
+        allow_profiles_outside_organization: z.boolean(),
+        domains: z.array(z.record(z.string(), z.unknown())),
+        stripe_customer_id: z.string().nullable().optional(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Update a WorkOS organization.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OrganizationSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OrganizationSchema>> => {
+        const response = await nango.put({
+            // https://workos.com/docs/reference/organization
+            endpoint: `/organizations/${encodeURIComponent(input.organization_id)}`,
+            data: {
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.domain_data !== undefined && { domain_data: input.domain_data }),
+                ...(input.stripe_customer_id !== undefined && { stripe_customer_id: input.stripe_customer_id }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.metadata !== undefined && { metadata: input.metadata })
+            },
+            retries: 3
+        });
+        return OrganizationSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/update-user.ts
+++ b/integrations/workos/actions/update-user.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({
+    user_id: z.string().min(1).describe('WorkOS user ID. Example: "user_01H..."'),
+    email: z.string().email().optional(),
+    name: z.string().optional(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    email_verified: z.boolean().optional(),
+    password: z.string().optional(),
+    password_hash: z.string().optional(),
+    password_hash_type: z.enum(['bcrypt', 'firebase-scrypt', 'ssha', 'scrypt', 'argon2']).optional(),
+    external_id: z.string().optional(),
+    locale: z.string().optional(),
+    metadata: z.record(z.string(), z.string().nullable()).optional()
+});
+const UserSchema = z
+    .object({
+        object: z.literal('user'),
+        id: z.string(),
+        email: z.string(),
+        email_verified: z.boolean(),
+        profile_picture_url: z.string().nullable(),
+        name: z.string().nullable(),
+        first_name: z.string().nullable(),
+        last_name: z.string().nullable(),
+        last_sign_in_at: z.string().nullable(),
+        locale: z.string().nullable(),
+        created_at: z.string(),
+        updated_at: z.string(),
+        external_id: z.string().nullable().optional(),
+        metadata: z.record(z.string(), z.string()).optional()
+    })
+    .passthrough();
+
+const action = createAction({
+    description: 'Update a WorkOS user.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: UserSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof UserSchema>> => {
+        const response = await nango.put({
+            // https://workos.com/docs/reference/user-management/user
+            endpoint: `/user_management/users/${encodeURIComponent(input.user_id)}`,
+            data: {
+                ...(input.email !== undefined && { email: input.email }),
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.first_name !== undefined && { first_name: input.first_name }),
+                ...(input.last_name !== undefined && { last_name: input.last_name }),
+                ...(input.email_verified !== undefined && { email_verified: input.email_verified }),
+                ...(input.password !== undefined && { password: input.password }),
+                ...(input.password_hash !== undefined && { password_hash: input.password_hash }),
+                ...(input.password_hash_type !== undefined && { password_hash_type: input.password_hash_type }),
+                ...(input.external_id !== undefined && { external_id: input.external_id }),
+                ...(input.locale !== undefined && { locale: input.locale }),
+                ...(input.metadata !== undefined && { metadata: input.metadata })
+            },
+            retries: 3
+        });
+        return UserSchema.parse(response.data);
+    }
+});
+
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/actions/verify-organization-domain.ts
+++ b/integrations/workos/actions/verify-organization-domain.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createAction } from 'nango';
+
+const InputSchema = z.object({ organization_domain_id: z.string() });
+const ResourceSchema = z
+    .object({
+        object: z.literal('organization_domain'),
+        id: z.string(),
+        organization_id: z.string(),
+        domain: z.string(),
+        state: z.enum(['failed', 'legacy_verified', 'pending', 'unverified', 'verified']).optional(),
+        verification_prefix: z.string().optional(),
+        verification_token: z.string().optional(),
+        verification_strategy: z.enum(['dns', 'manual']).optional(),
+        created_at: z.string(),
+        updated_at: z.string()
+    })
+    .passthrough();
+const OutputSchema = ResourceSchema;
+const action = createAction({
+    description: 'Verify a WorkOS organization domain.',
+    version: '1.0.0',
+    input: InputSchema,
+    output: OutputSchema,
+    scopes: [],
+    exec: async (nango, input): Promise<z.infer<typeof OutputSchema>> => {
+        const response = await nango.post({
+            // https://workos.com/docs/reference/organization-domain
+            endpoint: `/organization_domains/${encodeURIComponent(input.organization_domain_id)}/verify`,
+            data: {},
+            retries: 3
+        });
+        return ResourceSchema.parse(response.data);
+    }
+});
+export type NangoActionLocal = Parameters<(typeof action)['exec']>[0];
+export default action;

--- a/integrations/workos/tests/workos-actions.test.ts
+++ b/integrations/workos/tests/workos-actions.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import createOrganization from '../actions/create-organization.js';
+import createUser from '../actions/create-user.js';
+import deleteOrganization from '../actions/delete-organization.js';
+import deleteUser from '../actions/delete-user.js';
+import getOrganization from '../actions/get-organization.js';
+import getUser from '../actions/get-user.js';
+import listDirectoryGroups from '../actions/list-directory-groups.js';
+import listDirectoryUsers from '../actions/list-directory-users.js';
+import listOrganizations from '../actions/list-organizations.js';
+import listUsers from '../actions/list-users.js';
+import updateOrganization from '../actions/update-organization.js';
+import updateUser from '../actions/update-user.js';
+
+const user = {
+    object: 'user' as const,
+    id: 'user_123',
+    email: 'ada@example.com',
+    email_verified: true,
+    profile_picture_url: null,
+    name: 'Ada Lovelace',
+    first_name: 'Ada',
+    last_name: 'Lovelace',
+    last_sign_in_at: null,
+    locale: null,
+    created_at: '2026-09-10T00:00:00.000Z',
+    updated_at: '2026-09-10T00:00:00.000Z',
+    external_id: null,
+    metadata: {}
+};
+const organization = {
+    object: 'organization' as const,
+    id: 'org_123',
+    name: 'Analytical Engines',
+    allow_profiles_outside_organization: false,
+    domains: [],
+    created_at: '2026-09-10T00:00:00.000Z',
+    updated_at: '2026-09-10T00:00:00.000Z',
+    external_id: null,
+    metadata: {}
+};
+const directoryGroup = {
+    id: 'directory_group_123',
+    idp_id: 'idp_group_123',
+    directory_id: 'directory_123',
+    organization_id: 'org_123',
+    name: 'Engineering',
+    created_at: '2026-09-10T00:00:00.000Z',
+    updated_at: '2026-09-10T00:00:00.000Z',
+    raw_attributes: {}
+};
+const directoryUser = {
+    object: 'directory_user' as const,
+    id: 'directory_user_123',
+    directory_id: 'directory_123',
+    organization_id: 'org_123',
+    idp_id: 'idp_user_123',
+    first_name: 'Ada',
+    last_name: 'Lovelace',
+    email: 'ada@example.com',
+    state: 'active',
+    raw_attributes: {},
+    custom_attributes: {},
+    groups: [directoryGroup],
+    created_at: '2026-09-10T00:00:00.000Z',
+    updated_at: '2026-09-10T00:00:00.000Z'
+};
+
+function mockNango(data: unknown = {}) {
+    return {
+        get: vi.fn().mockResolvedValue({ data }),
+        post: vi.fn().mockResolvedValue({ data }),
+        put: vi.fn().mockResolvedValue({ data }),
+        delete: vi.fn().mockResolvedValue({ data })
+    } as any;
+}
+
+describe('WorkOS actions', () => {
+    it('lists users with forward cursor pagination', async () => {
+        const nango = mockNango({ object: 'list', data: [user], list_metadata: { after: 'next_user', before: null } });
+        await expect(listUsers.exec(nango, { cursor: 'current_user', limit: 25, organization_id: 'org_123' })).resolves.toEqual({
+            items: [user],
+            next_cursor: 'next_user'
+        });
+        expect(nango.get).toHaveBeenCalledWith({
+            endpoint: '/user_management/users',
+            params: { after: 'current_user', limit: '25', organization_id: 'org_123' },
+            retries: 3
+        });
+    });
+
+    it('lists organizations with backward cursor pagination', async () => {
+        const nango = mockNango({ object: 'list', data: [organization], list_metadata: { after: null, before: 'previous_org' } });
+        await expect(listOrganizations.exec(nango, { cursor: 'current_org', cursor_direction: 'before', domains: ['example.com'] })).resolves.toEqual({
+            items: [organization],
+            next_cursor: 'previous_org'
+        });
+        expect(nango.get).toHaveBeenCalledWith({
+            endpoint: '/organizations',
+            params: { before: 'current_org', domains: ['example.com'] },
+            retries: 3
+        });
+    });
+
+    it('gets and creates users', async () => {
+        const getNango = mockNango(user);
+        await expect(getUser.exec(getNango, { user_id: 'user/123' })).resolves.toEqual(user);
+        expect(getNango.get).toHaveBeenCalledWith({ endpoint: '/user_management/users/user%2F123', retries: 3 });
+
+        const createNango = mockNango(user);
+        await createUser.exec(createNango, { email: 'ada@example.com', first_name: 'Ada', email_verified: true });
+        expect(createNango.post).toHaveBeenCalledWith({
+            endpoint: '/user_management/users',
+            data: { email: 'ada@example.com', first_name: 'Ada', email_verified: true },
+            retries: 3
+        });
+    });
+
+    it('updates and deletes users', async () => {
+        const updateNango = mockNango(user);
+        await updateUser.exec(updateNango, { user_id: 'user_123', first_name: 'Augusta', metadata: { title: null } });
+        expect(updateNango.put).toHaveBeenCalledWith({
+            endpoint: '/user_management/users/user_123',
+            data: { first_name: 'Augusta', metadata: { title: null } },
+            retries: 3
+        });
+
+        const deleteNango = mockNango();
+        await expect(deleteUser.exec(deleteNango, { user_id: 'user_123' })).resolves.toEqual({ id: 'user_123', success: true });
+        expect(deleteNango.delete).toHaveBeenCalledWith({ endpoint: '/user_management/users/user_123', retries: 3 });
+    });
+
+    it('gets and creates organizations', async () => {
+        const getNango = mockNango(organization);
+        await expect(getOrganization.exec(getNango, { organization_id: 'org/123' })).resolves.toEqual(organization);
+        expect(getNango.get).toHaveBeenCalledWith({ endpoint: '/organizations/org%2F123', retries: 3 });
+
+        const createNango = mockNango(organization);
+        await createOrganization.exec(createNango, { name: 'Analytical Engines', domain_data: [{ domain: 'example.com', state: 'verified' }] });
+        expect(createNango.post).toHaveBeenCalledWith({
+            endpoint: '/organizations',
+            data: { name: 'Analytical Engines', domain_data: [{ domain: 'example.com', state: 'verified' }] },
+            retries: 3
+        });
+    });
+
+    it('updates and deletes organizations', async () => {
+        const updateNango = mockNango(organization);
+        await updateOrganization.exec(updateNango, { organization_id: 'org_123', name: 'New Name', external_id: null });
+        expect(updateNango.put).toHaveBeenCalledWith({
+            endpoint: '/organizations/org_123',
+            data: { name: 'New Name', external_id: null },
+            retries: 3
+        });
+
+        const deleteNango = mockNango();
+        await expect(deleteOrganization.exec(deleteNango, { organization_id: 'org_123' })).resolves.toEqual({ id: 'org_123', success: true });
+        expect(deleteNango.delete).toHaveBeenCalledWith({ endpoint: '/organizations/org_123', retries: 3 });
+    });
+
+    it('lists directory users and groups', async () => {
+        const usersNango = mockNango({ object: 'list', data: [directoryUser], list_metadata: { after: 'next_directory_user', before: null } });
+        await expect(listDirectoryUsers.exec(usersNango, { directory: 'directory_123' })).resolves.toEqual({
+            items: [directoryUser],
+            next_cursor: 'next_directory_user'
+        });
+        expect(usersNango.get).toHaveBeenCalledWith({ endpoint: '/directory_users', params: { directory: 'directory_123' }, retries: 3 });
+
+        const groupsNango = mockNango({ object: 'list', data: [directoryGroup], list_metadata: { after: null, before: null } });
+        await expect(listDirectoryGroups.exec(groupsNango, { user: 'directory_user_123' })).resolves.toEqual({ items: [directoryGroup] });
+        expect(groupsNango.get).toHaveBeenCalledWith({ endpoint: '/directory_groups', params: { user: 'directory_user_123' }, retries: 3 });
+    });
+});

--- a/integrations/workos/tests/workos-priority-actions.test.ts
+++ b/integrations/workos/tests/workos-priority-actions.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import createConnection from '../actions/create-connection.js';
+import createInvitation from '../actions/create-invitation.js';
+import createOrganizationDomain from '../actions/create-organization-domain.js';
+import createOrganizationMembership from '../actions/create-organization-membership.js';
+import deactivateOrganizationMembership from '../actions/deactivate-organization-membership.js';
+import deleteConnection from '../actions/delete-connection.js';
+import deleteDirectory from '../actions/delete-directory.js';
+import deleteOrganizationDomain from '../actions/delete-organization-domain.js';
+import deleteOrganizationMembership from '../actions/delete-organization-membership.js';
+import getConnection from '../actions/get-connection.js';
+import getDirectory from '../actions/get-directory.js';
+import getDirectoryGroup from '../actions/get-directory-group.js';
+import getDirectoryUser from '../actions/get-directory-user.js';
+import getInvitation from '../actions/get-invitation.js';
+import getOrganizationDomain from '../actions/get-organization-domain.js';
+import getOrganizationMembership from '../actions/get-organization-membership.js';
+import listConnections from '../actions/list-connections.js';
+import listDirectories from '../actions/list-directories.js';
+import listEvents from '../actions/list-events.js';
+import listInvitations from '../actions/list-invitations.js';
+import listOrganizationMembershipGroups from '../actions/list-organization-membership-groups.js';
+import listOrganizationMemberships from '../actions/list-organization-memberships.js';
+import reactivateOrganizationMembership from '../actions/reactivate-organization-membership.js';
+import resendInvitation from '../actions/resend-invitation.js';
+import revokeInvitation from '../actions/revoke-invitation.js';
+import updateConnection from '../actions/update-connection.js';
+import updateOrganizationMembership from '../actions/update-organization-membership.js';
+import verifyOrganizationDomain from '../actions/verify-organization-domain.js';
+
+function mockNango(data: unknown = {}) {
+    return {
+        get: vi.fn().mockResolvedValue({ data }),
+        post: vi.fn().mockResolvedValue({ data }),
+        put: vi.fn().mockResolvedValue({ data }),
+        patch: vi.fn().mockResolvedValue({ data }),
+        delete: vi.fn().mockResolvedValue({ data })
+    } as any;
+}
+
+const now = '2026-09-10T00:00:00.000Z';
+const directory = {
+    object: 'directory' as const,
+    id: 'directory_123',
+    domain: 'example.com',
+    external_key: 'example',
+    name: 'Example',
+    organization_id: 'org_123',
+    state: 'linked',
+    type: 'okta scim v2.0',
+    created_at: now,
+    updated_at: now
+};
+const directoryGroup = {
+    id: 'directory_group_123',
+    idp_id: 'idp_group_123',
+    directory_id: 'directory_123',
+    organization_id: 'org_123',
+    name: 'Engineering',
+    created_at: now,
+    updated_at: now,
+    raw_attributes: {}
+};
+const directoryUser = {
+    object: 'directory_user' as const,
+    id: 'directory_user_123',
+    directory_id: 'directory_123',
+    organization_id: 'org_123',
+    idp_id: 'idp_user_123',
+    first_name: 'Ada',
+    last_name: 'Lovelace',
+    email: 'ada@example.com',
+    state: 'active' as const,
+    raw_attributes: {},
+    groups: [directoryGroup],
+    created_at: now,
+    updated_at: now
+};
+const membership = {
+    object: 'organization_membership' as const,
+    id: 'om_123',
+    user_id: 'user_123',
+    organization_id: 'org_123',
+    status: 'active' as const,
+    directory_managed: false,
+    role: { slug: 'member' },
+    roles: [{ slug: 'member' }],
+    user: { id: 'user_123' },
+    created_at: now,
+    updated_at: now
+};
+const invitation = {
+    object: 'invitation' as const,
+    id: 'invite_123',
+    email: 'ada@example.com',
+    state: 'pending' as const,
+    accepted_at: null,
+    revoked_at: null,
+    expires_at: now,
+    organization_id: 'org_123',
+    inviter_user_id: null,
+    accepted_user_id: null,
+    role_slug: 'member',
+    created_at: now,
+    updated_at: now,
+    token: 'token_123',
+    accept_invitation_url: 'https://example.com/accept'
+};
+const connection = {
+    object: 'connection' as const,
+    id: 'conn_123',
+    organization_id: 'org_123',
+    connection_type: 'OktaSAML',
+    name: 'Example',
+    state: 'active' as const,
+    status: 'linked' as const,
+    domains: [{ id: 'domain_123', object: 'connection_domain' as const, domain: 'example.com' }],
+    created_at: now,
+    updated_at: now
+};
+const organizationDomain = {
+    object: 'organization_domain' as const,
+    id: 'org_domain_123',
+    organization_id: 'org_123',
+    domain: 'example.com',
+    state: 'pending' as const,
+    verification_strategy: 'dns' as const,
+    created_at: now,
+    updated_at: now
+};
+const event = { id: 'event_123', event: 'user.created', created_at: now, data: { id: 'user_123' } };
+const page = (data: unknown[], after: string | null = null) => ({ object: 'list', data, list_metadata: { before: null, after } });
+
+describe('WorkOS priority actions', () => {
+    it('lists, gets, and deletes directories', async () => {
+        const listNango = mockNango(page([directory], 'next_directory'));
+        await expect(listDirectories.exec(listNango, { organization_id: 'org_123' })).resolves.toEqual({ items: [directory], next_cursor: 'next_directory' });
+        expect(listNango.get).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/directories', params: expect.objectContaining({ organization_id: 'org_123' }) })
+        );
+
+        const getNango = mockNango(directory);
+        await getDirectory.exec(getNango, { directory_id: 'directory/123' });
+        expect(getNango.get).toHaveBeenCalledWith({ endpoint: '/directories/directory%2F123', retries: 3 });
+
+        const deleteNango = mockNango();
+        await expect(deleteDirectory.exec(deleteNango, { directory_id: 'directory_123' })).resolves.toEqual({ id: 'directory_123', success: true });
+    });
+
+    it('gets directory groups and users', async () => {
+        const groupNango = mockNango(directoryGroup);
+        await getDirectoryGroup.exec(groupNango, { group_id: 'directory_group/123' });
+        expect(groupNango.get).toHaveBeenCalledWith({ endpoint: '/directory_groups/directory_group%2F123', retries: 3 });
+
+        const userNango = mockNango(directoryUser);
+        await expect(getDirectoryUser.exec(userNango, { directory_user_id: 'directory_user_123' })).resolves.toEqual(directoryUser);
+    });
+
+    it('manages organization memberships', async () => {
+        const listNango = mockNango(page([membership], 'next_membership'));
+        await expect(listOrganizationMemberships.exec(listNango, { organization_id: 'org_123', statuses: ['active'] })).resolves.toEqual({
+            items: [membership],
+            next_cursor: 'next_membership'
+        });
+        expect(listNango.get).toHaveBeenCalledWith(
+            expect.objectContaining({ params: expect.objectContaining({ organization_id: 'org_123', statuses: 'active' }) })
+        );
+
+        const nango = mockNango(membership);
+        await createOrganizationMembership.exec(nango, { user_id: 'user_123', organization_id: 'org_123', role_slug: 'member' });
+        await getOrganizationMembership.exec(nango, { membership_id: 'om_123' });
+        await updateOrganizationMembership.exec(nango, { membership_id: 'om_123', role_slugs: ['admin', 'member'] });
+        await deactivateOrganizationMembership.exec(nango, { membership_id: 'om_123' });
+        await reactivateOrganizationMembership.exec(nango, { membership_id: 'om_123' });
+        expect(nango.put).toHaveBeenCalledTimes(3);
+
+        const groupsNango = mockNango(page([{ id: 'group_123', name: 'Engineering', organization_id: 'org_123' }]));
+        await expect(listOrganizationMembershipGroups.exec(groupsNango, { membership_id: 'om_123' })).resolves.toEqual({
+            items: [{ id: 'group_123', name: 'Engineering', organization_id: 'org_123' }]
+        });
+
+        const deleteNango = mockNango();
+        await expect(deleteOrganizationMembership.exec(deleteNango, { membership_id: 'om_123' })).resolves.toEqual({ id: 'om_123', success: true });
+    });
+
+    it('manages user invitations', async () => {
+        const listNango = mockNango(page([invitation]));
+        await expect(listInvitations.exec(listNango, { email: 'ada@example.com' })).resolves.toEqual({ items: [invitation] });
+
+        const nango = mockNango(invitation);
+        await createInvitation.exec(nango, { email: 'ada@example.com', organization_id: 'org_123', role_slug: 'member', expires_in_days: 7 });
+        await getInvitation.exec(nango, { invitation_id: 'invite_123' });
+        await resendInvitation.exec(nango, { invitation_id: 'invite_123', locale: 'en' });
+        await revokeInvitation.exec(nango, { invitation_id: 'invite_123' });
+        expect(nango.post).toHaveBeenLastCalledWith(expect.objectContaining({ endpoint: '/user_management/invitations/invite_123/revoke', data: {} }));
+    });
+
+    it('manages SSO connections', async () => {
+        const listNango = mockNango(page([connection], 'next_connection'));
+        await expect(listConnections.exec(listNango, { organization_id: 'org_123' })).resolves.toEqual({ items: [connection], next_cursor: 'next_connection' });
+
+        const nango = mockNango(connection);
+        await createConnection.exec(nango, {
+            organization_id: 'org_123',
+            name: 'Example',
+            saml_options: { idp_metadata_url: 'https://idp.example.com/metadata.xml' }
+        });
+        await getConnection.exec(nango, { connection_id: 'conn/123' });
+        await updateConnection.exec(nango, { connection_id: 'conn_123', name: 'Updated', external_id: null });
+        expect(nango.patch).toHaveBeenCalledWith({ endpoint: '/connections/conn_123', data: { name: 'Updated', external_id: null }, retries: 3 });
+
+        const deleteNango = mockNango();
+        await expect(deleteConnection.exec(deleteNango, { connection_id: 'conn_123' })).resolves.toEqual({ id: 'conn_123', success: true });
+    });
+
+    it('manages organization domains', async () => {
+        const nango = mockNango(organizationDomain);
+        await createOrganizationDomain.exec(nango, { organization_id: 'org_123', domain: 'example.com' });
+        await getOrganizationDomain.exec(nango, { organization_domain_id: 'org_domain/123' });
+        await verifyOrganizationDomain.exec(nango, { organization_domain_id: 'org_domain_123' });
+        expect(nango.post).toHaveBeenLastCalledWith({ endpoint: '/organization_domains/org_domain_123/verify', data: {}, retries: 3 });
+
+        const deleteNango = mockNango();
+        await expect(deleteOrganizationDomain.exec(deleteNango, { organization_domain_id: 'org_domain_123' })).resolves.toEqual({
+            id: 'org_domain_123',
+            success: true
+        });
+    });
+
+    it('lists events with filters and cursor pagination', async () => {
+        const nango = mockNango(page([event], 'next_event'));
+        await expect(listEvents.exec(nango, { events: ['user.created'], organization_id: 'org_123', cursor: 'event_100' })).resolves.toEqual({
+            items: [event],
+            next_cursor: 'next_event'
+        });
+        expect(nango.get).toHaveBeenCalledWith({
+            endpoint: '/events',
+            params: { after: 'event_100', events: ['user.created'], organization_id: 'org_123' },
+            retries: 3
+        });
+    });
+});


### PR DESCRIPTION
Adds a WorkOS integration with 40 typed actions covering users, organizations, SSO connections, directories, directory users and groups, events, invitations, memberships, and organization domains.

The actions follow the current WorkOS API request and response shapes, encode path parameters, expose cursor pagination consistently, and validate mutually exclusive connection and membership options. Generated Nango artifacts and focused tests are included.

Examples include `list-connections`, `get-directory-user`, `create-invitation`, and `deactivate-organization-membership`.

Tested with `npx vitest run workos` (14 tests), `npm run lint -- --quiet`, and `npm run compile:integrations`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a WorkOS integration with 40 typed actions for users, organizations, directories, SSO connections, invitations, memberships, events, and domains so teams can manage identity resources through Nango.

**New Features**
- Actions match current WorkOS request and response shapes, encode path parameters, and expose cursor pagination and order values consistently.
- Validation covers password hashing inputs, mutually exclusive membership roles and event cursors, directory filter requirements, and required resource IDs.
- Response schemas accept compact organization domains, suspended directory users, optional deprecated groups, and forward all supported connection update options.
- Includes generated Nango artifacts and focused tests verified with `npx vitest run workos`.

<sup>Written for commit 9b49e44bbd7953607ab915bdd3bba104edbb4a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NangoHQ/integration-templates/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

